### PR TITLE
WIP: Add bind9 dns seeder

### DIFF
--- a/src/templates/Dockerfile_bind9
+++ b/src/templates/Dockerfile_bind9
@@ -1,0 +1,5 @@
+FROM ubuntu/bind9:9.16-20.04_beta
+COPY dns-seed.zone /etc/bind/dns-seed.zone
+COPY named.conf.local /etc/bind/named.conf.local
+
+CMD ["/usr/sbin/named", "-g", "-c", "/etc/bind/named.conf"]

--- a/src/templates/dns-seed.zone
+++ b/src/templates/dns-seed.zone
@@ -1,0 +1,14 @@
+;
+; BIND data file for warnet dns seeder service
+;
+dns-seed. 300 IN  SOA dns-seed. admin.warnet.com. (
+        2023082401  ; Serial
+        3600        ; Refresh
+        1800        ; Retry
+        604800      ; Expire
+        86400       ; Minimum TTL
+)
+dns-seed. 300 IN NS dns-seed.
+; following line likely needs to be changed to the container ip address
+dns-seed. 300 IN A 127.0.0.1
+

--- a/src/templates/named.conf.local
+++ b/src/templates/named.conf.local
@@ -1,0 +1,4 @@
+zone "dns-seed" {
+    type master;
+    file "/etc/bind/dns-seed.zone";
+};

--- a/src/warnet/main.py
+++ b/src/warnet/main.py
@@ -103,8 +103,16 @@ def from_file(graph_file: str, network: str = "warnet"):
     wn.write_docker_compose()
     wn.write_prometheus_config()
     wn.docker_compose_up()
+    wn.generate_zone_file_from_tanks()
+    wn.apply_zone_file()
     wn.apply_network_conditions()
     wn.connect_edges()
+
+@warnet_app.command()
+def sync_dns_seeder(graph_file: str, network: str = "warnet"):
+    wn = Warnet.from_graph_file(graph_file, network)
+    wn.generate_zone_file_from_tanks()
+    wn.apply_zone_file()
 
 @warnet_app.command()
 def stop():

--- a/src/warnet/main.py
+++ b/src/warnet/main.py
@@ -109,8 +109,8 @@ def from_file(graph_file: str, network: str = "warnet"):
     wn.connect_edges()
 
 @warnet_app.command()
-def sync_dns_seeder(graph_file: str, network: str = "warnet"):
-    wn = Warnet.from_graph_file(graph_file, network)
+def sync_dns_seed(network: str = "warnet"):
+    wn = Warnet.from_docker_env(network)
     wn.generate_zone_file_from_tanks()
     wn.apply_zone_file()
 

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -5,6 +5,7 @@
 import docker
 import logging
 import networkx
+import shutil
 import subprocess
 import yaml
 from pathlib import Path
@@ -16,6 +17,7 @@ from warnet.utils import (
 )
 
 TMPDIR_PREFIX = "warnet_tmp_"
+ZONE_FILE_NAME = "dns-seed.zone"
 
 class Warnet:
     def __init__(self):
@@ -75,6 +77,37 @@ class Warnet:
         for tank in self.tanks:
             tank.apply_network_conditions()
 
+    def generate_zone_file_from_tanks(self):
+        records_list = [f"seed.dns-seed.     300 IN  A   {tank.ipv4}" for tank in self.tanks]
+        content = []
+        with open(str(TEMPLATES / ZONE_FILE_NAME), 'r') as f:
+            content = [line.rstrip() for line in f]
+
+        # TODO: Really we should also read active SOA value from dns-seed, and increment from there
+
+        content.extend(records_list)
+        # Join the content into a single string and escape single quotes for echoing
+        content_str = '\n'.join(content).replace("'", "'\\''")
+        with open(self.tmpdir / ZONE_FILE_NAME, 'w') as f:
+            f.write(content_str)
+
+    def apply_zone_file(self):
+        """
+        Sync the dns seed list served by dns-seed with currently active Tanks.
+        """
+        seeder = self.docker.containers.get("dns-seed")
+
+        # Read the content from the generated zone file
+        with open(self.tmpdir / ZONE_FILE_NAME, 'r') as f:
+            content_str = f.read().replace("'", "'\\''")
+
+        # Overwrite all existing content
+        result = seeder.exec_run(f"sh -c 'echo \"{content_str}\" > /etc/bind/dns-seed.zone'")
+        logging.debug(f"result of updating {ZONE_FILE_NAME}: {result}")
+
+        # Reload that single zone only
+        seeder.exec_run("rndc reload dns-seed")
+
     def connect_edges(self):
         for edge in self.graph.edges():
             (src, dst) = edge
@@ -92,7 +125,7 @@ class Warnet:
         except Exception as e:
             logging.error(f"An error occurred while executing `{' '.join(command)}` in {self.tmpdir}: {e}")
 
-    def write_docker_compose(self):
+    def write_docker_compose(self, dns=True):
         compose = {
             "version": "3.8",
             "networks": {
@@ -148,6 +181,21 @@ class Warnet:
                 self.docker_network
             ]
         }
+        if dns:
+            compose["services"]["dns-seed"] = {
+                "container_name": "dns-seed",
+                "ports": ["15353:53/udp", "15353:53/tcp"],
+                "build": {
+                    "context": ".",
+                    "dockerfile": str(TEMPLATES / "Dockerfile_bind9"),
+                },
+                "networks": [
+                    "warnet"
+                ],
+            }
+            # Copy to tmpdir for dockerfile. Using volume means changes on container reflect on template
+            shutil.copy(str(TEMPLATES / 'dns-seed.zone'), self.tmpdir)
+            shutil.copy(str(TEMPLATES / 'named.conf.local'), self.tmpdir)
 
         docker_compose_path = self.tmpdir / "docker-compose.yml"
         try:


### PR DESCRIPTION
TODO:

* [ ] read SOA records if warnet running, and increment them
* [ ] reroute traffic destined for hardcoded DNS seeds to the `dns-seed` container