### PR TITLE
fork-observer: extract from warnet

### DIFF
--- a/src/interfaces/docker_interface.py
+++ b/src/interfaces/docker_interface.py
@@ -248,8 +248,7 @@ class DockerInterface(ContainerInterface):
         defaults += f" -rpcport={tank.rpc_port}"
         return defaults
 
-    def copy_configs(self, tank):
-        import shutil
+    def copy_tank_configs(self, tank):
         shutil.copyfile(TEMPLATES / DOCKERFILE_NAME, tank.config_dir / DOCKERFILE_NAME)
         shutil.copyfile(TEMPLATES / TORRC_NAME, tank.config_dir / TORRC_NAME)
         shutil.copyfile(TEMPLATES / ENTRYPOINT_NAME, tank.config_dir / ENTRYPOINT_NAME)
@@ -274,7 +273,7 @@ class DockerInterface(ContainerInterface):
                 },
             }
             services[tank.container_name]['build'] = build
-            self.copy_configs(tank)
+            self.copy_tank_configs(tank)
         else:
             image = f"{DOCKER_REGISTRY}:{tank.version}"
             services[tank.container_name]['image'] = image

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -255,7 +255,6 @@ class Server():
                 wn.generate_deployment()
                 # grep: disable-exporters
                 # wn.write_prometheus_config()
-                wn.write_fork_observer_config()
                 wn.warnet_build()
                 wn.warnet_up()
                 wn.apply_network_conditions()

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -5,9 +5,7 @@
 import logging
 import networkx
 import shutil
-import yaml
 from pathlib import Path
-from templates import TEMPLATES
 from typing import List, Optional
 
 from services.prometheus import Prometheus
@@ -18,7 +16,6 @@ from warnet.tank import Tank
 from warnet.utils import gen_config_dir, bubble_exception_str, version_cmp_ge
 
 logger = logging.getLogger("warnet")
-FO_CONF_NAME = "fork_observer_config.toml"
 
 
 class Warnet:
@@ -174,22 +171,4 @@ class Warnet:
         #     logger.info(f"Wrote file: {prometheus_path}")
         # except Exception as e:
         #     logger.error(f"An error occurred while writing to {prometheus_path}: {e}")
-
-
-    @bubble_exception_str
-    def write_fork_observer_config(self):
-        shutil.copy(TEMPLATES / FO_CONF_NAME, self.fork_observer_config)
-        with open(self.fork_observer_config, "a") as f:
-            for tank in self.tanks:
-                f.write(f"""
-                    [[networks.nodes]]
-                    id = {tank.index}
-                    name = "Node {tank.index}"
-                    description = "Warnet tank {tank.index}"
-                    rpc_host = "{tank.ipv4}"
-                    rpc_port = {tank.rpc_port}
-                    rpc_user = "{tank.rpc_user}"
-                    rpc_password = "{tank.rpc_password}"
-                """)
-        logger.info(f"Wrote file: {self.fork_observer_config}")
 


### PR DESCRIPTION
This is best implemented by the container implementation

@josibake Going to propose this for now. We should remove FO from `Warnet` in any case, this just lets you handle it in your own way more cleanly