### PR TITLE
fixup error message when config dir already exists

### DIFF
--- a/src/warnet/cli/network.py
+++ b/src/warnet/cli/network.py
@@ -57,7 +57,11 @@ def start(graph_file: Path, force: bool, network: str):
             "network_from_file",
             {"graph_file": encoded_graph_file, "force": force, "network": network},
         )
-        print_repr(result)
+        # It's a warnet
+        if isinstance(result, dict):
+            print_repr(result)
+        else:
+            print(result)
     except Exception as e:
         print(f"Error creating network: {e}")
 

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -211,7 +211,7 @@ class Server:
                     scenario_list.append((s.name, m.cli_help()))
             return scenario_list
         except Exception as e:
-            return [f"Exception {e}"]
+            return [(f"Exception {e}", )]
 
     def scenarios_run(
         self, scenario: str, additional_args: List[str], network: str = "warnet"


### PR DESCRIPTION
fixes an oversight when we try a custom print of a dict on an error string