### PR TITLE
Send graph via base64 rather than file path

### DIFF
--- a/src/warnet/cli/network.py
+++ b/src/warnet/cli/network.py
@@ -1,3 +1,4 @@
+import base64
 from pathlib import Path
 
 import click
@@ -24,9 +25,12 @@ def start(graph_file: Path, force: bool, network: str):
     Start a warnet with topology loaded from a <graph_file> into <--network> (default: "warnet")
     """
     try:
+        encoded_graph_file = ""
+        with open(graph_file, "rb") as graph_file_buffer:
+            encoded_graph_file = base64.b64encode(graph_file_buffer.read()).decode("utf-8")
         result = rpc_call(
             "network_from_file",
-            {"graph_file": str(graph_file), "force": force, "network": network},
+            {"graph_file": encoded_graph_file, "force": force, "network": network},
         )
         print(result)
     except Exception as e:

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -292,7 +292,7 @@ class Server():
                 wn.apply_network_conditions()
                 wn.connect_edges()
                 self.logger.info(
-                    f"Created warnet named '{network}' from graph file {graph_file}"
+                    f"Created warnet named '{network}'"
                 )
             except Exception as e:
                 self.logger.error(f"Exception {e}")

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -2,6 +2,7 @@
   Warnet is the top-level class for a simulated network.
 """
 
+import base64
 import json
 import logging
 import networkx
@@ -57,14 +58,16 @@ class Warnet:
     @classmethod
     @bubble_exception_str
     def from_graph_file(
-        cls, graph_file: str, config_dir: Path, network: str = "warnet"
+        cls, base64_graph: str, config_dir: Path, network: str = "warnet"
     ):
         self = cls(config_dir)
         destination = self.config_dir / self.graph_name
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(graph_file, destination)
+        graph_file = base64.b64decode(base64_graph)
+        with open(destination, "wb") as f:
+            f.write(graph_file)
         self.network_name = network
-        self.graph = networkx.read_graphml(graph_file, node_type=int)
+        self.graph = networkx.parse_graphml(graph_file.decode("utf-8"), node_type=int)
         self.tanks_from_graph()
         logger.info(f"Created Warnet using directory {self.config_dir}")
         return self


### PR DESCRIPTION
Supports scenarios where the RPC is running on a different machine and doesn't have access to the file paths