### PR TITLE
WIP: test: always kill warnet server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "docker==6.1.3",
     "flask==2.3.3",
     "Flask-JSONRPC==2.2.2",
+    "gunicorn==21.2.0",
     "jsonschema",
     "jsonrpcserver==5.0.3",
     "jsonrpcclient==4.0.0",

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import pkgutil
-import re
 import shutil
 import signal
 import subprocess
@@ -336,12 +335,13 @@ class Server():
         return wn.container_interface.logs_grep(pattern, container_name)
 
 
-def run_server():
-    # https://flask.palletsprojects.com/en/2.3.x/api/#flask.Flask.run
-    # "If the debug flag is set the server will automatically reload
-    # for code changes and show a debugger in case an exception happened."
-    Server().app.run(host="0.0.0.0", port=WARNET_SERVER_PORT, debug=False)
+server = Server()
+app = server.app
 
+def run_server():
+    from gunicorn.app.wsgiapp import run
+    sys.argv = [sys.argv[0], "warnet.server:app", "-b", f"0.0.0.0:{WARNET_SERVER_PORT}", "-w", "1"]
+    run()
 
 if __name__ == "__main__":
     run_server()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,8 +1,10 @@
 import atexit
+import threading
 from pathlib import Path
 from subprocess import Popen, run, PIPE
 from tempfile import mkdtemp
 from time import sleep
+from typing import Optional
 from warnet.cli.rpc import rpc_call
 from warnet.warnet import Warnet
 from warnet.utils import exponential_backoff
@@ -16,42 +18,45 @@ class TestBase:
         # Use the same dir name for the warnet network name
         self.network_name = self.tmpdir.name
         self.logfile = None
-        self.server = None
+        self.server: Optional[Popen] = None
+        self.cleaned_up = False
 
         atexit.register(self.cleanup)
 
         print(f"\nWarnet test base started")
 
+    def cleanup_server(self):
+        self.warcli("stop")
+        sleep(2)
+        if self.server.poll() is None:
+            # kill it!
+            print("Error stopping server using `warcli stop`, killing with terminate()")
+            self.server.terminate()
+            self.server.wait()
 
-    def cleanup(self, signum = None, frame = None):
-        if self.server is None:
-            return
-
+    def cleanup_network(self):
         try:
             print("\nStopping network")
             self.warcli("network down")
 
             self.wait_for_all_tanks_status(target="none", timeout=60, interval=1)
 
-            print("\nStopping server")
-            self.warcli("stop", False)
         except Exception as e:
             # Remove the temporary docker network when we quit.
             # If the warnet server exited prematurely then docker-compose down
             # likely did not succeed or was never executed.
             print(f"Error stopping server: {e}")
-            print("Attempting to cleanup docker network")
+            print("Attempting to force cleanup of docker network")
             wn = Warnet.from_network(self.network_name)
-            wn.docker_compose_down()
+            wn.warnet_down()
 
-        print("\nRemaining server output:")
-        print(self.logfile.read())
-        self.logfile.close()
+    def cleanup(self, signum = None, frame = None):
+        if self.cleaned_up:
+            return
 
-        self.logfile = None
-        self.server.terminate()
-        self.server = None
-
+        self.cleanup_network()
+        self.cleanup_server()
+        self.cleaned_up = True
 
     # Execute a warcli RPC using command line (always returns string)
     def warcli(self, str, network=True):
@@ -64,17 +69,25 @@ class TestBase:
             stderr=PIPE)
         return proc.stdout.decode().strip()
 
-
     # Execute a warnet RPC API call directly (may return dict or list)
     def rpc(self, method, params = []):
         return rpc_call(method, params)
-
 
     # Repeatedly execute an RPC until it succeeds
     @exponential_backoff()
     def wait_for_rpc(self, method, params = []):
         return rpc_call(method, params)
 
+    def output_reader(self, pipe):
+        """
+        Write stdout and stderr to stdout and a file
+        """
+        with open(self.logfilepath, 'a') as logfile:
+            for line in iter(pipe.readline, b''):
+                line_decoded = line.decode('utf-8')
+                print(line_decoded, end='')  # Print to main STDOUT
+                logfile.write(line_decoded)
+                logfile.flush()
 
     # Start the Warnet server and wait for RPC interface to respond
     def start_server(self):
@@ -85,28 +98,25 @@ class TestBase:
         #       maybe also ensure that no conflicting docker networks exist
 
         print(f"\nStarting Warnet server, logging to: {self.logfilepath}")
-        self.server = Popen(
-            f"warnet > {self.logfilepath}",
-            shell=True)
+        self.server = Popen(["warnet"], stdout=PIPE, stderr=PIPE)
+
+        # capture STDOUT and STDERR using threads
+        stdout_thread = threading.Thread(target=self.output_reader, args=(self.server.stdout,), daemon=True)
+        stderr_thread = threading.Thread(target=self.output_reader, args=(self.server.stderr,), daemon=True)
+        stdout_thread.start()
+        stderr_thread.start()
 
         print("\nWaiting for RPC")
         # doesn't require anything docker-related
         self.wait_for_rpc("scenarios_list")
-        # open the log file for reading for the duration of the test
-        self.logfile = open(self.logfilepath, "r")
-
 
     # Quit
     def stop_server(self):
         self.cleanup()
-
+        sleep(1) # Give reader std* threads a second to process final output
 
     def wait_for_predicate(self, predicate, timeout=5*60, interval=5):
         while True:
-            # Inside the loop, this continuously prints the log output.
-            # It will read whatever has been written to the file
-            # since the last read.
-            print(self.logfile.read())
             if predicate():
                 break
             sleep(interval)
@@ -114,11 +124,9 @@ class TestBase:
             if timeout < 0:
                 raise Exception(f"Timed out waiting for predicate Truth")
 
-
     def get_tank(self, index):
         wn = Warnet.from_network(self.network_name)
         return wn.tanks[index]
-
 
     # Poll the warnet server for container status
     # Block until all tanks are running


### PR DESCRIPTION
This fixes the test framework logging to not use files, but instead threads which write std{out/err} to the file and main test program stdout. I believe these open files could have been interrupting shutdown somehow.

It also calls `terminate()` on the server, if `warcli stop` fails (which should not fail, but does).

This fixes the symptom, but not the problem...