### PR TITLE
Add bind9 dns seed

### DIFF
--- a/src/templates/Dockerfile_bind9
+++ b/src/templates/Dockerfile_bind9
@@ -1,0 +1,5 @@
+FROM ubuntu/bind9:9.16-20.04_beta
+COPY dns-seed.zone /etc/bind/dns-seed.zone
+COPY named.conf.local /etc/bind/named.conf.local
+
+CMD ["/usr/sbin/named", "-g", "-c", "/etc/bind/named.conf"]

--- a/src/templates/dns-seed.zone
+++ b/src/templates/dns-seed.zone
@@ -1,0 +1,14 @@
+;
+; BIND data file for warnet dns seeder service
+;
+dns-seed. 300 IN  SOA dns-seed. admin.warnet.com. (
+        2023082401  ; Serial
+        3600        ; Refresh
+        1800        ; Retry
+        604800      ; Expire
+        86400       ; Minimum TTL
+)
+dns-seed. 300 IN NS dns-seed.
+; following line likely needs to be changed to the container ip address
+dns-seed. 300 IN A 127.0.0.1
+

--- a/src/templates/named.conf.local
+++ b/src/templates/named.conf.local
@@ -1,0 +1,4 @@
+zone "dns-seed" {
+    type master;
+    file "/etc/bind/dns-seed.zone";
+};

--- a/src/warnet/cli.py
+++ b/src/warnet/cli.py
@@ -100,6 +100,16 @@ def run(scenario: str):
     except Exception as e:
         print(f"Error running scenario: {e}")
 
+@debug.command()
+def update_dns_seed(graph_file: Path = EXAMPLE_GRAPH_FILE, network: str = "warnet"):
+    """
+    Update the dns seed database using a graph file
+    """
+    try:
+        result = rpc("update_dns_seeder", {"graph_file": str(graph_file), "network": network})
+        print(result)
+    except Exception as e:
+        print(f"Error updating dns seed addresses: {e}")
 
 @debug.command()
 def generate_compose(graph_file: str, network: str = "warnet"):

--- a/src/warnet/warnetd.py
+++ b/src/warnet/warnetd.py
@@ -146,6 +146,8 @@ def from_file(graph_file: str, network: str = "warnet") -> str:
             wn.write_docker_compose()
             wn.write_prometheus_config()
             wn.docker_compose_up()
+            wn.generate_zone_file_from_tanks()
+            wn.apply_zone_file()
             wn.apply_network_conditions()
             wn.connect_edges()
             logger.info(f"Created warnet named '{network}' from graph file {graph_file}")
@@ -154,6 +156,20 @@ def from_file(graph_file: str, network: str = "warnet") -> str:
 
     threading.Thread(target=lambda: thread_start(wn)).start()
     return f"Starting warnet network named '{network}' with the following parameters:\n{wn}"
+
+
+@jsonrpc.method()
+def update_dns_seeder(graph_file: str, network: str = "warnet") -> str:
+    try:
+        wn = Warnet.from_graph_file(graph_file, network)
+        wn.generate_zone_file_from_tanks()
+        wn.apply_zone_file()
+        with open(wn.zone_file_path, 'r') as f:
+            zone_file = f.read()
+
+        return f"DNS seeder update using zone file:\n{zone_file}"
+    except Exception as e:
+        return f"DNS seeder not updated due to exception: {e}"
 
 
 @jsonrpc.method()


### PR DESCRIPTION
@pinheadmz would be interested in your feedback on this...

Enabled by default, but `warnet debug update-dns-seed` will update based on a graph file in production 👀 It might not be what we want? (might be better to scan the network for all active tanks and use that list of ipv4?)