### PR TITLE
add readiness probe to dev rpc

### DIFF
--- a/src/templates/rpc/readiness.sh
+++ b/src/templates/rpc/readiness.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if pidof python > /dev/null; then
+    exit 0
+fi
+
+exit 1
+

--- a/src/templates/rpc/warnet-rpc-statefulset-dev.yaml
+++ b/src/templates/rpc/warnet-rpc-statefulset-dev.yaml
@@ -22,6 +22,14 @@ spec:
         volumeMounts:
           - name: source-code
             mountPath: /root/warnet
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /root/warnet/src/templates/rpc/readiness.sh
+          initialDelaySeconds: 5
+          periodSeconds: 10
       volumes:
       - name: source-code
         hostPath:


### PR DESCRIPTION
This will run until a python process (warnet) is detected, then return that the pod is ready back to kubectl:

![image](https://github.com/bitcoin-dev-project/warnet/assets/6606587/4ca73531-8d10-4650-b818-fb6526f37d9d)
