### PR TITLE
add persist option to network_down

### DIFF
--- a/src/interfaces/interfaces.py
+++ b/src/interfaces/interfaces.py
@@ -25,7 +25,7 @@ class ContainerInterface(ABC):
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
-    def down(self) -> bool:
+    def down(self, persist: bool = False) -> bool:
         """
         Bring an exsiting network down.
             e.g. `docker compose down`

--- a/src/warnet/cli/network.py
+++ b/src/warnet/cli/network.py
@@ -52,12 +52,13 @@ def up(network: str):
 
 @network.command()
 @click.option("--network", default="warnet", show_default=True)
-def down(network: str):
+@click.option('--persist', is_flag=True)
+def down(network: str, persist: bool):
     """
     Run 'docker compose down on a warnet named <--network> (default: "warnet").
     """
     try:
-        result = rpc_call("network_down", {"network": network})
+        result = rpc_call("network_down", {"network": network, "persist": persist})
         print(result)
     except Exception as e:
         print(f"Error running docker compose down on network {network}: {e}")

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -316,13 +316,13 @@ class Server():
         xml_data = bio.getvalue()
         return f"Generated graph:\n\n{xml_data.decode('utf-8')}"
 
-    def network_down(self, network: str = "warnet") -> str:
+    def network_down(self, persist: bool, network: str = "warnet") -> str:
         """
         Stop all containers in <network>.
         """
         wn = Warnet.from_network(network)
         try:
-            wn.warnet_down()
+            wn.warnet_down(persist)
             return "Stopping warnet"
         except Exception as e:
             return f"Exception {e}"

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -148,8 +148,8 @@ class Warnet:
         self.container_interface.up()
 
     @bubble_exception_str
-    def warnet_down(self):
-        self.container_interface.down()
+    def warnet_down(self, persist):
+        self.container_interface.down(persist)
 
     def generate_deployment(self):
         self.container_interface.generate_deployment_file(self)


### PR DESCRIPTION
Closes: #209

For docker, this enables keeping the images in local docker registry and not needing to pull them again.

Use with:

```
docker network down --persist
```

This is off by default, unsure whether on-by-default makes more sense? It's mainly going to be folks like us using it?...