### PR TITLE
extra lint rules

### DIFF
--- a/api/auth/api_token.py
+++ b/api/auth/api_token.py
@@ -1,6 +1,7 @@
 import jwt
-from ..db import schemas
 from decouple import config
+
+from ..db import schemas
 
 JWT_SECRET = config("JWT_SECRET")
 

--- a/api/db/crud.py
+++ b/api/db/crud.py
@@ -1,6 +1,8 @@
+import uuid
+
 import bcrypt
 from sqlalchemy.orm import Session
-import uuid
+
 from ..auth import api_token
 from . import models, schemas
 

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -1,5 +1,6 @@
 import datetime
-from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, DateTime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from .database import Base

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,8 @@
 from fastapi import Depends, FastAPI, HTTPException
 from sqlalchemy.orm import Session
-from .db import crud, models, schemas, database
-from .validation import email
 
+from .db import crud, database, models, schemas
+from .validation import email
 
 models.Base.metadata.create_all(bind=database.engine)
 
@@ -17,8 +17,11 @@ def get_db():
         db.close()
 
 
+SESSION = Depends(get_db)
+
+
 @app.post("/users/", response_model=schemas.User)
-def create_user(user: schemas.UserLogin, db: Session = Depends(get_db)):
+def create_user(user: schemas.UserLogin, db: Session = SESSION):
     """
     Create a new user.
     """
@@ -33,7 +36,7 @@ def create_user(user: schemas.UserLogin, db: Session = Depends(get_db)):
 
 
 @app.get("/users/", response_model=list[schemas.User])
-def read_users(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+def read_users(skip: int = 0, limit: int = 100, db: Session = SESSION):
     """
     Retrieve users.
     """
@@ -42,7 +45,7 @@ def read_users(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
 
 
 @app.get("/users/{user_id}", response_model=schemas.User)
-def read_user(user_id: int, db: Session = Depends(get_db)):
+def read_user(user_id: int, db: Session = SESSION):
     """
     Get a specific user by id.
     """
@@ -53,9 +56,7 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/users/{user_id}/networks/", response_model=schemas.Network)
-def create_network_for_user(
-    user_id: int, network: schemas.NetworkCreate, db: Session = Depends(get_db)
-):
+def create_network_for_user(user_id: int, network: schemas.NetworkCreate, db: Session = SESSION):
     """
     Create a network for a specific user.
     """
@@ -63,7 +64,7 @@ def create_network_for_user(
 
 
 @app.get("/networks/", response_model=list[schemas.Network])
-def read_networks(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+def read_networks(skip: int = 0, limit: int = 100, db: Session = SESSION):
     """
     Retrieve networks.
     """

--- a/api/validation/email.py
+++ b/api/validation/email.py
@@ -1,7 +1,6 @@
 import email_validator
 from decouple import config
 
-
 email_validator.SPECIAL_USE_DOMAIN_NAMES.remove("test")
 email_validator.CHECK_DELIVERABILITY = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,19 @@ exclude = '''
 extend-exclude = ["src/test_framework/*.py"]
 line-length = 100
 indent-width = 4
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+ignore = ["E501"] # Line too long

--- a/scripts/apidocs.py
+++ b/scripts/apidocs.py
@@ -1,9 +1,10 @@
-import re
 import os
-from click import Context
-from warnet.cli.main import cli
-from tabulate import tabulate
+import re
 from pathlib import Path
+
+from click import Context
+from tabulate import tabulate
+from warnet.cli.main import cli
 
 doc = ""
 
@@ -38,7 +39,7 @@ with Context(cli) as ctx:
 
 file_path = Path(os.path.dirname(os.path.abspath(__file__))) / ".." / "docs" / "warcli.md"
 
-with open(file_path, "r") as file:
+with open(file_path) as file:
     text = file.read()
 
 pattern = r"(## API Commands\n)(.*\n)*?(# Next)"

--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
 from typing import List
 
 

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -2,33 +2,32 @@ import logging
 import re
 import shutil
 import subprocess
-import yaml
-
 from datetime import datetime
 from pathlib import Path
-from typing import cast, List, Tuple
-import docker
-from docker.models.containers import Container
+from typing import List, Tuple, cast
 
+import docker
+import yaml
 from backends import BackendInterface, ServiceType
+from docker.models.containers import Container
+from templates import TEMPLATES
+from warnet.lnnode import LNNode
+from warnet.status import RunningStatus
+from warnet.tank import Tank
+from warnet.utils import (
+    default_bitcoin_conf_args,
+    parse_raw_messages,
+    set_execute_permission,
+)
+
 from .services import SERVICES
 from .services.cadvisor import CAdvisor
 from .services.fork_observer import ForkObserver
 from .services.grafana import Grafana
-from .services.prometheus import Prometheus
-from .services.node_exporter import NodeExporter
 from .services.loki.loki import Loki
+from .services.node_exporter import NodeExporter
+from .services.prometheus import Prometheus
 from .services.promtail.promtail import Promtail
-from templates import TEMPLATES
-from warnet.tank import Tank
-from warnet.status import RunningStatus
-from warnet.lnnode import LNNode
-from warnet.utils import (
-    parse_raw_messages,
-    default_bitcoin_conf_args,
-    set_execute_permission,
-)
-
 
 DOCKER_COMPOSE_NAME = "docker-compose.yml"
 DOCKERFILE_NAME = "Dockerfile"
@@ -470,7 +469,7 @@ class ComposeBackend(BackendInterface):
         # Get tank names, versions and IP addresses from docker-compose
         docker_compose_path = warnet.config_dir / DOCKER_COMPOSE_NAME
         compose = None
-        with open(docker_compose_path, "r") as file:
+        with open(docker_compose_path) as file:
             compose = yaml.safe_load(file)
         for service_name in compose["services"]:
             tank = self.tank_from_deployment(compose["services"][service_name], warnet)

--- a/src/backends/compose/services/fluentd.py
+++ b/src/backends/compose/services/fluentd.py
@@ -1,5 +1,7 @@
 import shutil
+
 from templates import TEMPLATES
+
 from .base_service import BaseService
 
 FLUENT_CONF = "fluent.conf"

--- a/src/backends/compose/services/loki/loki.py
+++ b/src/backends/compose/services/loki/loki.py
@@ -1,6 +1,6 @@
-from ..base_service import BaseService
 from pathlib import Path
 
+from ..base_service import BaseService
 
 LOKI_CONF_DIR = Path(__file__).parent
 IMAGE = "grafana/loki:2.9.3"

--- a/src/backends/compose/services/promtail/promtail.py
+++ b/src/backends/compose/services/promtail/promtail.py
@@ -1,6 +1,6 @@
-from ..base_service import BaseService
 from pathlib import Path
 
+from ..base_service import BaseService
 
 PROMTAIL_CONF_DIR = Path(__file__).parent
 IMAGE = "grafana/promtail:2.9.3"

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -1,23 +1,19 @@
-from backends import BackendInterface, ServiceType
+import io
+import re
+import time
 from pathlib import Path
+from typing import List, cast
 
+import yaml
+from backends import BackendInterface, ServiceType
 from kubernetes import client, config
 from kubernetes.client.models.v1_pod import V1Pod
-from kubernetes.stream import stream
 from kubernetes.client.rest import ApiException
-
-
-import time
-import re
-import yaml
-import io
-
-from typing import cast, List
-
-from warnet.tank import Tank
+from kubernetes.stream import stream
 from warnet.lnnode import LNNode
 from warnet.status import RunningStatus
-from warnet.utils import parse_raw_messages, default_bitcoin_conf_args
+from warnet.tank import Tank
+from warnet.utils import default_bitcoin_conf_args, parse_raw_messages
 
 DOCKER_REGISTRY_CORE = "bitcoindevproject/k8s-bitcoin-core"
 DOCKER_REGISTRY_LND = "lightninglabs/lnd:v0.17.0-beta"
@@ -56,6 +52,7 @@ class KubernetesBackend(BackendInterface):
         for tank in warnet.tanks:
             pod_name = self.get_pod_name(tank.index)
             self.client.delete_namespaced_pod(pod_name, self.namespace)
+        return True
 
     def get_file(self, tank_index: int, service: ServiceType, file_path: str):
         """

--- a/src/scenarios/ln_init.py
+++ b/src/scenarios/ln_init.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import json
 from time import sleep
-from warnet.test_framework_bridge import WarnetTestFramework
+
 from scenarios.utils import ensure_miner
+from warnet.test_framework_bridge import WarnetTestFramework
 
 
 def cli_help():

--- a/src/scenarios/miner_std.py
+++ b/src/scenarios/miner_std.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 from time import sleep
-from warnet.test_framework_bridge import WarnetTestFramework
+
 from scenarios.utils import ensure_miner
+from warnet.test_framework_bridge import WarnetTestFramework
 
 
 def cli_help():

--- a/src/scenarios/sens_relay.py
+++ b/src/scenarios/sens_relay.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from warnet.test_framework_bridge import WarnetTestFramework
 from scenarios.utils import ensure_miner
+from warnet.test_framework_bridge import WarnetTestFramework
 
 
 def cli_help():

--- a/src/scenarios/tx_flood.py
+++ b/src/scenarios/tx_flood.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-from warnet.test_framework_bridge import WarnetTestFramework
 from scenarios.utils import ensure_miner
+from warnet.test_framework_bridge import WarnetTestFramework
 
 BLOCKS = 100
 TXS = 100

--- a/src/warnet/cli/debug.py
+++ b/src/warnet/cli/debug.py
@@ -1,6 +1,5 @@
 import click
 from rich import print
-
 from warnet.cli.rpc import rpc_call
 
 

--- a/src/warnet/cli/graph.py
+++ b/src/warnet/cli/graph.py
@@ -3,7 +3,6 @@ from typing import List
 
 import click
 from rich import print
-
 from warnet.cli.rpc import rpc_call
 from warnet.utils import DEFAULT_TAG
 

--- a/src/warnet/cli/main.py
+++ b/src/warnet/cli/main.py
@@ -1,7 +1,6 @@
 import click
 from requests.exceptions import ConnectionError
 from rich import print as richprint
-
 from warnet.cli.debug import debug
 from warnet.cli.graph import graph
 from warnet.cli.network import network

--- a/src/warnet/cli/network.py
+++ b/src/warnet/cli/network.py
@@ -1,4 +1,4 @@
-import base64
+import base64  # noqa: I001
 from pathlib import Path
 from typing import List
 
@@ -6,10 +6,9 @@ import click
 from rich import print
 from rich.console import Console
 from rich.table import Table
+from warnet.cli.rpc import rpc_call  # noqa: I001
 
-from graphs import GRAPHS
-from warnet.cli.rpc import rpc_call
-
+from graphs import GRAPHS  # noqa: I001
 
 DEFAULT_GRAPH_FILE = GRAPHS / "default.graphml"
 

--- a/src/warnet/cli/rpc.py
+++ b/src/warnet/cli/rpc.py
@@ -1,8 +1,9 @@
-import requests
 import sys
-from jsonrpcclient.responses import Error, Ok, parse
+from typing import Any, Dict, Optional, Tuple, Union
+
+import requests
 from jsonrpcclient.requests import request
-from typing import Any, Dict, Tuple, Union, Optional
+from jsonrpcclient.responses import Error, Ok, parse
 from warnet.server import WARNET_SERVER_PORT
 
 

--- a/src/warnet/cli/scenarios.py
+++ b/src/warnet/cli/scenarios.py
@@ -1,10 +1,9 @@
-import click
 from typing import List
+
+import click
 from rich import print
 from rich.console import Console
 from rich.table import Table
-
-
 from warnet.cli.rpc import rpc_call
 
 
@@ -58,7 +57,7 @@ def active():
     assert isinstance(result, List), "Result is not a list"  # Make mypy happy again
 
     table = Table(show_header=True, header_style="bold")
-    for key in result[0].keys():
+    for key in result[0].keys():  # noqa: SIM118
         table.add_column(key.capitalize())
 
     for scenario in result:

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -1,9 +1,11 @@
 import json
 import os
-from warnet.utils import exponential_backoff, generate_ipv4_addr
-from backends import BackendInterface, ServiceType
-from .status import RunningStatus
 from typing import List
+
+from backends import BackendInterface, ServiceType
+from warnet.utils import exponential_backoff, generate_ipv4_addr
+
+from .status import RunningStatus
 
 
 class LNNode:

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -3,18 +3,18 @@ Tanks are containerized bitcoind nodes
 """
 
 import logging
-
 from pathlib import Path
+
+from backends import ServiceType
 from warnet.lnnode import LNNode
 from warnet.utils import (
+    SUPPORTED_TAGS,
     exponential_backoff,
     generate_ipv4_addr,
     sanitize_tc_netem_command,
-    SUPPORTED_TAGS,
 )
-from backends import ServiceType
-from .status import RunningStatus
 
+from .status import RunningStatus
 
 CONTAINER_PREFIX_PROMETHEUS = "prometheus_exporter"
 
@@ -73,11 +73,10 @@ class Tank:
         node = warnet.graph.nodes[index]
         version = node.get("version")
         if version:
-            if not ("/" in version and "#" in version):
-                if version not in SUPPORTED_TAGS:
-                    raise Exception(
-                        f"Unsupported version: can't be generated from Docker images: {version}"
-                    )
+            if not ("/" in version and "#" in version) and version not in SUPPORTED_TAGS:
+                raise Exception(
+                    f"Unsupported version: can't be generated from Docker images: {version}"
+                )
             self.version = version
         self.conf = node.get("bitcoin_config", self.conf)
         self.netem = node.get("tc_netem", self.netem)

--- a/src/warnet/test_framework_bridge.py
+++ b/src/warnet/test_framework_bridge.py
@@ -6,15 +6,16 @@ import random
 import signal
 import sys
 import tempfile
+
 from test_framework.authproxy import AuthServiceProxy
 from test_framework.p2p import NetworkThread
 from test_framework.test_framework import (
-    BitcoinTestFramework,
     TMPDIR_PREFIX,
+    BitcoinTestFramework,
     TestStatus,
 )
 from test_framework.test_node import TestNode
-from test_framework.util import get_rpc_proxy, PortSeed
+from test_framework.util import PortSeed, get_rpc_proxy
 from warnet.warnet import Warnet
 
 
@@ -121,10 +122,10 @@ class WarnetTestFramework(BitcoinTestFramework):
         if seed is None:
             seed = random.randrange(sys.maxsize)
         else:
-            self.log.info("User supplied random seed {}".format(seed))
+            self.log.info(f"User supplied random seed {seed}")
 
         random.seed(seed)
-        self.log.info("PRNG seed is: {}".format(seed))
+        self.log.info(f"PRNG seed is: {seed}")
 
         self.log.debug("Setting up network thread")
         self.network_thread = NetworkThread()
@@ -277,7 +278,8 @@ class WarnetTestFramework(BitcoinTestFramework):
         self.options.previous_releases_path = previous_releases_path
         config = configparser.ConfigParser()
         if self.options.configfile is not None:
-            config.read_file(open(self.options.configfile))
+            with open(self.options.configfile) as f:
+                config.read_file(f)
 
         config["environment"] = {"PACKAGE_BUGREPORT": ""}
 

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -13,10 +13,8 @@ from pathlib import Path
 from typing import List, Optional
 
 import networkx as nx
-
-from test_framework.p2p import MESSAGEMAP
 from test_framework.messages import ser_uint256
-
+from test_framework.p2p import MESSAGEMAP
 
 logger = logging.getLogger("utils")
 
@@ -394,7 +392,7 @@ def default_bitcoin_conf_args() -> str:
 
     conf_args = []
 
-    for section, kvs in defaults.items():
+    for kvs in defaults.values():
         # Skip section names, just focus on key-value pairs
         for key, value in kvs:
             conf_args.append(f"-{key}={value}")
@@ -454,7 +452,7 @@ def create_graph_with_probability(
     if bitcoin_conf is not None:
         conf = Path(bitcoin_conf)
         if conf.is_file():
-            with open(conf, "r") as f:
+            with open(conf) as f:
                 # parse INI style conf then dump using for_graph
                 conf_dict = parse_bitcoin_conf(f.read())
                 conf_contents = dump_bitcoin_conf(conf_dict, for_graph=True)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -5,14 +5,14 @@
 import base64
 import json
 import logging
-import networkx
 import os
 import shutil
 from pathlib import Path
-from templates import TEMPLATES
 from typing import List, Optional
 
+import networkx
 from backends import ComposeBackend, KubernetesBackend
+from templates import TEMPLATES
 from warnet.tank import Tank
 from warnet.utils import gen_config_dir, version_cmp_ge
 

--- a/test/build_branch_test.py
+++ b/test/build_branch_test.py
@@ -2,8 +2,9 @@
 
 import json
 import os
-from test_base import TestBase
 from pathlib import Path
+
+from test_base import TestBase
 
 graph_file_path = Path(os.path.dirname(__file__)) / "data" / "build_v24_test.graphml"
 

--- a/test/ln_test.py
+++ b/test/ln_test.py
@@ -2,9 +2,10 @@
 
 import json
 import os
-from time import sleep
-from test_base import TestBase
 from pathlib import Path
+from time import sleep
+
+from test_base import TestBase
 
 graph_file_path = Path(os.path.dirname(__file__)) / "data" / "ln.graphml"
 
@@ -19,7 +20,7 @@ if base.backend != "compose":
 else:
     print("\nTesting warcli network export")
     path = Path(base.warcli("network export")) / "sim.json"
-    with open(path, "r") as file:
+    with open(path) as file:
         data = json.load(file)
         print(json.dumps(data, indent=4))
         assert len(data["nodes"]) == 3
@@ -44,10 +45,9 @@ print(base.warcli(f"lncli 0 payinvoice -f {inv}"))
 print("Waiting for payment success")
 while True:
     invs = json.loads(base.warcli("lncli 2 listinvoices"))["invoices"]
-    if len(invs) > 0:
-        if invs[0]["state"] == "SETTLED":
-            print("\nSettled!")
-            break
+    if len(invs) > 0 and invs[0]["state"] == "SETTLED":
+        print("\nSettled!")
+        break
     sleep(2)
 
 base.stop_server()

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import os
-from test_base import TestBase
 from pathlib import Path
+
+from test_base import TestBase
 
 graph_file_path = Path(os.path.dirname(__file__)) / "data" / "v25_x_12.graphml"
 

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import os
-from test_base import TestBase
 from pathlib import Path
+
+from test_base import TestBase
 
 graph_file_path = Path(os.path.dirname(__file__)) / "data" / "v25_x_12.graphml"
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -2,6 +2,7 @@
 import tempfile
 import uuid
 from pathlib import Path
+
 from test_base import TestBase
 from warnet.utils import DEFAULT_TAG
 

--- a/test/v25_net_test.py
+++ b/test/v25_net_test.py
@@ -2,8 +2,9 @@
 
 import json
 import os
-from test_base import TestBase
 from pathlib import Path
+
+from test_base import TestBase
 
 graph_file_path = Path(os.path.dirname(__file__)) / "data" / "v25_x_12.graphml"
 
@@ -20,13 +21,11 @@ def wait_for_reachability():
         global onion_addr
         info = json.loads(base.warcli("rpc 0 getnetworkinfo"))
         for net in info["networks"]:
-            if net["name"] == "ipv4":
-                if not net["reachable"]:
-                    return False
-            if net["name"] == "onion":
-                if not net["reachable"]:
-                    return False
-        if not len(info["localaddresses"]) == 2:
+            if net["name"] == "ipv4" and not net["reachable"]:
+                return False
+            if net["name"] == "onion" and not net["reachable"]:
+                return False
+        if len(info["localaddresses"]) != 2:
             return False
         for addr in info["localaddresses"]:
             assert "100." in addr["address"] or ".onion" in addr["address"]


### PR DESCRIPTION
This turns on a few more `ruff` linting rules to help further standardise the codebase and ensure best practice.

It adds the following config to pyproject.toml:

```toml
[tool.ruff.lint]
select = [
    # pycodestyle
    "E",
    # Pyflakes
    "F",
    # pyupgrade
    "UP",
    # flake8-bugbear
    "B",
    # flake8-simplify
    "SIM",
    # isort
    "I",
]
ignore = ["E501"] # Line too long
```

These should be automatically detected and used by your ruff linter (if setup correctly).
