### PR TITLE
scenarios: add small sleep between sends

### DIFF
--- a/src/scenarios/tx_flood.py
+++ b/src/scenarios/tx_flood.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from warnet.test_framework_bridge import WarnetTestFramework
 from scenarios.utils import ensure_miner
+from time import sleep
 
 BLOCKS = 100
 TXS = 100
@@ -21,8 +22,10 @@ class TXFlood(WarnetTestFramework):
         for b in range(BLOCKS):
             for t in range(TXS):
                 txid = self.nodes[0].sendtoaddress(address=addr, amount=0.001)
+                sleep(0.1)
                 self.log.info(f"sending tx {t}/{TXS}: {txid}")
             block = self.generate(self.nodes[0], 1)
+            sleep(1)
             self.log.info(f"generating block {b}/{BLOCKS}: {block}")
 
 


### PR DESCRIPTION
give single CPU setups (docker) time to context switch and keep up