### PR TITLE
fix: add ports for docker compose

### DIFF
--- a/src/warnet/generate_docker_compose.py
+++ b/src/warnet/generate_docker_compose.py
@@ -52,7 +52,14 @@ def generate_docker_compose(version, node_count):
             },
             "volumes": [
                 f"./config/bitcoin.conf:/root/.bitcoin/bitcoin.conf"
-            ]
+            ],
+            "ports":[
+               "18444",
+               "18443",
+               "8332",
+               "8333",
+               "9051"
+             ]
         }
         c = c + 2
 


### PR DESCRIPTION
This is WIP, but adding ports here at least allows for ingress for RPC commands.