### PR TITLE
JSON-IFY the server properly

### DIFF
--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -24,7 +24,6 @@ from warnet.tank import Tank
 from warnet.status import RunningStatus
 from warnet.lnnode import LNNode
 from warnet.utils import (
-    bubble_exception_str,
     parse_raw_messages,
     default_bitcoin_conf_args,
     set_execute_permission,
@@ -51,7 +50,6 @@ class ComposeBackend(BackendInterface):
         self.network_name = network_name
         self.client = docker.DockerClient = docker.from_env()
 
-    @bubble_exception_str
     def build(self) -> bool:
         command = ["docker", "compose", "build"]
         try:
@@ -72,7 +70,6 @@ class ComposeBackend(BackendInterface):
             return False
         return True
 
-    @bubble_exception_str
     def up(self, *_):
         command = ["docker", "compose", "up", "--detach"]
         try:
@@ -91,7 +88,6 @@ class ComposeBackend(BackendInterface):
                 f"An error occurred while executing `{' '.join(command)}` in {self.config_dir}: {e}"
             )
 
-    @bubble_exception_str
     def down(self, warnet):
         command = ["docker", "compose", "down"]
         try:

--- a/src/backends/compose/services/loki/loki.py
+++ b/src/backends/compose/services/loki/loki.py
@@ -8,7 +8,6 @@ PORT = 3100
 
 
 class Loki(BaseService):
-
     def __init__(self, docker_network):
         super().__init__(docker_network)
         self.service = {

--- a/src/backends/compose/services/promtail/promtail.py
+++ b/src/backends/compose/services/promtail/promtail.py
@@ -7,7 +7,6 @@ IMAGE = "grafana/promtail:2.9.3"
 
 
 class Promtail(BaseService):
-
     def __init__(self, docker_network):
         super().__init__(docker_network)
         self.service = {
@@ -17,8 +16,8 @@ class Promtail(BaseService):
                 f"{PROMTAIL_CONF_DIR}:/etc/promtail",
                 # to read container labels and logs
                 "/var/run/docker.sock:/var/run/docker.sock",
-                "/var/lib/docker/containers:/var/lib/docker/containers"
-                ],
+                "/var/lib/docker/containers:/var/lib/docker/containers",
+            ],
             "command": "-config.file=/etc/promtail/config.yaml",
             "networks": [self.docker_network],
         }

--- a/src/warnet/cli/debug.py
+++ b/src/warnet/cli/debug.py
@@ -16,8 +16,4 @@ def generate_compose(graph_file: str, network: str):
     """
     Generate the docker-compose file for a given <graph_file> and <--network> (default: "warnet") name and return it.
     """
-    try:
-        result = rpc_call("generate_compose", {"graph_file": graph_file, "network": network})
-        print(result)
-    except Exception as e:
-        print(f"Error generating compose: {e}")
+    print(rpc_call("generate_compose", {"graph_file": graph_file, "network": network}))

--- a/src/warnet/cli/graph.py
+++ b/src/warnet/cli/graph.py
@@ -25,8 +25,8 @@ def create(
     """
     Create a graph file of type random AS graph with [params]
     """
-    try:
-        result = rpc_call(
+    print(
+        rpc_call(
             "graph_generate",
             {
                 "params": params,
@@ -36,6 +36,4 @@ def create(
                 "random": random,
             },
         )
-        print(result)
-    except Exception as e:
-        print(f"Error generating graph: {e}")
+    )

--- a/src/warnet/cli/rpc.py
+++ b/src/warnet/cli/rpc.py
@@ -1,17 +1,27 @@
 import requests
-from jsonrpcclient.responses import Ok, parse
+import sys
+from jsonrpcclient.responses import Error, Ok, parse
 from jsonrpcclient.requests import request
 from typing import Any, Dict, Tuple, Union, Optional
 from warnet.server import WARNET_SERVER_PORT
 
 
+class JSONRPCException(Exception):
+    def __init__(self, code, message):
+        try:
+            errmsg = f"{code} {message}"
+        except (KeyError, TypeError):
+            errmsg = ""
+        super().__init__(errmsg)
+
+
 def rpc_call(rpc_method, params: Optional[Union[Dict[str, Any], Tuple[Any, ...]]]):
     payload = request(rpc_method, params)
     response = requests.post(f"http://localhost:{WARNET_SERVER_PORT}/api", json=payload)
-    parsed = parse(response.json())
-
-    if isinstance(parsed, Ok):
-        return parsed.result
-    else:
-        error_message = getattr(parsed, "message", "Unknown RPC error")
-        raise Exception(error_message)
+    match parse(response.json()):
+        case Ok(result, _):
+            return result
+        case Error(code, message, _, _):
+            print(f"{code}: {message}")
+            sys.exit(1)
+            # raise JSONRPCException(code, message)

--- a/src/warnet/cli/scenarios.py
+++ b/src/warnet/cli/scenarios.py
@@ -1,4 +1,5 @@
 import click
+from typing import List
 from rich import print
 from rich.console import Console
 from rich.table import Table
@@ -18,21 +19,17 @@ def list():
     List available scenarios in the Warnet Test Framework
     """
     console = Console()
-    try:
-        result = rpc_call("scenarios_list", None)
+    result = rpc_call("scenarios_list", None)
+    assert isinstance(result, List)
 
-        # Create the table
-        table = Table(show_header=True, header_style="bold")
-        table.add_column("Name")
-        table.add_column("Description")
+    # Create the table
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name")
+    table.add_column("Description")
 
-        for scenario in result:
-            table.add_row(scenario[0], scenario[1])
-
-        console.print(table)
-
-    except Exception as e:
-        console.print(f"[red]Error listing scenarios: {e}[/red]")
+    for scenario in result:
+        table.add_row(scenario[0], scenario[1])
+    console.print(table)
 
 
 @scenarios.command(context_settings={"ignore_unknown_options": True})
@@ -43,16 +40,12 @@ def run(scenario, network, additional_args):
     """
     Run <scenario> from the Warnet Test Framework on <--network> with optional arguments
     """
-    try:
-        params = {
-            "scenario": scenario,
-            "additional_args": additional_args,
-            "network": network,
-        }
-        res = rpc_call("scenarios_run", params)
-        print(res)
-    except Exception as e:
-        print(f"Error running scenario: {e}")
+    params = {
+        "scenario": scenario,
+        "additional_args": additional_args,
+        "network": network,
+    }
+    print(rpc_call("scenarios_run", params))
 
 
 @scenarios.command()
@@ -61,22 +54,17 @@ def active():
     List running scenarios "name": "pid" pairs
     """
     console = Console()
-    try:
-        result = rpc_call("scenarios_list_running", {})
-        if result:
-            table = Table(show_header=True, header_style="bold")
-            for key in result[0].keys():
-                table.add_column(key.capitalize())
+    result = rpc_call("scenarios_list_running", {})
+    assert isinstance(result, List), "Result is not a list"  # Make mypy happy again
 
-            for scenario in result:
-                table.add_row(*[str(scenario[key]) for key in scenario])
+    table = Table(show_header=True, header_style="bold")
+    for key in result[0].keys():
+        table.add_column(key.capitalize())
 
-            console.print(table)
-        else:
-            console.print("No scenarios running")
+    for scenario in result:
+        table.add_row(*[str(scenario[key]) for key in scenario])
 
-    except Exception as e:
-        console.print(f"[red]Error listing scenarios: {e}[/red]")
+    console.print(table)
 
 
 @scenarios.command()
@@ -85,9 +73,5 @@ def stop(pid: int):
     """
     Stop scenario with PID <pid> from running
     """
-    try:
-        params = {"pid": pid}
-        res = rpc_call("scenarios_stop", params)
-        print(res)
-    except Exception as e:
-        print(f"Error stopping scenario: {e}")
+    params = {"pid": pid}
+    print(rpc_call("scenarios_stop", params))

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -46,7 +46,7 @@ class LNNode:
         uri = tank.lnnode.getURI()
         res = self.lncli(f"connect {uri}")
         return res
-    
+
     def generate_cli_command(self, command: List[str]):
         network = f"--network={self.tank.warnet.bitcoin_network}"
         cmd = f"{network} {' '.join(command)}"

--- a/src/warnet/test_framework_bridge.py
+++ b/src/warnet/test_framework_bridge.py
@@ -20,8 +20,10 @@ from warnet.warnet import Warnet
 
 # Ensure that all RPC calls are made with brand new http connections
 def auth_proxy_request(self, method, path, postdata):
-    self._set_conn() # creates new http client connection
+    self._set_conn()  # creates new http client connection
     return self.oldrequest(method, path, postdata)
+
+
 AuthServiceProxy.oldrequest = AuthServiceProxy._request
 AuthServiceProxy._request = auth_proxy_request
 

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -1,5 +1,4 @@
 import functools
-import inspect
 import ipaddress
 import logging
 import os
@@ -346,23 +345,6 @@ def gen_config_dir(network: str) -> Path:
     config_dir = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.warnet"))
     config_dir = Path(config_dir) / "warnet" / network
     return config_dir
-
-
-def bubble_exception_str(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            func_name = inspect.currentframe().f_code.co_name
-            local_vars = inspect.currentframe().f_locals
-            # Filter out the 'self' variable from the local_vars
-            context_str = ", ".join(f"{k}={v}" for k, v in local_vars.items() if k != "self")
-            raise Exception(
-                f"Exception in function '{func_name}' with context ({context_str}): {str(e)}"
-            )
-
-    return wrapper
 
 
 def remove_version_prefix(version_str):

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -14,7 +14,7 @@ from typing import List, Optional
 
 from backends import ComposeBackend, KubernetesBackend
 from warnet.tank import Tank
-from warnet.utils import gen_config_dir, bubble_exception_str, version_cmp_ge
+from warnet.utils import gen_config_dir, version_cmp_ge
 
 logger = logging.getLogger("warnet")
 FO_CONF_NAME = "fork_observer_config.toml"
@@ -105,7 +105,6 @@ class Warnet:
         return repr
 
     @classmethod
-    @bubble_exception_str
     def from_graph_file(
         cls,
         base64_graph: str,
@@ -126,7 +125,6 @@ class Warnet:
         return self
 
     @classmethod
-    @bubble_exception_str
     def from_graph(cls, graph, backend="compose", network="warnet"):
         self = cls(Path(), backend, network)
         self.graph = graph
@@ -135,7 +133,6 @@ class Warnet:
         return self
 
     @classmethod
-    @bubble_exception_str
     def from_network(cls, network_name, backend="compose"):
         config_dir = gen_config_dir(network_name)
         self = cls(config_dir, backend, network_name)
@@ -148,11 +145,9 @@ class Warnet:
         return self
 
     @property
-    @bubble_exception_str
     def fork_observer_config(self):
         return self.config_dir / FO_CONF_NAME
 
-    @bubble_exception_str
     def tanks_from_graph(self):
         if not self.graph:
             return
@@ -164,12 +159,10 @@ class Warnet:
             self.tanks.append(Tank.from_graph_node(node_id, self))
         logger.info(f"Imported {len(self.tanks)} tanks from graph")
 
-    @bubble_exception_str
     def apply_network_conditions(self):
         for tank in self.tanks:
             tank.apply_network_conditions()
 
-    @bubble_exception_str
     def connect_edges(self):
         if self.graph is None:
             return
@@ -190,26 +183,21 @@ class Warnet:
                 logger.info(f"Using `{cmd}` to connect tanks {src} to {dst}")
             src_tank.exec(cmd=cmd, user="bitcoin")
 
-    @bubble_exception_str
     def warnet_build(self):
         self.container_interface.build()
 
-    @bubble_exception_str
     def get_ln_node_from_tank(self, index):
         return self.tanks[index].lnnode
 
-    @bubble_exception_str
     def warnet_up(self):
         self.container_interface.up(self)
 
-    @bubble_exception_str
     def warnet_down(self):
         self.container_interface.down(self)
 
     def generate_deployment(self):
         self.container_interface.generate_deployment_file(self)
 
-    @bubble_exception_str
     def write_fork_observer_config(self):
         shutil.copy(TEMPLATES / FO_CONF_NAME, self.fork_observer_config)
         with open(self.fork_observer_config, "a") as f:
@@ -228,7 +216,6 @@ class Warnet:
                 )
         logger.info(f"Wrote file: {self.fork_observer_config}")
 
-    @bubble_exception_str
     def export(self, subdir):
         if self.backend != "compose":
             raise NotImplementedError("Export is only supported for compose backend")


### PR DESCRIPTION
Use proper `ServerErrors` and things to neaten and homogenize the server interfaces.

Gets rid of most of the `try: except` stuff in all the cli modules. Allows us to raise custom JSONRPC exceptions using the native interface on the server side. Auto-handled on the CLI side (well, printed for now). Should generally make things more robust.

Fixes: #198