### PR TITLE
fork-observer: reduce query interval

### DIFF
--- a/src/templates/fork_observer_config.toml
+++ b/src/templates/fork_observer_config.toml
@@ -7,7 +7,7 @@ database_path = "db"
 www_path = "./www"
 
 # Interval for checking for new blocks
-query_interval = 10
+query_interval = 60
 
 # Webserver listen address
 address = "0.0.0.0:2323"


### PR DESCRIPTION
For S-C-A-L-I-N-G

Reduce query interval to every 60 seconds by default. Helps on larger networks.