### PR TITLE
add container resource profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The graphml file has the following specification:
 * `y` specifies the node's y position when rendered in a GUI
 * `version` specifies the node's Bitcoin Core major version, or built branch
 * `bitcoin_config` is a comma-separated list of values the node should apply to it's bitcoin.conf, using bitcoin.conf syntax
+* `profile` is a profile name from the pre-built selection in src/warnet/resources.py
 
 `version` should be either a version number from the pre-compiled binary list on https://bitcoincore.org/bin/ **or** a built branch using `<user>/<repo>#<branch>` syntax.
 
@@ -54,6 +55,7 @@ Nodes can be added to the graph as follows:
 <data key="version">24.0</data>
 <data key="bitcoin_config">uacomment=warnet0_v24,debugexclude=libevent</data>
 <data key="tc_netem"></data>
+<data key="profile"></data>
 </node>
 ```
 
@@ -66,6 +68,7 @@ Or for a custom built branch with traffic shaping rules applied:
 <data key="version">vasild/bitcoin#relay_tx_to_priv_nets</data>
 <data key="bitcoin_config">uacomment=warnet1_custom,debug=1</data>
 <data key="tc_netem">tc qdisc add dev eth0 root netem delay 100ms</data>
+<data key="profile">raspberry_pi</data>
 </node>
 ```
 

--- a/src/templates/example.graphml
+++ b/src/templates/example.graphml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key attr.name="version" attr.type="string" for="node" id="version"/>
   <key attr.name="bitcoin_config" attr.type="string" for="node" id="bitcoin_config"/>
+  <key attr.name="tc_netem" attr.type="string" for="node" id="tc_netem"/>
+  <key attr.name="profile" attr.type="string" for="node" id="profile"/>
   <graph edgedefault="directed">
     <node id="0">
         <data key="version">25.0</data>
@@ -13,10 +15,13 @@
     <node id="2">
         <data key="version">23.2</data>
         <data key="bitcoin_config">uacomment=w2</data>
+        <data key="profile">laptop</data>
     </node>
     <node id="3">
         <data key="version">22.1</data>
         <data key="bitcoin_config">uacomment=w3</data>
+        <data key="profile">raspberry_pi</data>
+        <data key="tc_netem">tc qdisc add dev eth0 root netem delay 1000ms</data>
     </node>
     <node id="4">
         <data key="version">0.21.2</data>

--- a/src/warnet/resources.py
+++ b/src/warnet/resources.py
@@ -1,0 +1,23 @@
+# resource profile presets
+resource_profiles = {
+    "default": {
+        "cpus": "4",
+        "memory": "4G",
+    },
+    "raspberry_pi": {
+        "cpus": "2",
+        "memory": "2G",
+    },
+    "laptop": {
+        "cpus": "4",
+        "memory": "8G",
+    },
+    "desktop": {
+        "cpus": "8",
+        "memory": "16G",
+    },
+    "server": {
+        "cpus": "16",
+        "memory": "32G",
+    },
+}

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -175,10 +175,9 @@ class Warnet:
             content_str = f.read().replace("'", "'\\''")
 
         # Overwrite all existing content
-        result = seeder.exec_run(
+        _result = seeder.exec_run(
             f"sh -c 'echo \"{content_str}\" > /etc/bind/invalid.zone'"
         )
-        logger.debug(f"result of updating {ZONE_FILE_NAME}: {result}")
 
         # Reload that single zone only
         seeder.exec_run("rndc reload invalid")


### PR DESCRIPTION
Closes: #26

Adds a few demo profiles such as laptop, desktop, raspberry_pi, server to the graph config.

While we are using docker-compose, and not swarm, we cannot easily limit physical CPUS (withough downgrading to docker-compose v2), but we can get "relative resourse usage", and memory limitations.

This line:
```python
"cpu_shares": int(self.resource_profile.get("cpus", "0.5")) * 1024,
```

 is the temporary "hack" which converts our cpu number from a profile to a rough `cpu_shares` value (which docker-compose accepts).
 
 Link: https://docs.docker.com/config/containers/resource_constraints/