### PR TITLE
tank: Use healthcheck that relies on RPC

### DIFF
--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -251,7 +251,7 @@ class Tank:
                     }
                 },
                 "healthcheck": {
-                    "test": ["CMD", "pidof", "bitcoind"],
+                    "test": ["CMD-SHELL", f"bitcoin-cli -rpcport={self.rpc_port} -rpcuser={self.rpc_user} -rpcpassword={self.rpc_password} getblockcount"],
                     "interval": "5s",            # Check every 5 seconds
                     "timeout": "1s",             # Give the check 1 second to complete
                     "start_period": "5s",       # Start checking after 2 seconds


### PR DESCRIPTION
Currently using the PID can still result in a race where the process has started but the RPC is not actually online.

I think this should fix some spurious `onion` test failures, like this one: https://github.com/bitcoin-dev-project/warnet/actions/runs/6516835067/job/17700750888?pr=93#step:6:2278