### PR TITLE
Re-enable prometheus exporter

### DIFF
--- a/src/graphs/default.graphml
+++ b/src/graphs/default.graphml
@@ -3,30 +3,37 @@
   <key attr.name="bitcoin_config" attr.type="string" for="node" id="bitcoin_config"/>
   <key attr.name="tc_netem" attr.type="string" for="node" id="tc_netem"/>
   <key attr.name="build_args" attr.type="string" for="node" id="build_args"/>
+  <key attr.name="exporter" attr.type="boolean" for="node" id="exporter"/>
   <graph edgedefault="directed">
     <node id="0">
         <data key="version">25.1</data>
         <data key="bitcoin_config">-uacomment=w0</data>
+        <data key="exporter">true</data>
     </node>
     <node id="1">
         <data key="version">25.1</data>
         <data key="bitcoin_config">-uacomment=w1</data>
+        <data key="exporter">true</data>
     </node>
     <node id="2">
         <data key="version">25.1</data>
         <data key="bitcoin_config">-uacomment=w2</data>
+        <data key="exporter">true</data>
     </node>
     <node id="3">
         <data key="version">25.1</data>
         <data key="bitcoin_config">-uacomment=w3</data>
+        <data key="exporter">true</data>
     </node>
     <node id="4">
         <data key="version">25.1</data>
         <data key="bitcoin_config">-uacomment=w4</data>
+        <data key="exporter">true</data>
     </node>
     <node id="5">
         <data key="version">25.1</data>
         <data key="bitcoin_config">-uacomment=w5</data>
+        <data key="exporter">true</data>
     </node>
     <node id="6">
         <data key="version">25.1</data>

--- a/src/graphs/default.graphml
+++ b/src/graphs/default.graphml
@@ -6,57 +6,57 @@
   <key attr.name="exporter" attr.type="boolean" for="node" id="exporter"/>
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w0</data>
         <data key="exporter">true</data>
     </node>
     <node id="1">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w1</data>
         <data key="exporter">true</data>
     </node>
     <node id="2">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w2</data>
         <data key="exporter">true</data>
     </node>
     <node id="3">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w3</data>
         <data key="exporter">true</data>
     </node>
     <node id="4">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w4</data>
         <data key="exporter">true</data>
     </node>
     <node id="5">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w5</data>
         <data key="exporter">true</data>
     </node>
     <node id="6">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w6</data>
     </node>
     <node id="7">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w7</data>
     </node>
     <node id="8">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w8</data>
     </node>
     <node id="9">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w9</data>
     </node>
     <node id="10">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w10</data>
     </node>
     <node id="11">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w11</data>
     </node>
     <!-- connect the nodes in a ring to start -->

--- a/src/services/grafana-provisioning/dashboards/bitcoin_rpc_scraper.json
+++ b/src/services/grafana-provisioning/dashboards/bitcoin_rpc_scraper.json
@@ -1,0 +1,340 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusdatasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusdatasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "bitcoin_mempool_size",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Mempool Size (# Txs)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusdatasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusdatasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "bitcoin_conn_out",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Outbound connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusdatasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusdatasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "bitcoin_conn_in",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Inbound connections",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Bitcoin RPC scraper",
+  "uid": "fe65ef87-2bb3-4bef-b57e-0f4d30abdf96",
+  "version": 1,
+  "weekStart": ""
+}

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -308,8 +308,6 @@ class Server:
         def thread_start(wn):
             try:
                 wn.generate_deployment()
-                # grep: disable-exporters
-                # wn.write_prometheus_config()
                 # wn.write_fork_observer_config()
                 wn.warnet_build()
                 wn.warnet_up()

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -35,6 +35,7 @@ class Tank:
         self.conf = ""
         self.conf_file = None
         self.netem = None
+        self.exporter = False
         self.rpc_port = 18443
         self.rpc_user = "warnet_user"
         self.rpc_password = "2themoon"
@@ -79,6 +80,7 @@ class Tank:
             self.version = version
         self.conf = node.get("bitcoin_config", self.conf)
         self.netem = node.get("tc_netem", self.netem)
+        self.exporter = node.get("exporter", self.exporter)
         self.extra_build_args = node.get("build_args", self.extra_build_args)
 
         if "ln" in node:

--- a/test/data/build_v24_test.graphml
+++ b/test/data/build_v24_test.graphml
@@ -5,7 +5,7 @@
   <key attr.name="build_args" attr.type="string" for="node" id="build_args"/>
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w0</data>
     </node>
     <node id="1">

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -6,22 +6,22 @@
   <key attr.name="channel"        attr.type="string" for="edge" id="channel"/>
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">uacomment=w0</data>
         <data key="ln">lnd</data>
     </node>
     <node id="1">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">uacomment=w1</data>
         <data key="ln">lnd</data>
     </node>
     <node id="2">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">uacomment=w2</data>
         <data key="ln">lnd</data>
     </node>
     <node id="3">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">uacomment=w3</data>
     </node>
     <edge id="1" source="0" target="1"></edge>

--- a/test/data/v25_x_12.graphml
+++ b/test/data/v25_x_12.graphml
@@ -4,51 +4,51 @@
   <key attr.name="tc_netem" attr.type="string" for="node" id="tc_netem"/>
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w0</data>
     </node>
     <node id="1">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w1</data>
     </node>
     <node id="2">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w2</data>
     </node>
     <node id="3">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w3</data>
     </node>
     <node id="4">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w4</data>
     </node>
     <node id="5">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w5</data>
     </node>
     <node id="6">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w6</data>
     </node>
     <node id="7">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w7</data>
     </node>
     <node id="8">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w8</data>
     </node>
     <node id="9">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w9</data>
     </node>
     <node id="10">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w10</data>
     </node>
     <node id="11">
-        <data key="version">25.1</data>
+        <data key="version">26.0</data>
         <!-- no bitcoin_config to test unused options -->
     </node>
     <!-- connect the nodes in a ring to start -->


### PR DESCRIPTION
This adds a new option to the graph file schema. When `<data key="exporter">true</data>` is present in a node definition, it will be paired with a bitcoin-prometheus-exporter container, and the exported data is visible in grafana. I also included a new default dashboard "Bitcoin RPC dashboard" which shows a little sample of the RPC data collected:

<img width="2032" alt="Screen Shot 2023-12-21 at 3 06 42 PM" src="https://github.com/bitcoin-dev-project/warnet/assets/2084648/94122b66-b0bd-401f-b624-a020b56f8616">
