### PR TITLE
Support custom images on kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https://raw.githubusercontent.com/bitcoin-dev-project/warnet/main/pyproject.toml)
 # Warnet
 
 Monitor and analyze the emergent behaviors of Bitcoin networks.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -1,0 +1,23 @@
+# Developer notes
+
+## Kubernetes
+
+Kubernetes is running the RPC server as a `statefulSet` which is pulled from a
+container image on a registry. This means that (local) changes to the RPC
+server are **not** reflected on the RPC server when running in Kubernetes,
+unless you **also** push an updated image to a registry and update the
+Kubernetes config files.
+
+To help with this a helper script is provided: [build-k8s-rpc.sh](../scripts/build-k8s-rpc.sh).
+
+This script can be run in the following way:
+
+```bash
+DOCKER_REGISTRY=bitcoindevproject/warnet-rpc TAG=0.1 ./scripts/build-k8s-rpc.sh Dockerfile_rpc
+```
+> [!important]
+> The `TAG` used **must** match the `SERVER_VERSION` found in [server.py](src/warnet/server.py]
+
+The versioning/tagging is so that the CLI will call the correct URL on the RPC server, and breaking changes will be obvious to the user as no RPCs will be found at the called URL.
+
+Once a new image has been pushed, it should be referenced in [warnet-rpc-statefulset.yaml](../src/templates/warnet-rpc-statefulset.yaml) in the `image` field.

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -49,6 +49,9 @@ warcli network start <path/to/file.graphml> --network="network_name"
 
 Nodes can be added to the graph as follows:
 
+
+#### Release binaries
+
 ```graphml
 <node id="0">
 <data key="x">5.5</data>
@@ -58,8 +61,24 @@ Nodes can be added to the graph as follows:
 <data key="tc_netem"></data>
 </node>
 ```
+#### Pre-built custom image
 
-Or for a custom built branch with traffic shaping rules applied:
+For a pre-built custom image, remove the `version` tag, and add the image repository to an `image` tag.
+These should be built using the `warcli image build` command to ensure they have the needed patches.
+
+```graphml
+<node id="0">
+<data key="x">5.5</data>
+<data key="y">2.5</data>
+<data key="image">bitcoindevproject/bitcoin-core:26.0</data>
+<data key="bitcoin_config">uacomment=warnet0_v24,debugexclude=libevent</data>
+<data key="tc_netem"></data>
+</node>
+```
+
+#### On-demand built branch
+
+For an on-demand built branch with traffic shaping rules applied using `tc_netem`:
 
 ```graphml
 <node id="0">
@@ -71,7 +90,7 @@ Or for a custom built branch with traffic shaping rules applied:
 </node>
 ```
 
-`x`, `y`, `version`, `bitcoin_config` and `tc_netem` datafields are optional for all nodes.
+`x`, `y`, `version`, `bitcoin_config` and `tc_netem` data fields are optional for all nodes.
 
 ### Edges
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,8 +1,8 @@
 # Running Warnet
 
-Warnet runs a server which can be used to manage multiple networks.
-On docker this runs locally, but on Kubernetes this runs as a statefulset in
-the cluster.
+Warnet runs a server which can be used to manage multiple networks. On docker
+this runs locally, but on Kubernetes this runs as a `statefulSet` in the
+cluster.
 
 If the `$XDG_STATE_HOME` environment variable is set, the server will log to
 a file `$XDG_STATE_HOME/warnet/warnet.log`, otherwise it will use `$HOME/.warnet/warnet.log`.
@@ -24,7 +24,9 @@ This can be done with:
 kubectl port-forward svc/rpc 9276:9276
 ```
 
-This allows you to communicate with the RPC server using `warcli`.
+This allows you to communicate with the RPC server using `warcli`. Developers
+should check the [developer notes](developer-notes.md) to see how to
+update the RPC server when developing on Kubernetes.
 
 Currently, while `warcli network down` will bring down the pods, the RPC server needs manual deletion.
 This can be done using:

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -10,7 +10,7 @@ See [`src/scenarios`](../src/scenarios) for examples of how these can be written
 To see available scenarios (loaded from the default directory):
 
 ```bash
-warcli scenarios list
+warcli scenarios available
 ```
 
 Once a scenarios is selected it can be run with `warcli scenarios run [--network=warnet] <scenario_name> [scenario_params]`, e.g.:
@@ -25,7 +25,7 @@ This will run the run the scenario in the background until it exits or is stoppe
 Active scenarios can be listed and terminated by PID:
 
 ```bash
-$ warcli scenarios list
+$ warcli scenarios active
 miner_std           Generate blocks over time. Options: [--allnodes | --interval=<number>]
 sens_relay          Send a transaction using sensitive relay
 tx_flood            Generate 100 blocks with 100 TXs each

--- a/docs/warcli.md
+++ b/docs/warcli.md
@@ -39,10 +39,10 @@ Display help information for the given command.
     If no command is given, display help for the main CLI.
 
 options:
-| name    | type   | required   | default   |
-|---------|--------|------------|-----------|
-| command | String | False      |           |
-| help    | Bool   | False      | False     |
+| name     | type   | required   | default   |
+|----------|--------|------------|-----------|
+| commands | String | False      |           |
+| help     | Bool   | False      | False     |
 
 ### `warcli lncli`
 Call lightning cli \<command> on \<node> in \<--network>
@@ -197,7 +197,7 @@ options:
 |--------|--------|------------|-----------|
 | help   | Bool   | False      | False     |
 
-### `warcli scenarios list`
+### `warcli scenarios available`
 List available scenarios in the Warnet Test Framework
 
 options:

--- a/docs/warcli.md
+++ b/docs/warcli.md
@@ -44,6 +44,17 @@ options:
 | command | String | False      |           |
 | help    | Bool   | False      | False     |
 
+### `warcli lncli`
+Call lightning cli \<command> on \<node> in \<--network>
+
+options:
+| name    | type   | required   | default   |
+|---------|--------|------------|-----------|
+| node    | Int    | True       |           |
+| command | String | True       |           |
+| network | String | False      | warnet    |
+| help    | Bool   | False      | False     |
+
 ### `warcli messages`
 Fetch messages sent between \<node_a> and \<node_b> in \<network>
 
@@ -97,15 +108,31 @@ options:
 |--------------|--------|------------|-----------|
 | params       | String | False      |           |
 | outfile      | Func   | False      |           |
-| version      | String | False      |      25.1 |
+| version      | String | False      |        26 |
 | bitcoin_conf | Func   | False      |           |
-| random       | Bool   | False      |       0   |
-| help         | Bool   | False      |       0   |
+| random       | Bool   | False      |         0 |
+| help         | Bool   | False      |         0 |
+
+## Image
+
+### `warcli image build`
+Build bitcoind and bitcoin-cli from \<repo>/\<branch> and deploy to \<registry>
+    This requires docker and buildkit to be enabled.
+
+options:
+| name       | type   | required   | default   |
+|------------|--------|------------|-----------|
+| registry   | String | True       |           |
+| repo       | String | True       |           |
+| branch     | String | True       |           |
+| build_args | String | False      |           |
+| arches     | String | False      |           |
+| help       | Bool   | False      | False     |
 
 ## Network
 
 ### `warcli network down`
-Run 'docker compose down on a warnet named \<--network> (default: "warnet").
+Bring down a running warnet named \<--network> (default: "warnet").
 
 options:
 | name    | type   | required   | default   |
@@ -152,7 +179,7 @@ options:
 | help    | Bool   | False      | False     |
 
 ### `warcli network up`
-Run 'docker compose up' on a warnet named \<--network> (default: "warnet").
+Bring up a previously-stopped warnet named \<--network> (default: "warnet").
 
 options:
 | name    | type   | required   | default   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "warnet"
 description = "Monitor and analyze the emergent behaviours of bitcoin networks"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 keywords = ["bitcoin", "warnet"]
 license = {text = "MIT"}
 classifiers = [
@@ -32,27 +32,6 @@ dynamic = ["version"]
 [project.scripts]
 warnet = "warnet.server:run_server"
 warcli = "warnet.cli.main:cli"
-
-[tool.black]
-line-length = 100
-target-version = ['py37']
-exclude = '''
-(
-  /(
-      \.git
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-    | api
-    | src/test_framework
-  )/
-  | src/warnet/test_framework_bridge\.py
-)
-'''
 
 [tool.ruff]
 extend-exclude = ["src/test_framework/*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "networkx==3.1",
     "numpy==1.26.0",
     "rich==13.5.2",
+    "tabulate==0.9.0",
     "PyYAML==6.0.1",
 ]
 dynamic = ["version"]

--- a/scripts/build-k8s-rpc.sh
+++ b/scripts/build-k8s-rpc.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Run with e.g.:
+# $ DOCKER_REGISTRY=bitcoindevproject/warnet-rpc TAG=0.1 ./scripts/build-k8s-rpc.sh Dockerfile_rpc
+
 # Fail on any step
 set -ex
 
@@ -8,9 +11,11 @@ docker buildx create --use
 
 # Read DOCKER_REGISTRY from the environment
 : "${DOCKER_REGISTRY?Need to set DOCKER_REGISTRY}"
+: "${TAG?Need to set TAG}"
 
 # Architectures for building
-ARCHS=("amd64" "arm64" "armhf")
+ARCHS=("amd64")
+# ARCHS=("amd64" "arm64" "armhf")
 
 # Read Dockerfile from the first argument
 DOCKERFILE_PATH=$1
@@ -22,14 +27,14 @@ fi
 # Loop through each architecture to build and push
 IMAGES_LIST=()  # Array to store images for manifest
 for DOCKER_ARCH in "${ARCHS[@]}"; do
-    IMAGE_TAG="$DOCKER_ARCH"
-    IMAGE_FULL_NAME="$DOCKER_REGISTRY:$IMAGE_TAG"
+    IMAGE_FULL_NAME="$DOCKER_REGISTRY:$TAG"
   
     # Use Buildx to build the image for the specified architecture
     docker buildx build --platform linux/"$DOCKER_ARCH" \
         --file "$DOCKERFILE_PATH" \
+        --progress=plain \
         --tag "$IMAGE_FULL_NAME" \
-        src/templates --push  # set build context to src/templates
+        . --push  # set build context to src/templates
 
     IMAGES_LIST+=("$IMAGE_FULL_NAME")
 done

--- a/scripts/build-k8s-rpc.sh
+++ b/scripts/build-k8s-rpc.sh
@@ -7,15 +7,15 @@
 set -ex
 
 # Create a new builder to enable building multi-platform images
-docker buildx create --use
+BUILDER_NAME="warnet-rpc-builder"
+docker buildx create --name "$BUILDER_NAME" --use
 
 # Read DOCKER_REGISTRY from the environment
 : "${DOCKER_REGISTRY?Need to set DOCKER_REGISTRY}"
 : "${TAG?Need to set TAG}"
 
 # Architectures for building
-ARCHS=("amd64")
-# ARCHS=("amd64" "arm64" "armhf")
+ARCHS="linux/amd64,linux/arm64"
 
 # Read Dockerfile from the first argument
 DOCKERFILE_PATH=$1
@@ -25,21 +25,11 @@ if [[ ! -f "$DOCKERFILE_PATH" ]]; then
 fi
 
 # Loop through each architecture to build and push
-IMAGES_LIST=()  # Array to store images for manifest
-for DOCKER_ARCH in "${ARCHS[@]}"; do
-    IMAGE_FULL_NAME="$DOCKER_REGISTRY:$TAG"
-  
-    # Use Buildx to build the image for the specified architecture
-    docker buildx build --platform linux/"$DOCKER_ARCH" \
-        --file "$DOCKERFILE_PATH" \
-        --progress=plain \
-        --tag "$IMAGE_FULL_NAME" \
-        . --push  # set build context to src/templates
+IMAGE_FULL_NAME="$DOCKER_REGISTRY:$TAG"
 
-    IMAGES_LIST+=("$IMAGE_FULL_NAME")
-done
-
-# Create the manifest list under the same repository
-MANIFEST_TAG="$DOCKER_REGISTRY:latest"
-docker buildx imagetools create --tag "$MANIFEST_TAG" "${IMAGES_LIST[@]}"
-
+# Use Buildx to build the image for the specified architecture
+docker buildx build --platform "$ARCHS" \
+    --file "$DOCKERFILE_PATH" \
+    --progress=plain \
+    --tag "$IMAGE_FULL_NAME" \
+    . --push

--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import List
 
 
 class ServiceType(Enum):
@@ -60,7 +59,7 @@ class BackendInterface(ABC):
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
-    def ln_cli(self, tank, command: List[str]) -> str:
+    def ln_cli(self, tank, command: list[str]) -> str:
         """
         Call `lightning cli` on tank [tank_index] with <command>
         """

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple, cast
+from typing import cast
 
 import docker
 import yaml
@@ -157,7 +157,7 @@ class ComposeBackend(BackendInterface):
         )
         return cast(bytes, logs).decode("utf8")  # cast for typechecker
 
-    def ln_cli(self, tank: Tank, command: List[str]):
+    def ln_cli(self, tank: Tank, command: list[str]):
         if tank.lnnode is None:
             raise Exception("No LN node configured for tank")
         cmd = tank.lnnode.generate_cli_command(command)
@@ -205,7 +205,7 @@ class ComposeBackend(BackendInterface):
         messages.sort(key=lambda x: x["time"])
         return messages
 
-    def get_containers_in_network(self, network: str) -> List[str]:
+    def get_containers_in_network(self, network: str) -> list[str]:
         # Return list of container names in the specified network
         containers = []
         for container in self.client.containers.list(filters={"network": network}):
@@ -217,7 +217,7 @@ class ComposeBackend(BackendInterface):
         compiled_pattern = re.compile(pattern)
         containers = self.get_containers_in_network(network)
 
-        all_matching_logs: List[Tuple[str, str]] = []
+        all_matching_logs: list[tuple[str, str]] = []
 
         for container_name in containers:
             logger.debug(f"Fetching logs from {container_name}")

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -352,7 +352,7 @@ class ComposeBackend(BackendInterface):
         services[container_name] = {}
         logger.debug(f"{tank.version=}")
 
-        # Setup bitcoind, either release binary or build from source
+        # Setup bitcoind, either release binary, pre-built image or built from source on demand
         if "/" and "#" in tank.version:
             # it's a git branch, building step is necessary
             repo, branch = tank.version.split("#")
@@ -367,7 +367,12 @@ class ComposeBackend(BackendInterface):
             }
             services[container_name]["build"] = build
             self.copy_configs(tank)
+        elif tank.is_custom_build and tank.image:
+            # Pre-built custom image
+            image = tank.image
+            services[container_name]["image"] = image
         else:
+            # Pre-built regular release
             image = f"{DOCKER_REGISTRY}:{tank.version}"
             services[container_name]["image"] = image
         # Add common bitcoind service details

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -292,7 +292,7 @@ class KubernetesBackend(BackendInterface):
         # Create and return a Pod object
         # TODO: pass a custom namespace , e.g. different warnet sims can be deployed into diff namespaces
         container_name = BITCOIN_CONTAINER_NAME
-        container_image = tank.version if tank.is_custom_build else f"{DOCKER_REGISTRY_CORE}:{tank.version}"
+        container_image = tank.image if tank.is_custom_build else f"{DOCKER_REGISTRY_CORE}:{tank.version}"
         container_env = [client.V1EnvVar(name="BITCOIN_ARGS", value=self.default_config_args(tank))]
 
         # TODO: support custom builds

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -292,7 +292,9 @@ class KubernetesBackend(BackendInterface):
         # Create and return a Pod object
         # TODO: pass a custom namespace , e.g. different warnet sims can be deployed into diff namespaces
         container_name = BITCOIN_CONTAINER_NAME
-        container_image = tank.image if tank.is_custom_build else f"{DOCKER_REGISTRY_CORE}:{tank.version}"
+        container_image = (
+            tank.image if tank.is_custom_build else f"{DOCKER_REGISTRY_CORE}:{tank.version}"
+        )
         container_env = [client.V1EnvVar(name="BITCOIN_ARGS", value=self.default_config_args(tank))]
 
         # TODO: support custom builds

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -388,14 +388,15 @@ class KubernetesBackend(BackendInterface):
         for tank in warnet.tanks:
             pod_ip = None
             while not pod_ip:
-                response = self.get_pod(tank.container_name)
-                pod_ip = response.status.pod_ip
+                pod_name = self.get_pod_name(tank.index)
+                pod = self.get_pod(pod_name)
+                pod_ip = pod.status.pod_ip
                 if not pod_ip:
                     print("Waiting for pod IP...")
                     time.sleep(3)  # sleep for 5 seconds
 
             tank._ipv4 = pod_ip
-            print(f"Tank {tank.container_name} created")
+            print(f"Tank {tank.index} created")
 
         with open(warnet.config_dir / "warnet-tanks.yaml", "w") as f:
             for pod in tank_resource_files:

--- a/src/graphs/default.graphml
+++ b/src/graphs/default.graphml
@@ -5,6 +5,7 @@
   <key attr.name="build_args" attr.type="string" for="node" id="build_args"/>
   <key attr.name="exporter" attr.type="boolean" for="node" id="exporter"/>
   <key attr.name="collect_logs" attr.type="boolean" for="node" id="collect_logs"/>
+  <key attr.name="image" attr.type="string" for="node" id="image"/>
   <graph edgedefault="directed">
     <node id="0">
         <data key="version">26.0</data>
@@ -19,7 +20,7 @@
         <data key="collect_logs">true</data>
     </node>
     <node id="2">
-        <data key="version">26.0</data>
+        <data key="image">bitcoindevproject/bitcoin-core:26.0</data>
         <data key="bitcoin_config">-uacomment=w2</data>
         <data key="exporter">true</data>
         <data key="collect_logs">true</data>

--- a/src/templates/Dockerfile_k8
+++ b/src/templates/Dockerfile_k8
@@ -1,7 +1,6 @@
 FROM debian:bookworm-slim as builder
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG ARCH
 ARG REPO
 ARG BRANCH
 ARG BUILD_ARGS
@@ -21,7 +20,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libminiupnpc-dev \
         libnatpmp-dev \
         libzmq3-dev \
-        libqrencode-dev \
         libsqlite3-dev \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*  # Clean up to reduce image size
@@ -46,7 +44,6 @@ FROM debian:bookworm-slim
 
 ARG UID=3338
 ARG GID=3338
-ARG REPO
 ARG TOR=0
 ARG WARNET=0
 ARG BITCOIN_ARGS
@@ -67,7 +64,13 @@ RUN set -ex \
         gosu \
         iproute2 \
         tor \
-        $(if [ -n "${REPO}" ]; then echo "libboost-dev libevent-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev"; fi) \
+        libboost-dev \
+        libevent-dev \
+        libdb5.3++-dev \
+        libminiupnpc-dev \
+        libnatpmp-dev \
+        libzmq3-dev \
+        libsqlite3-dev \
     && apt-get clean \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
@@ -80,5 +83,5 @@ VOLUME ["/home/bitcoin/.bitcoin"]
 EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
 
 ENTRYPOINT ["/entrypoint.sh"]
-RUN bitcoind -version | grep -E "Bitcoin Core( Daemon)? version ${BRANCH}"
+CMD echo bitcoind -version
 CMD ["bitcoind"]

--- a/src/templates/warnet-rpc-statefulset.yaml
+++ b/src/templates/warnet-rpc-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: warnet-rpc
         imagePullPolicy: Always
-        image: bitcoindevproject/warnet-rpc
+        image: bitcoindevproject/warnet-rpc:0.1
         ports:
         - containerPort: 9276
 

--- a/src/utils/image_build.py
+++ b/src/utils/image_build.py
@@ -1,0 +1,89 @@
+import os
+import subprocess
+
+ARCHES = ["amd64", "arm64", "armhf"]
+
+
+def run_command(command):
+    try:
+        subprocess.run(command, shell=True, check=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def build_and_upload_images(
+    repo: str,
+    branch: str,
+    docker_registry: str,
+    tag: str,
+    build_args: str,
+    arches: str,
+):
+    if not build_args:
+        build_args = (
+            '"--disable-tests --with-incompatible-bdb --without-gui --disable-bench '
+            "--disable-fuzz-binary --enable-suppress-external-warnings "
+            '--without-miniupnpc --without-natpmp"'
+        )
+    else:
+        build_args = f'"{build_args}"'
+
+    build_arches = []
+    if not arches:
+        build_arches.append("amd64")
+    else:
+        build_arches.extend(arches.split(","))
+
+    for arch in build_arches:
+        if arch not in ARCHES:
+            print(f"Error: {arch} is not a valid architecture")
+            return False
+
+    print(f"{repo=:}")
+    print(f"{branch=:}")
+    print(f"{docker_registry=:}")
+    print(f"{tag=:}")
+    print(f"{build_args=:}")
+    print(f"{build_arches=:}")
+
+    if not os.path.isdir("src/templates"):
+        print("Directory src/templates does not exist.")
+        print("Please run this script from the project root.")
+        return False
+    os.chdir("src/templates")
+
+    # Setup buildkit
+    builder_name = "warnet-builder"
+    if not run_command(f"docker buildx create --name {builder_name} --use"):
+        return False
+
+    image_full_name = f"{docker_registry}:{tag}"
+    print(f"Image full name: {image_full_name}")
+
+    platforms = ','.join([f"linux/{arch}" for arch in build_arches])
+
+    build_command = (
+        f"docker buildx build"
+        f" --platform {platforms}"
+        f" --provenance=false"
+        f" --build-arg REPO={repo}"
+        f" --build-arg BRANCH={branch}"
+        f" --build-arg BUILD_ARGS={build_args}"
+        f" --tag {image_full_name}"
+        f" --file Dockerfile_k8 ."
+        f" --push"
+    )
+    print(f"{build_command=:}")
+
+    if not run_command(build_command):
+        return False
+
+    # Tidy up the buildx builder
+    cleanup_command = f"docker buildx rm {builder_name}"
+    if not run_command(cleanup_command):
+        print("Warning: Failed to remove the buildx builder.")
+    else:
+        print("Buildx builder removed successfully.")
+
+    return True

--- a/src/warnet/cli/graph.py
+++ b/src/warnet/cli/graph.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 import click
 from rich import print
@@ -19,7 +18,7 @@ def graph():
 @click.option("--bitcoin_conf", type=Path)
 @click.option("--random", is_flag=True)
 def create(
-    params: List[str], outfile: Path, version: str, bitcoin_conf: Path, random: bool = False
+    params: list[str], outfile: Path, version: str, bitcoin_conf: Path, random: bool = False
 ):
     """
     Create a graph file of type random AS graph with [params]

--- a/src/warnet/cli/image.py
+++ b/src/warnet/cli/image.py
@@ -1,0 +1,26 @@
+import sys
+
+import click
+from utils.image_build import build_and_upload_images
+
+
+@click.group(name="image")
+def image():
+    """Compile and deploy a custom version of bitcoin core to a docker image registry"""
+
+
+@image.command()
+@click.option("--repo", required=True, type=str)
+@click.option("--branch", required=True, type=str)
+@click.option("--registry", required=True, type=str)
+@click.option("--tag", required=True, type=str)
+@click.option("--build-args", required=False, type=str)
+@click.option("--arches", required=False, type=str)
+def build(repo, branch, registry, tag, build_args, arches):
+    """
+    Build bitcoind and bitcoin-cli from <repo>/<branch> and deploy to <registry> as <tag>
+    This requires docker and buildkit to be enabled.
+    """
+    res = build_and_upload_images(repo, branch, registry, tag, build_args, arches)
+    if not res:
+        sys.exit(1)

--- a/src/warnet/cli/main.py
+++ b/src/warnet/cli/main.py
@@ -2,8 +2,8 @@ import click
 from requests.exceptions import ConnectionError
 from rich import print as richprint
 from warnet.cli.debug import debug
-from warnet.cli.image import image
 from warnet.cli.graph import graph
+from warnet.cli.image import image
 from warnet.cli.network import network
 from warnet.cli.rpc import rpc_call
 from warnet.cli.scenarios import scenarios

--- a/src/warnet/cli/main.py
+++ b/src/warnet/cli/main.py
@@ -2,6 +2,7 @@ import click
 from requests.exceptions import ConnectionError
 from rich import print as richprint
 from warnet.cli.debug import debug
+from warnet.cli.image import image
 from warnet.cli.graph import graph
 from warnet.cli.network import network
 from warnet.cli.rpc import rpc_call
@@ -15,8 +16,9 @@ def cli():
 
 cli.add_command(debug)
 cli.add_command(graph)
-cli.add_command(scenarios)
+cli.add_command(image)
 cli.add_command(network)
+cli.add_command(scenarios)
 
 
 @cli.command(name="help")

--- a/src/warnet/cli/main.py
+++ b/src/warnet/cli/main.py
@@ -22,44 +22,36 @@ cli.add_command(scenarios)
 
 
 @cli.command(name="help")
-@click.argument("command", required=False, default=None)
+@click.argument("commands", required=False, nargs=-1)
 @click.pass_context
-def help_command(ctx, command):
+def help_command(ctx, commands):
     """
     Display help information for the given command.
     If no command is given, display help for the main CLI.
     """
-    if command is None:
+    if not commands:
         # Display help for the main CLI
         richprint(ctx.parent.get_help())
         return
 
-    # Fetch the command object
-    cmd_obj = cli.get_command(ctx, command)
+    # Recurse down the subcommands, fetching the command object for each
+    cmd_obj = cli
+    for command in commands:
+        cmd_obj = cmd_obj.get_command(ctx, command)
+        if cmd_obj is None:
+            richprint(f'Unknown command "{command}" in {commands}')
+            return
+        ctx = click.Context(cmd_obj, info_name=command, parent=ctx)
 
     if cmd_obj is None:
-        richprint(f"Unknown command: {command}")
+        richprint(f"Unknown command: {commands}")
         return
 
-    # Extract only the relevant help information (excluding the initial usage line)
-    # help_info = cmd_obj.get_help(ctx).split("\n", 1)[-1].strip()
+    # Get the help info
     help_info = cmd_obj.get_help(ctx).strip()
-
-    # Extract the arguments of the command
-    arguments = [
-        param.human_readable_name.upper()
-        for param in cmd_obj.params
-        if isinstance(param, click.Argument)
-    ]
-
-    # Determine the correct usage string based on whether the command has subcommands
-    if isinstance(cmd_obj, click.Group) and cmd_obj.list_commands(ctx):
-        usage_str = f"Usage: warnet {command} [OPTIONS] COMMAND [ARGS...]\n\n{help_info}"
-    else:
-        args_str = " ".join(arguments)
-        usage_str = f"Usage: warnet {command} [OPTIONS] {args_str}\n\n{help_info}"
-
-    richprint(usage_str)
+    # Get rid of the duplication
+    help_info = help_info.replace("Usage: warcli help [COMMANDS]...", "Usage: warcli", 1)
+    richprint(help_info)
 
 
 cli.add_command(help_command)

--- a/src/warnet/cli/network.py
+++ b/src/warnet/cli/network.py
@@ -1,6 +1,6 @@
 import base64  # noqa: I001
+import sys
 from pathlib import Path
-from typing import List
 
 import click
 from rich import print
@@ -65,6 +65,9 @@ def start(graph_file: Path, force: bool, network: str):
         {"graph_file": encoded_graph_file, "force": force, "network": network},
     )
     assert isinstance(result, dict), "Result is not a dict"  # Make mypy happy
+    if not isinstance(result, dict):
+        print(f"Error. Expected dict, got {type(result)}. May indicate mismatch between RPC and CLI")
+        sys.exit(1)
     print_repr(result)
 
 
@@ -85,7 +88,7 @@ def down(network: str):
     """
 
     running_scenarios = rpc_call("scenarios_list_running", {})
-    assert isinstance(running_scenarios, List)
+    assert isinstance(running_scenarios, list)
     if running_scenarios:
         for scenario in running_scenarios:
             pid = scenario.get("pid")

--- a/src/warnet/cli/rpc.py
+++ b/src/warnet/cli/rpc.py
@@ -5,7 +5,7 @@ from typing import Any
 import requests
 from jsonrpcclient.requests import request
 from jsonrpcclient.responses import Error, Ok, parse
-from warnet.server import WARNET_SERVER_PORT
+from warnet.server import SERVER_VERSION, WARNET_SERVER_PORT
 
 
 class JSONRPCException(Exception):
@@ -19,7 +19,13 @@ class JSONRPCException(Exception):
 
 def rpc_call(rpc_method, params: dict[str, Any] | tuple[Any, ...] | None):
     payload = request(rpc_method, params)
-    response = requests.post(f"http://localhost:{WARNET_SERVER_PORT}/api", json=payload)
+    url = f"http://localhost:{WARNET_SERVER_PORT}/api/{SERVER_VERSION}"
+    try:
+        response = requests.post(url, json=payload)
+    except ConnectionRefusedError as e:
+        print(f"Error connecting to {url}. Is the server running and using matching API URL?")
+        logging.debug(e)
+        return
     match parse(response.json()):
         case Ok(result, _):
             return result

--- a/src/warnet/cli/rpc.py
+++ b/src/warnet/cli/rpc.py
@@ -1,5 +1,6 @@
+import logging
 import sys
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any
 
 import requests
 from jsonrpcclient.requests import request
@@ -16,7 +17,7 @@ class JSONRPCException(Exception):
         super().__init__(errmsg)
 
 
-def rpc_call(rpc_method, params: Optional[Union[Dict[str, Any], Tuple[Any, ...]]]):
+def rpc_call(rpc_method, params: dict[str, Any] | tuple[Any, ...] | None):
     payload = request(rpc_method, params)
     response = requests.post(f"http://localhost:{WARNET_SERVER_PORT}/api", json=payload)
     match parse(response.json()):

--- a/src/warnet/cli/scenarios.py
+++ b/src/warnet/cli/scenarios.py
@@ -1,4 +1,4 @@
-from typing import List
+import sys
 
 import click
 from rich import print
@@ -19,7 +19,7 @@ def list():
     """
     console = Console()
     result = rpc_call("scenarios_list", None)
-    assert isinstance(result, List)
+    assert isinstance(result, list)
 
     # Create the table
     table = Table(show_header=True, header_style="bold")
@@ -54,7 +54,9 @@ def active():
     """
     console = Console()
     result = rpc_call("scenarios_list_running", {})
-    assert isinstance(result, List), "Result is not a list"  # Make mypy happy again
+    if not isinstance(result, dict): # Make mypy happy
+        print(f"Error. Expected dict but got {type(result)}: {result}")
+        sys.exit(1)
 
     table = Table(show_header=True, header_style="bold")
     for key in result[0].keys():  # noqa: SIM118

--- a/src/warnet/cli/scenarios.py
+++ b/src/warnet/cli/scenarios.py
@@ -13,13 +13,15 @@ def scenarios():
 
 
 @scenarios.command()
-def list():
+def available():
     """
     List available scenarios in the Warnet Test Framework
     """
     console = Console()
-    result = rpc_call("scenarios_list", None)
-    assert isinstance(result, list)
+    result = rpc_call("scenarios_available", None)
+    if not isinstance(result, list): # Make mypy happy
+        print(f"Error. Expected list but got {type(result)}: {result}")
+        sys.exit(1)
 
     # Create the table
     table = Table(show_header=True, header_style="bold")

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -1,6 +1,5 @@
 import json
 import os
-from typing import List
 
 from backends import BackendInterface, ServiceType
 from warnet.utils import exponential_backoff, generate_ipv4_addr
@@ -49,7 +48,7 @@ class LNNode:
         res = self.lncli(f"connect {uri}")
         return res
 
-    def generate_cli_command(self, command: List[str]):
+    def generate_cli_command(self, command: list[str]):
         network = f"--network={self.tank.warnet.bitcoin_network}"
         cmd = f"{network} {' '.join(command)}"
         match self.impl:

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -96,7 +96,7 @@ class Server:
         self.jsonrpc.register(self.tank_debug_log)
         self.jsonrpc.register(self.tank_messages)
         # Scenarios
-        self.jsonrpc.register(self.scenarios_list)
+        self.jsonrpc.register(self.scenarios_available)
         self.jsonrpc.register(self.scenarios_run)
         self.jsonrpc.register(self.scenarios_stop)
         self.jsonrpc.register(self.scenarios_list_running)
@@ -216,7 +216,7 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
-    def scenarios_list(self) -> list[tuple]:
+    def scenarios_available(self) -> list[tuple]:
         """
         List available scenarios in the Warnet Test Framework
         """

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -14,7 +14,6 @@ from io import BytesIO
 from logging import StreamHandler
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import List, Optional
 
 import networkx as nx
 import scenarios
@@ -115,7 +114,7 @@ class Server:
         self.jsonrpc.register(self.logs_grep)
 
     def tank_bcli(
-        self, node: int, method: str, params: Optional[List[str]] = None, network: str = "warnet"
+        self, node: int, method: str, params: list[str] | None = None, network: str = "warnet"
     ) -> str:
         """
         Call bitcoin-cli on <node> <method> <params> in [network]
@@ -128,7 +127,7 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
-    def tank_lncli(self, node: int, command: List[str], network: str = "warnet") -> str:
+    def tank_lncli(self, node: int, command: list[str], network: str = "warnet") -> str:
         """
         Call lightning cli on <node> <command> in [network]
         """
@@ -174,7 +173,7 @@ class Server:
 
             for message in messages:
                 # Check if 'time' key exists and its value is a number
-                if not (message.get("time") and isinstance(message["time"], (int, float))):
+                if not (message.get("time") and isinstance(message["time"], int | float)):
                     continue
 
                 timestamp = datetime.utcfromtimestamp(message["time"] / 1e6).strftime(
@@ -214,7 +213,7 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
-    def scenarios_list(self) -> List[tuple]:
+    def scenarios_list(self) -> list[tuple]:
         """
         List available scenarios in the Warnet Test Framework
         """
@@ -231,7 +230,7 @@ class Server:
             raise ServerError(message=msg) from e
 
     def scenarios_run(
-        self, scenario: str, additional_args: List[str], network: str = "warnet"
+        self, scenario: str, additional_args: list[str], network: str = "warnet"
     ) -> str:
         base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         scenario_path = os.path.join(base_dir, "scenarios", f"{scenario}.py")
@@ -291,7 +290,7 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg)
 
-    def scenarios_list_running(self) -> List[dict]:
+    def scenarios_list_running(self) -> list[dict]:
         running = [
             {
                 "pid": sc["pid"],
@@ -370,10 +369,10 @@ class Server:
 
     def graph_generate(
         self,
-        params: List[str],
+        params: list[str],
         outfile: str,
         version: str,
-        bitcoin_conf: Optional[str] = None,
+        bitcoin_conf: str | None = None,
         random: bool = False,
     ) -> str:
         try:

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -26,6 +26,8 @@ from warnet.utils import (
 )
 from warnet.warnet import Warnet
 
+# Breaking API changes should bump/change this for k8s
+SERVER_VERSION = "0.1"
 WARNET_SERVER_PORT = 9276
 CONFIG_DIR_ALREADY_EXISTS = 32001
 
@@ -50,12 +52,13 @@ class Server:
         self.running_scenarios = []
 
         self.app = Flask(__name__)
-        self.jsonrpc = JSONRPC(self.app, "/api")
+        self.jsonrpc = JSONRPC(self.app, f"/api/{SERVER_VERSION}")
 
         self.log_file_path = os.path.join(self.basedir, "warnet.log")
         self.logger: logging.Logger
         self.setup_logging()
         self.setup_rpc()
+        self.logger.info(f"Started server version {SERVER_VERSION}")
 
     def setup_logging(self):
         # Ensure the directory exists

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -44,7 +44,7 @@ class Tank:
         self._ipv4 = None
         self._exporter_name = None
         self.extra_build_args = ""
-        self.lnnode = None
+        self.lnnode: LNNode | None = None
         self.zmqblockport = 28332
         self.zmqtxport = 28333
 

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -32,6 +32,7 @@ class Tank:
         self.network_name = warnet.network_name
         self.bitcoin_network = warnet.bitcoin_network
         self.version = "25.1"
+        self.image: str = ""
         self.is_custom_build = False
         self.conf = ""
         self.conf_file = None

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -32,6 +32,7 @@ class Tank:
         self.network_name = warnet.network_name
         self.bitcoin_network = warnet.bitcoin_network
         self.version = "25.1"
+        self.is_custom_build = False
         self.conf = ""
         self.conf_file = None
         self.netem = None
@@ -60,6 +61,26 @@ class Tank:
             f"\t)"
         )
 
+    def parse_version(self, node):
+        version = node.get("version", "")
+        image = node.get("image", "")
+        logger.debug(f"{version=:}")
+        logger.debug(f"{image=:}")
+        if version and image:
+            raise Exception(
+                f"Tank has {version=:} and {image=:} supplied and can't be built. Provide one or the other."
+            )
+        if image:
+            self.image = image
+            self.is_custom_build = True
+        else:
+            if (version in SUPPORTED_TAGS) or ("/" in version and "#" in version):
+                self.version = version
+            else:
+                raise Exception(
+                    f"Unsupported version: can't be generated from Docker images: {version}"
+                )
+
     @classmethod
     def from_graph_node(cls, index, warnet, tank=None):
         assert index is not None
@@ -71,13 +92,7 @@ class Tank:
         if self is None:
             self = cls(index, config_dir, warnet)
         node = warnet.graph.nodes[index]
-        version = node.get("version")
-        if version:
-            if not ("/" in version and "#" in version) and version not in SUPPORTED_TAGS:
-                raise Exception(
-                    f"Unsupported version: can't be generated from Docker images: {version}"
-                )
-            self.version = version
+        self.parse_version(node)
         self.conf = node.get("bitcoin_config", self.conf)
         self.netem = node.get("tc_netem", self.netem)
         self.exporter = node.get("exporter", self.exporter)

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -10,7 +10,6 @@ import sys
 import time
 from io import BytesIO
 from pathlib import Path
-from typing import List, Optional
 
 import networkx as nx
 from test_framework.messages import ser_uint256
@@ -401,7 +400,7 @@ def default_bitcoin_conf_args() -> str:
 
 
 def create_graph_with_probability(
-    graph_func, params: List, version: str, bitcoin_conf: Optional[str], random_version: bool
+    graph_func, params: list, version: str, bitcoin_conf: str | None, random_version: bool
 ):
     kwargs = {}
     for param in params:
@@ -489,7 +488,7 @@ def convert_unsupported_attributes(graph):
         for key, value in node_data.items():
             if isinstance(value, set):
                 node_data[key] = list(value)
-            elif isinstance(value, (int, float, str)):
+            elif isinstance(value, int | float | str):
                 continue
             else:
                 node_data[key] = str(value)
@@ -498,7 +497,7 @@ def convert_unsupported_attributes(graph):
         for key, value in edge_data.items():
             if isinstance(value, set):
                 edge_data[key] = list(value)
-            elif isinstance(value, (int, float, str)):
+            elif isinstance(value, int | float | str):
                 continue
             else:
                 edge_data[key] = str(value)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -8,7 +8,6 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import List, Optional
 
 import networkx
 from backends import ComposeBackend, KubernetesBackend
@@ -32,10 +31,10 @@ class Warnet:
         self.bitcoin_network: str = "regtest"
         self.network_name: str = "warnet"
         self.subnet: str = "100.0.0.0/8"
-        self.graph: Optional[networkx.Graph] = None
+        self.graph: networkx.Graph | None = None
         self.graph_name = "graph.graphml"
-        self.tanks: List[Tank] = []
-        self.deployment_file: Optional[Path] = None
+        self.tanks: list[Tank] = []
+        self.deployment_file: Path | None = None
         self.backend = backend
 
     def __str__(self) -> str:

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -13,7 +13,7 @@ print(base.warcli(f"network start {graph_file_path}"))
 base.wait_for_all_tanks_status(target="running")
 
 # Use rpc instead of warcli so we get raw JSON object
-scenarios = base.rpc("scenarios_list")
+scenarios = base.rpc("scenarios_available")
 assert len(scenarios) == 4
 
 # Exponential backoff will repeat this command until it succeeds.

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -120,7 +120,7 @@ class TestBase:
         self.server_thread.start()
 
         # doesn't require anything docker-related
-        self.wait_for_rpc("scenarios_list")
+        self.wait_for_rpc("scenarios_available")
 
     # Quit
     def stop_server(self):


### PR DESCRIPTION
Support building and using custom images (i.e. github branches) on K8s.

Unfortunately I've ended up with another multi-faceted pull here. Needed various un-related changes to makes things work.

* Add `warcli image build` command to build an image from a repo, apply networking patches, and push it to a registry.
* Handle using custom images in the graph file
* Switch `scenarios list` -->  `scenarios available` (list is a very bad function name in python)
* Introduce RPC versioning. K8s rpc is pulled from an image too. Ideally this needs to be version-controlled/in sync with the CLI. This adds a `/api/<version>/` field to the endpoint, so we can at least co-ordinate breaking changes in the future.