### PR TITLE
chore: add unified observable dashboards

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dropdown-menu": "^2.0.5",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-select": "^1.2.2",
+        "@radix-ui/react-tabs": "^1.0.4",
         "@types/node": "20.5.0",
         "@types/react": "18.2.20",
         "@types/react-dom": "18.2.7",
@@ -973,6 +974,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3010",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -14,6 +14,7 @@
     "@radix-ui/react-dropdown-menu": "^2.0.5",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-select": "^1.2.2",
+    "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.6",
     "@types/node": "20.5.0",
     "@types/react": "18.2.20",

--- a/frontend/src/app/dashboards/page.tsx
+++ b/frontend/src/app/dashboards/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as Tabs from "@radix-ui/react-tabs";
+
+function Dashboard() {
+    // TODO: make this a bit more dynamic
+    // fetch the list of dashboards and their URLs from the server
+  return (
+    <Tabs.Root defaultValue="prometheus" className={`flex flex-col space-y-4`}>
+      <Tabs.List className="flex gap-x-4 px-10 pt-6" aria-label="Dashboard tabs">
+        <Tabs.Trigger
+          value="prometheus"
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 focus:outline-none"
+        >
+          Prometheus
+        </Tabs.Trigger>
+        <Tabs.Trigger
+          value="forkObserver"
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 focus:outline-none"
+        >
+          Fork Observer
+        </Tabs.Trigger>
+      </Tabs.List>
+
+      <div className="flex-1 p-5 px-10">
+        <Tabs.Content value="prometheus">
+          <iframe
+            className={`rounded shadow-lg w-full h-screen`}
+            src="http://localhost:9090/graph"
+          />
+        </Tabs.Content>
+
+        <Tabs.Content value="forkObserver">
+          <iframe
+            className="rounded shadow-lg w-full h-screen"
+            src="http://localhost:12323/"
+          ></iframe>
+        </Tabs.Content>
+      </div>
+    </Tabs.Root>
+  );
+}
+
+export default Dashboard;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,6 +24,7 @@ body {
       rgb(var(--background-end-rgb))
     )
     rgb(var(--background-start-rgb));
+  overflow-y: scroll;
 }
 
 .init_dialog_table_config td, .init_dialog_table_config th {
@@ -45,3 +46,4 @@ body {
   color: #777;
   font-size: 12px;
 }
+

--- a/frontend/src/components/DraggableNode.tsx
+++ b/frontend/src/components/DraggableNode.tsx
@@ -1,6 +1,5 @@
 import { useNodeFlowContext } from "@/contexts/node-flow-context";
 import { GraphNode } from "@/flowTypes";
-import { useCallback } from "react";
 import { Handle, Position } from "reactflow";
 
 interface IDraggableNode {

--- a/frontend/src/components/dialog.tsx
+++ b/frontend/src/components/dialog.tsx
@@ -6,7 +6,6 @@ import { Cross2Icon } from "@radix-ui/react-icons";
 
 import NodeAccordion from "./node-accordion";
 import { useNodeFlowContext } from "@/contexts/node-flow-context";
-import DefaultSelectBox from "./default-select";
 
 const DialogBox = () => {
   const {

--- a/frontend/src/components/node-info-dialog.tsx
+++ b/frontend/src/components/node-info-dialog.tsx
@@ -5,7 +5,7 @@ import {
   RAM_OPTIONS,
 } from "@/config";
 import * as Dialog from "@radix-ui/react-dialog";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import DefaultSelectBox from "./default-select";
 import { useNodeFlowContext } from "@/contexts/node-flow-context";
 import { parseBitcoinConf } from "@/helpers/parse-conf-file";

--- a/frontend/src/components/node-persona-info.tsx
+++ b/frontend/src/components/node-persona-info.tsx
@@ -3,8 +3,7 @@ import { BITCOIN_CORE_BINARY_VERSIONS, NODE_LATENCY } from "@/config";
 import { useNodeFlowContext } from "@/contexts/node-flow-context";
 
 const NodePersonaInfo = () => {
-  const { nodePersonaType, nodePersona, closeDialog, showGraphFunc } =
-    useNodeFlowContext();
+  const { nodePersona } = useNodeFlowContext();
 
   return (
     <section className={` w-[330px] h-[300px] bg-white rounded-md p-5`}>

--- a/frontend/src/contexts/network-context.tsx
+++ b/frontend/src/contexts/network-context.tsx
@@ -3,12 +3,8 @@ import React, { useState } from "react";
 import { defaultEdgesData, defaultNodesData, tempSavednetwork } from "@/app/data";
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from "@/config";
 import {
-  GraphEdge,
-  GraphNode,
   NetworkContext,
   NetworkTopology,
-  NodePersona,
-  NodePersonaType,
   SavedNetworkGraph,
 } from "@/flowTypes";
 
@@ -71,7 +67,6 @@ export const NetworkProvider = ({
   children: React.ReactNode;
 }) => {
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
-  // const [showGraph, setShowGraph] = useState<boolean>(false);
   const [selectedNetwork, setSelectedNetwork] = useState(defaultNetworkTopology)
   const [networkList, setNetworkList] = useState<SavedNetworkGraph[]>(
     tempSavednetwork

--- a/frontend/src/contexts/node-flow-context.tsx
+++ b/frontend/src/contexts/node-flow-context.tsx
@@ -9,7 +9,6 @@ import {
   NodePersonaType,
 } from "@/flowTypes";
 import { defaultNodePersona } from "@/app/data";
-import { v4 } from "uuid";
 import { Edge, Node, useEdgesState, useNodesState } from "reactflow";
 import generateGraphML from "@/helpers/generate-graphml";
 export const nodeFlowContext = React.createContext<NodeGraphContext>(null!);
@@ -55,10 +54,6 @@ export const NodeGraphFlowProvider = ({
   };
 
   const generateNodeGraph = () => {
-    // const nodeGraph = {
-    //   nodes: nodes,
-    //   edges: edges,
-    // };
     generateGraphML({ nodes, edges });
   };
 
@@ -108,7 +103,6 @@ export const NodeGraphFlowProvider = ({
 
   const duplicateNode = (node: Node<GraphNode>) => {
     const id = (nodes[nodes.length - 1]?.id ?? 0) + 1;
-    const length = nodes.length;
     const duplicateNode = {
       ...node,
       id,
@@ -165,7 +159,6 @@ export const NodeGraphFlowProvider = ({
         editNode,
         saveEditedNode,
         selectNode,
-        // setNodeInfo,
         showGraphFunc,
         openDialog,
         closeDialog,

--- a/frontend/src/flowTypes.ts
+++ b/frontend/src/flowTypes.ts
@@ -1,4 +1,4 @@
-import { Edge, EdgeChange, Node, NodeChange, OnEdgesChange, OnNodesChange } from "reactflow";
+import { Edge, Node, OnEdgesChange, OnNodesChange } from "reactflow";
 import { BITCOIN_CORE_BINARY_VERSIONS, CPU_CORES, NODE_LATENCY, RAM_OPTIONS } from "./config";
 import * as NetworkContextExports from "./contexts/network-context";
 import { Dispatch } from "react";
@@ -86,7 +86,6 @@ export type NetworkContext = {
   networkList: SavedNetworkGraph[];
   networkTopologyList: NetworkTopology[];
   setNetworkList: (list: SavedNetworkGraph[]) => void;
-  // uploadToNodeGraph: () => void;
   openDialog: () => void;
   closeDialog: () => void;
   setStep: (step: NetworkContextExports.Steps) => void;

--- a/frontend/src/helpers/generate-graphml.ts
+++ b/frontend/src/helpers/generate-graphml.ts
@@ -76,10 +76,10 @@ const generateGraphML = ({ nodes, edges }: GraphElement) => {
   const xml = parse("graphml", graphmlData);
   const blob = new Blob([xml], { type: "application/xml" });
   const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = "graph.graphml";
-  a.click();
+  const downloadLink = document.createElement("a");
+  downloadLink.href = url;
+  downloadLink.download = "graph.graphml";
+  downloadLink.click();
 };
 
 export default generateGraphML;

--- a/frontend/src/helpers/get-node-peers.ts
+++ b/frontend/src/helpers/get-node-peers.ts
@@ -3,8 +3,8 @@ import { Edge, Node } from "reactflow";
 
 const getNodePeers = (
   nodeId: number | string,
-  nodes: Node<Partial<GraphNode>>[],
-  edges: Edge<Partial<GraphEdge>>[]
+  nodes: Node<GraphNode>[],
+  edges: Edge<GraphEdge>[]
 ) => {
   const nodeEdges = edges.filter(
     (edge) => edge.source === nodeId || edge.target === nodeId


### PR DESCRIPTION
To test:
- make sure your warnet server is running.
- run the frontend (`npm i && npm run dev`)
- In your browser go to `localhost:3010/dashboards`. You will see the fork observer and prometheus dashboards in one route.

Todo! 
- add graphana dashboard.
- persist prometheus state when switching tabs