### PR TITLE
Fix exec on k8s backend

### DIFF
--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -149,6 +149,8 @@ class KubernetesBackend(BackendInterface):
             stdin=False,
             stdout=True,
             tty=False,
+            # Avoid preloading the content to keep JSON intact
+            _preload_content=False,
         )
         # TODO: stream result is just a string, so there is no error code to check
         # ideally, we use a method where we can check for an error code, otherwise we will
@@ -158,6 +160,8 @@ class KubernetesBackend(BackendInterface):
         #     raise Exception(
         #         f"Command failed with exit code {result.exit_code}: {result.output.decode('utf-8')}"
         #     )
+        result.run_forever()
+        result = result.read_all()
         return result
 
     def get_bitcoin_debug_log(self, tank_index: int):


### PR DESCRIPTION
The official k8s stream method by default decodes the payload if it looks like JSON.
Upstream bug report: https://github.com/kubernetes-client/python/issues/1032

This _breaks_ `json.load` of basically all lightning and bitcoin cli outputs. 
E.g. `lncli newaddress p2wkh` would output (address mangled to avoid any copy/paste)
```
{
    "address": "___qmzz850w3t572tuwj9f68sc3jkku4py6qvpn___"
}
```
this would turn into
```
{
    'address': '___qmzz850w3t572tuwj9f68sc3jkku4py6qvpn___'
}
```
which fails on json.loads (single quotes vs. double quotes).

To avoid this we are disabling content parsing and manually let the [ws_client](https://github.com/kubernetes-client/python/blob/master/kubernetes/base/stream/ws_client.py) run.