### PR TITLE
load node versions from graph during Warnet.from_docker_env

### DIFF
--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -106,6 +106,11 @@ class Tank:
         ]["IPAddress"]
         return self
 
+    def update_from_docker_env(self):
+        self._ipv4 = self.container.attrs["NetworkSettings"]["Networks"][
+            self.docker_network
+        ]["IPAddress"]
+
     @property
     def suffix(self):
         if self._suffix is None:

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -69,7 +69,8 @@ class Warnet:
         self = cls(config_dir)
         destination = self.config_dir / self.graph_name
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(graph_file, destination)
+        if not graph_file == str(destination):
+            shutil.copy(graph_file, destination)
         self.docker_network = network
         self.graph = networkx.read_graphml(graph_file, node_type=int)
         self.tanks_from_graph()
@@ -103,19 +104,11 @@ class Warnet:
     @bubble_exception_str
     def from_docker_env(cls, network_name):
         config_dir = gen_config_dir(network_name)
-        self = cls(config_dir)
-        self.graph = networkx.read_graphml(
-            Path(self.config_dir / self.graph_name), node_type=int
-        )
+        # TODO fix this
+        self = Warnet.from_graph_file(str(config_dir / "graph.graphml"), config_dir)
         self.docker_network = network_name
-        index = 0
-        while index <= 999999:
-            try:
-                self.tanks.append(Tank.from_docker_env(self.docker_network, index))
-                index = index + 1
-            except:
-                assert index == len(self.tanks)
-                break
+        for tank in self.tanks:
+            tank.update_from_docker_env()
         return self
 
     @property

--- a/src/warnet/warnetd.py
+++ b/src/warnet/warnetd.py
@@ -240,7 +240,7 @@ def list_running_scenarios(network: str = "warnet") -> Dict[str, int]:
 
 @jsonrpc.method("up")
 def up(network: str = "warnet") -> str:
-    wn = Warnet.from_network(network=network, tanks=False)
+    wn = Warnet.from_network(network=network)
 
     def thread_start(wn):
         try:
@@ -283,7 +283,7 @@ def from_file(graph_file: str, force: bool = False, network: str = "warnet") -> 
             wn.apply_network_conditions()
             wn.connect_edges()
             logger.info(
-                f"Created warnet named '{network}' from graph file {graph_file}"
+                f"Successfully created warnet named '{network}' from graph file {graph_file}"
             )
         except Exception as e:
             logger.error(f"Exception {e}")


### PR DESCRIPTION
Currently we don't load node version properly, they are all set to 25.0. Fix this by reading a graph with default name in the config dir, which is copied in during setup.

This is needed so that we can switch on using addpeeraddress and addnode based on node version.

Alternatively we could ping each node with a `-getinfo` or `getinfo` and try to parse that, and keep the existing logic?

Also includes two related commits to properly parse and compare version strings, to determine whether we should use `addpeeraddress` or fallback to `addnode`