### PR TITLE
log: fix fluentd, add log-grepper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,11 @@ jobs:
       - run: pip install --upgrade pip
       - run: pip install -e .
       - run: ./test/v25_net_test.py
+  rpc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt install -y docker docker-compose
+      - run: pip install --upgrade pip
+      - run: pip install -e .
+      - run: ./test/rpc_test.py

--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ Monitor and analyze the emergent behaviors of Bitcoin networks.
 - [CLI Commands](docs/warcli.md)
 - [Scenarios](docs/scenarios.md)
 - [Network Topology](docs/graph.md)
+- [Data Collection](docs/data.md)
 
 ![warnet-art](docs/machines.webp)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Monitor and analyze the emergent behaviors of Bitcoin networks.
 * A local Tor authority provides an internal onion network and each node is reachable by a Tor V3 address.
 * Scenarios can be run across the network which can be programmed using the Bitcoin Core functional [test_framework language](https://github.com/bitcoin/bitcoin/tree/master/test/functional).
 * Nodes can have traffic shaping parameters assigned to them via the graph using [tc-netem](https://manpages.ubuntu.com/manpages/trusty/man8/tc-netem.8.html) tool.
-* Log files from nodes can be accessed directly.
+* Log files from nodes can be accessed directly
+* A unified log file can be grepped using regex
 * Some Bitcoin Core activity is polled and reported via a Graphana dashboard.
 * P2P messages between any two nodes can be retrieved in chronological order.
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,43 @@
+# Data Collection
+
+## Bitcoin Core logs
+
+Complete log output from a Bitcoin Core node can be retrieved by RPC `debug-log` using
+its network name and graph node index.
+
+Example:
+
+```
+$ warcli debug-log 0 --network=v25_test
+
+
+2023-10-11T17:54:39.616974Z Bitcoin Core version v25.0.0 (release build)
+2023-10-11T17:54:39.617209Z Using the 'arm_shani(1way,2way)' SHA256 implementation
+2023-10-11T17:54:39.628852Z Default data directory /home/bitcoin/.bitcoin
+... (etc)
+```
+
+## Aggregated logs from all nodes
+
+An aggregated log is recorded in a separate container in Warnet which can
+be searched using RPC `grep-logs` with regex patterns.
+
+Example:
+
+```
+$ warcli grep-logs 94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d
+
+warnet_test_uhynisdj_tank_000001: 2023-10-11T17:44:48.716582Z [miner] AddToWallet 94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d  newupdate
+warnet_test_uhynisdj_tank_000001: 2023-10-11T17:44:48.717787Z [miner] Submitting wtx 94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d to mempool for relay
+warnet_test_uhynisdj_tank_000001: 2023-10-11T17:44:48.717929Z [validation] Enqueuing TransactionAddedToMempool: txid=94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d wtxid=0cc875e73bb0bd8f892b70b8d1e5154aab64daace8d571efac94c62b8c1da3cf
+warnet_test_uhynisdj_tank_000001: 2023-10-11T17:44:48.718040Z [validation] TransactionAddedToMempool: txid=94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d wtxid=0cc875e73bb0bd8f892b70b8d1e5154aab64daace8d571efac94c62b8c1da3cf
+warnet_test_uhynisdj_tank_000001: 2023-10-11T17:44:48.723017Z [miner] AddToWallet 94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d
+warnet_test_uhynisdj_tank_000007: 2023-10-11T17:44:52.173199Z [validation] Enqueuing TransactionAddedToMempool: txid=94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d wtxid=0cc875e73bb0bd8f892b70b8d1e5154aab64daace8d571efac94c62b8c1da3cf
+warnet_test_uhynisdj_tank_000007: 2023-10-11T17:44:52.173237Z [mempool] AcceptToMemoryPool: peer=0: accepted 94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d (poolsz 1 txn, 1 kB)
+warnet_test_uhynisdj_tank_000007: 2023-10-11T17:44:52.173303Z [validation] TransactionAddedToMempool: txid=94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d wtxid=0cc875e73bb0bd8f892b70b8d1e5154aab64daace8d571efac94c62b8c1da3cf
+warnet_test_uhynisdj_tank_000001: 2023-10-11T17:44:52.172963Z [mempool] Removed 94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d from set of unbroadcast txns
+warnet_test_uhynisdj_tank_000002: 2023-10-11T17:44:52.325655Z [validation] Enqueuing TransactionAddedToMempool: txid=94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d wtxid=0cc875e73bb0bd8f892b70b8d1e5154aab64daace8d571efac94c62b8c1da3cf
+warnet_test_uhynisdj_tank_000002: 2023-10-11T17:44:52.325691Z [mempool] AcceptToMemoryPool: peer=1: accepted 94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d (poolsz 1 txn, 1 kB)
+warnet_test_uhynisdj_tank_000002: 2023-10-11T17:44:52.325838Z [validation] TransactionAddedToMempool: txid=94cacabc09b024b56dcbed9ccad15c90340c596e883159bcb5f1d2152997322d wtxid=0cc875e73bb0bd8f892b70b8d1e5154aab64daace8d571efac94c62b8c1da3cf
+... (etc)
+```

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -75,3 +75,5 @@ Edges can be added between the nodes as follows:
 ![random_internet_as_graph_n100](../docs/random_internet_as_graph_n100.png)
 *random_internet_as_graph_n100*
 
+
+# Next: [Collecting Data](data.md)

--- a/src/services/fluentd.py
+++ b/src/services/fluentd.py
@@ -1,6 +1,7 @@
+import shutil
+from templates import TEMPLATES
 from .base_service import BaseService
 
-FLUENT_IP = "100.102.108.117"
 FLUENT_CONF = "fluent.conf"
 
 class Fluentd(BaseService):
@@ -9,16 +10,22 @@ class Fluentd(BaseService):
     def __init__(self, docker_network, config_dir):
         super().__init__(docker_network, config_dir)
         self.service = {
-            "image": "fluent/fluentd:v1.16-debian-1", # Debian version is recommended officially since it has jemalloc support.
+            "image": "fluent/fluentd:v1.16-debian-1",  # Debian version is recommended officially since it has jemalloc support.
             "container_name": f"{self.docker_network}_fluentd",
-            "ports": [f"{self.PORT}:{self.PORT}"],
+            "ports": [
+                f"{self.PORT}:{self.PORT}"
+            ],
             "volumes": [
                 f"{self.config_dir / FLUENT_CONF}:/fluentd/etc/{FLUENT_CONF}"
             ],
-            "command": ["/bin/sh", "-c", f"sleep 10 && fluentd -c /fluentd/etc/{FLUENT_CONF}"],
-            "networks": {
-                self.docker_network: {
-                    "ipv4_address": f"{FLUENT_IP}",
-                }
-            },
+            "command": ["/bin/sh", "-c", f"fluentd -c /fluentd/etc/{FLUENT_CONF}"],
+            "healthcheck": {
+                "test": ["CMD", "/bin/bash", "-c", f"cat < /dev/null > /dev/tcp/localhost/{self.PORT}"],
+                "interval": "5s",           # Check every 5 seconds
+                "timeout": "1s",            # Give the check 1 second to complete
+                "start_period": "2s",       # Start checking after 2 seconds
+                "retries": 3
+            }
         }
+
+        shutil.copy(TEMPLATES / FLUENT_CONF, config_dir)

--- a/src/templates/bitcoin.conf
+++ b/src/templates/bitcoin.conf
@@ -5,6 +5,7 @@ regtest=1
 # Debugging
 debug=1
 logips=1
+logtimemicros=1
 capturemessages=1
 debugexclude=libevent
 debugexclude=leveldb

--- a/src/templates/bitcoin.conf
+++ b/src/templates/bitcoin.conf
@@ -4,6 +4,7 @@ regtest=1
 
 # Debugging
 debug=1
+debuglogfile=0
 logips=1
 logtimemicros=1
 capturemessages=1

--- a/src/templates/fluent.conf
+++ b/src/templates/fluent.conf
@@ -4,6 +4,25 @@
   bind 0.0.0.0
 </source>
 
+<filter **>
+  @type record_transformer
+  enable_ruby
+  <record>
+    message ${record['container_name'].gsub(/^\//, '')}: ${record['log']}
+  </record>
+</filter>
+
 <match *>
   @type stdout
+  <format>
+    @type single_value
+    message_key message
+  </format>
 </match>
+
+<source>
+  @type http
+  port 24220
+  bind 0.0.0.0
+</source>
+

--- a/src/warnet/cli/main.py
+++ b/src/warnet/cli/main.py
@@ -133,6 +133,25 @@ def messages(node_a, node_b, network):
 
 
 @cli.command()
+@click.argument("pattern", type=str, required=True)
+@click.option("--network", default="warnet", show_default=True)
+def grep_logs(pattern, network):
+    """
+    Grep combined logs via fluentd using regex [pattern]
+    """
+
+    try:
+        result = rpc_call(
+            "grep_logs", {"network": network, "pattern": pattern}
+        )
+        print(result)
+    except Exception as e:
+        print(
+                f"Error fetching combined log: {e}"
+        )
+
+
+@cli.command()
 def stop():
     """
     Stop warnet.

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -250,6 +250,13 @@ class Tank:
                         "condition": "service_healthy"
                     }
                 },
+                "healthcheck": {
+                    "test": ["CMD", "pidof", "bitcoind"],
+                    "interval": "5s",            # Check every 5 seconds
+                    "timeout": "1s",             # Give the check 1 second to complete
+                    "start_period": "5s",       # Start checking after 2 seconds
+                    "retries": 3
+                },
                 "logging": {
                     "driver": "fluentd",
                     "options": {

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -245,14 +245,17 @@ class Tank:
                 "privileged": True,
                 "cap_add": ["NET_ADMIN", "NET_RAW"],
                 "dns": [DNS_IP_ADDR],
-                # "depends_on": ["fluentd"],
-                # "logging": {
-                #     "driver": "fluentd",
-                #     "options": {
-                #         "fluentd-address": f"{FLUENT_IP}:24224",
-                #         "tag": "{{.Name}}"
-                #     }
-                # }
+                "depends_on": {
+                    "fluentd": {
+                        "condition": "service_healthy"
+                    }
+                },
+                "logging": {
+                    "driver": "fluentd",
+                    "options": {
+                        "tag": "{{.Name}}"
+                    }
+                }
             }
         )
 

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -17,7 +17,7 @@ from services.node_exporter import NodeExporter
 from services.grafana import Grafana
 from services.tor import Tor
 from services.fork_observer import ForkObserver
-# from services.fluentd import FLUENT_CONF, Fluentd, FLUENT_IP
+from services.fluentd import Fluentd
 from services.dns_seed import DnsSeed, ZONE_FILE_NAME, DNS_SEED_NAME
 from warnet.tank import Tank
 from warnet.utils import parse_bitcoin_conf, gen_config_dir, bubble_exception_str, version_cmp_ge
@@ -268,7 +268,7 @@ class Warnet:
             # Grafana(self.docker_network),
             Tor(self.docker_network, TEMPLATES),
             ForkObserver(self.docker_network, self.fork_observer_config),
-            # Fluentd(self.docker_network, self.config_dir),
+            Fluentd(self.docker_network, self.config_dir),
         ]
         if dns:
             services.append(DnsSeed(self.docker_network, TEMPLATES, self.config_dir))

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -313,14 +313,14 @@ class Warnet:
         # grep: disable-exporters
         # for tank in self.tanks:
         #     tank.add_scrapers(config["scrape_configs"])
-
-        prometheus_path = self.config_dir / "prometheus.yml"
-        try:
-            with open(prometheus_path, "w") as file:
-                yaml.dump(config, file)
-            logger.info(f"Wrote file: {prometheus_path}")
-        except Exception as e:
-            logger.error(f"An error occurred while writing to {prometheus_path}: {e}")
+        #
+        # prometheus_path = self.config_dir / "prometheus.yml"
+        # try:
+        #     with open(prometheus_path, "w") as file:
+        #         yaml.dump(config, file)
+        #     logger.info(f"Wrote file: {prometheus_path}")
+        # except Exception as e:
+        #     logger.error(f"An error occurred while writing to {prometheus_path}: {e}")
 
 
     @bubble_exception_str

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import os
+from test_base import TestBase
+from pathlib import Path
+
+graph_file_path = Path(os.path.dirname(__file__)) / "data" / "v25_x_12.graphml"
+
+base = TestBase()
+base.start_server()
+print(base.warcli(f"network start {graph_file_path}"))
+base.wait_for_all_tanks_status(target="running")
+
+# Exponential backoff will repeat this command until it succeeds.
+# That's when we are ready for commands
+base.warcli("rpc 0 getblockcount")
+
+# Fund wallet
+base.warcli("rpc 1 createwallet miner")
+base.warcli("rpc 1 -generate 101")
+
+base.wait_for_predicate(lambda: "101" in base.warcli("rpc 0 getblockcount"))
+
+txid = base.warcli("rpc 1 sendtoaddress --params=bcrt1qthmht0k2qnh3wy7336z05lu2km7emzfpm3wg46 --params=0.1")
+
+base.wait_for_predicate(lambda: txid in base.warcli("rpc 0 getrawmempool"))
+
+node_log = base.warcli('debug-log 1')
+assert txid in node_log
+
+all_logs = base.warcli(f'grep-logs {txid}')
+count = all_logs.count("Enqueuing TransactionAddedToMempool")
+# should be at least more than one node
+assert count > 1
+
+base.stop_server()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -62,7 +62,7 @@ class TestBase:
             cmd,
             stdout=PIPE,
             stderr=PIPE)
-        return proc.stdout.decode()
+        return proc.stdout.decode().strip()
 
 
     # Execute a warnet RPC API call directly (may return dict or list)


### PR DESCRIPTION
* Fluentd seems to only work listening on 0.0.0.0 and not an internal (warnet) network ip address.
* Implies a single docker daemon can only have a single flutend log driver.
* Search unified logs with `warcli grep-logs [regex pattern]`