### PR TITLE
fix and shorten miner wrap-around

### DIFF
--- a/src/scenarios/miner_std.py
+++ b/src/scenarios/miner_std.py
@@ -38,9 +38,7 @@ class MinerStd(WarnetTestFramework):
             block = self.generatetoaddress(self.nodes[current_miner], 1, addr)
             self.log.info(f"generated block from node {current_miner}: {block}")
             if self.options.allnodes:
-                current_miner = current_miner + 1
-                if current_miner >= self.num_nodes:
-                    current_miner = 0
+                current_miner = (current_miner + 1) % self.num_nodes
             sleep(self.options.interval)
 
 


### PR DESCRIPTION
For me (TM) without this miner dies after the first iteration when executing:

`warcli scenarios run miner_std --allnodes --interval=2`