### PR TITLE
build: switch to docker compose plugin by default

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -11,7 +11,7 @@ cp .env.sample .env
 2. Run the docker daemon
 
 ```bash
-docker-compose -f api-compose.yml up -d
+docker compose -f api-compose.yml up -d
 ```
 
 3. We use Postgresql as a data store. You can access it locally by using this connection string.

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,15 +2,30 @@
 
 ## Dependencies
 
-Install system dependencies:
+Install docker engine and it's `compose` plugin for your system: https://docs.docker.com/engine/install/
 
-* `docker`
-* `docker-compose`
-
-e.g. for debian-based linux distros:
+e.g. For Ubuntu:
 
 ```bash
-apt install docker docker-compose
+# First uninstall any old versions
+for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+# Install the docker packages and docker compose plugin
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 
 ### Using Docker

--- a/docs/warcli.md
+++ b/docs/warcli.md
@@ -37,9 +37,9 @@ warcli
   + network
   |   + start  Build and run a new Warnet network from a graph file (default: src/templates/example.graphml)
   |   |          ex: warcli network start ~/docs/cool_network.graphml --network=sweet
-  |   + up     Run "docker-compose up" on a given network
+  |   + up     Run "docker compose up" on a given network
   |   |          ex: warcli network up --network=sweet
-  |   + down   Run "docker-compose down" on a given network
+  |   + down   Run "docker compose down" on a given network
   |              ex: warcli network down --network=sweet
   + debug
       + generate_compose

--- a/src/warnet/cli/network.py
+++ b/src/warnet/cli/network.py
@@ -39,7 +39,7 @@ def start(
 @click.option("--network", default="warnet", show_default=True)
 def up(network: str = "warnet"):
     """
-    Run 'docker-compose up' on a warnet named <--network> (default: "warnet").
+    Run 'docker compose up' on a warnet named <--network> (default: "warnet").
     """
     try:
         result = rpc_call("up", {"network": network})
@@ -52,13 +52,13 @@ def up(network: str = "warnet"):
 @click.option("--network", default="warnet", show_default=True)
 def down(network: str = "warnet"):
     """
-    Run 'docker-compose down on a warnet named <--network> (default: "warnet").
+    Run 'docker compose down on a warnet named <--network> (default: "warnet").
     """
     try:
         result = rpc_call("down", {"network": network})
         print(result)
     except Exception as e:
-        print(f"Error running docker-compose down on network {network}: {e}")
+        print(f"Error running docker compose down on network {network}: {e}")
 
 
 @network.command()

--- a/src/warnet/client.py
+++ b/src/warnet/client.py
@@ -98,7 +98,7 @@ def stop_network(network="warnet") -> bool:
 
 def compose_down(network="warnet") -> bool:
     """
-    Run docker-compose down on a warnet
+    Run docker compose down on a warnet
     """
     wn = Warnet.from_network(network)
     wn.docker_compose_down()

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -193,7 +193,7 @@ class Warnet:
 
     @bubble_exception_str
     def docker_compose_build_up(self):
-        command = ["docker-compose", "-p", self.docker_network, "up", "-d", "--build"]
+        command = ["docker", "compose", "-p", self.docker_network, "up", "-d", "--build"]
         try:
             with subprocess.Popen(
                 command,
@@ -210,7 +210,7 @@ class Warnet:
 
     @bubble_exception_str
     def docker_compose_up(self):
-        command = ["docker-compose", "-p", self.docker_network, "up", "-d"]
+        command = ["docker", "compose", "-p", self.docker_network, "up", "-d"]
         try:
             with subprocess.Popen(
                 command,
@@ -227,7 +227,7 @@ class Warnet:
 
     @bubble_exception_str
     def docker_compose_down(self):
-        command = ["docker-compose", "down"]
+        command = ["docker", "compose", "down"]
         try:
             with subprocess.Popen(
                 command,


### PR DESCRIPTION
This should avoid docker-compose binary mismatches from system repos with old versions (looking at you Debian).