### PR TITLE
patch: addrman buckets ipv4 based on /32

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .git
 __pycache__
+.github
+.idea
+.ruff_cache

--- a/justfile
+++ b/justfile
@@ -74,3 +74,15 @@ stopd:
 # port forward
 p:
     kubectl port-forward svc/rpc 9276:9276
+
+registry := 'bitcoindevproject/demo'
+repo := 'bitcoin/bitcoin'
+build-args := "--disable-tests --without-gui --disable-bench --disable-fuzz-binary --enable-suppress-external-warnings --enable-debug"
+
+# Build docker images and push to registry
+build branch tag registry=registry repo=repo build-args=build-args:
+    DOCKER_REGISTRY={{ registry }} \
+    REPO={{ repo }} \
+    BRANCH=v26.0 TAG={{ tag }} \
+    BUILD_ARGS="{{ build-args }}" \
+    scripts/build-bitcoind.sh src/templates/Dockerfile_k8_alpine

--- a/scripts/build-bitcoind.sh
+++ b/scripts/build-bitcoind.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Run from the src/templates dir with e.g.:
+#
+# $ DOCKER_REGISTRY=bitcoindevproject/demo TAG=26.0 ../../scripts/build-k8s-rpc.sh Dockerfile_rpc_alpine
+
+
+BUILDER_NAME="warnet-bitcoind-builder"
+# Cleanup function to remove the Docker builder
+cleanup() {
+  echo "Removing builder..."
+  docker buildx rm "$BUILDER_NAME" || echo "Failed to remove builder $BUILDER_NAME"
+}
+
+# Set up trap to call cleanup function on EXIT signal
+trap cleanup EXIT SIGINT SIGTERM
+
+set -ex
+
+# Create a new builder to enable building multi-platform images
+docker buildx create --name "$BUILDER_NAME" --use
+
+# Read DOCKER_REGISTRY from the environment
+: "${DOCKER_REGISTRY?Need to set DOCKER_REGISTRY}"
+: "${TAG?Need to set TAG}"
+
+# Architectures for building
+ARCHS="linux/amd64,linux/arm64"
+
+# Read Dockerfile from the first argument
+DOCKERFILE_PATH=$1
+if [[ ! -f "$DOCKERFILE_PATH" ]]; then
+  echo "Dockerfile does not exist at the specified path: $DOCKERFILE_PATH"
+  exit 1
+fi
+
+# Loop through each architecture to build and push
+IMAGE_FULL_NAME="$DOCKER_REGISTRY:$TAG"
+
+# Use Buildx to build the image for the specified architecture
+docker buildx build --platform "$ARCHS" \
+    --file "$DOCKERFILE_PATH" \
+    --progress=plain \
+    --tag "$IMAGE_FULL_NAME" \
+    --build-arg REPO="$REPO" \
+    --build-arg BRANCH="$BRANCH" \
+    --build-arg BUILD_ARGS="$BUILD_ARGS" \
+    . --push

--- a/src/graphs/default.graphml
+++ b/src/graphs/default.graphml
@@ -26,7 +26,7 @@
         <data key="collect_logs">true</data>
     </node>
     <node id="3">
-        <data key="version">26.0</data>
+        <data key="image">bitcoindevproject/demo:26.0</data>
         <data key="bitcoin_config">-uacomment=w3</data>
         <data key="exporter">true</data>
     </node>

--- a/src/templates/Dockerfile_k8_alpine
+++ b/src/templates/Dockerfile_k8_alpine
@@ -1,0 +1,84 @@
+# Setup deps stage
+FROM alpine as deps
+ARG REPO
+ARG BRANCH
+ARG BUILD_ARGS
+
+RUN --mount=type=cache,target=/var/cache/apk \
+    sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories \
+    && apk --no-cache add \
+    autoconf \
+    automake \
+    boost-dev \
+    build-base \
+    chrpath \
+    file \
+    gnupg \
+    git \
+    libevent-dev \
+    libressl \
+    libtool \
+    linux-headers \
+    sqlite-dev \
+    zeromq-dev
+
+COPY src/templates/isroutable.patch /tmp/
+COPY src/templates/addrman.patch /tmp/
+
+
+# Clone and patch and build stage
+FROM deps as build
+ENV BITCOIN_PREFIX=/opt/bitcoin
+WORKDIR /build
+
+RUN set -ex \
+    && cd /build \
+    && git clone --depth 1 --branch "${BRANCH}" "https://github.com/${REPO}" \
+    && cd bitcoin \
+    && git apply /tmp/isroutable.patch \
+    && git apply /tmp/addrman.patch \
+    && sed -i s:sys/fcntl.h:fcntl.h: src/compat/compat.h \
+    && ./autogen.sh \
+    && ./configure \
+    LDFLAGS=-L`ls -d /opt/db*`/lib/ \
+    CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+    --prefix=${BITCOIN_PREFIX} \
+    ${BUILD_ARGS} \
+    && make -j$(nproc) \
+    && make install \
+    && strip ${BITCOIN_PREFIX}/bin/bitcoin-cli \
+    && strip ${BITCOIN_PREFIX}/bin/bitcoin-tx \
+    && strip ${BITCOIN_PREFIX}/bin/bitcoind \
+    && strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a \
+    && strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
+
+# Final clean stage
+FROM alpine
+ARG UID=100
+ARG GID=101
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_PREFIX=/opt/bitcoin
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+LABEL maintainer.0="bitcoindevproject"
+
+RUN addgroup bitcoin --gid ${GID} --system \
+    && adduser --uid ${UID} --system bitcoin --ingroup bitcoin
+RUN --mount=type=cache,target=/var/cache/apk sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories \
+    && apk --no-cache add \
+    bash \
+    libevent \
+    libzmq \
+    shadow \
+    sqlite-dev \
+    su-exec
+
+COPY --from=build /opt/bitcoin /usr/local
+COPY src/templates/entrypoint.sh /entrypoint.sh
+COPY src/templates/tor/torrc /etc/tor/warnet-torr
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bitcoind"]
+

--- a/src/templates/addrman.patch
+++ b/src/templates/addrman.patch
@@ -1,0 +1,17 @@
+diff --git a/src/netgroup.cpp b/src/netgroup.cpp
+index 0ae229b3f3..a861a38852 100644
+--- a/src/netgroup.cpp
++++ b/src/netgroup.cpp
+@@ -43,11 +43,7 @@ std::vector<unsigned char> NetGroupManager::GetGroup(const CNetAddr& address) co
+     } else if (!address.IsRoutable()) {
+         // all other unroutable addresses belong to the same group
+     } else if (address.HasLinkedIPv4()) {
+-        // IPv4 addresses (and mapped IPv4 addresses) use /16 groups
+-        uint32_t ipv4 = address.GetLinkedIPv4();
+-        vchRet.push_back((ipv4 >> 24) & 0xFF);
+-        vchRet.push_back((ipv4 >> 16) & 0xFF);
+-        return vchRet;
++        nBits = 32;
+     } else if (address.IsTor() || address.IsI2P()) {
+         nBits = 4;
+     } else if (address.IsCJDNS()) {

--- a/src/templates/entrypoint.sh
+++ b/src/templates/entrypoint.sh
@@ -57,7 +57,7 @@ fi
 
 if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
   echo
-  exec gosu bitcoin "$@"
+  exec su-exec bitcoin:bitcoin "$@"
 fi
 
 echo

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -8,7 +8,7 @@
   <key attr.name="image"          attr.type="string" for="node" id="image"/>
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">26.0</data>
+        <data key="image">bitcoindevproject/demo:26.0</data>
         <data key="bitcoin_config">uacomment=w0</data>
         <data key="ln">lnd</data>
         <data key="collect_logs">true</data>

--- a/test/data/v25_x_12.graphml
+++ b/test/data/v25_x_12.graphml
@@ -5,7 +5,7 @@
   <key attr.name="image"          attr.type="string" for="node" id="image"/>
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">26.0</data>
+        <data key="image">bitcoindevproject/demo:26.0</data>
         <data key="bitcoin_config">-uacomment=w0</data>
     </node>
     <node id="1">


### PR DESCRIPTION
This adds a(nother) new dockerfile for building small alpine linux images, with both isroutable and addrman bucketing fixes specific to warnet.

If all goes well, we should be able to use this dockerfile for building our default (tagged) images, and to use in the custom branch building code.

The script should also be cross-purpose for building bitcoind Docker images and warnet-rpc images.

This will enable us to remove from the codebase:

```bash
src/templates/Dockerfile
src/templates/Dockerfile_k8
scripts/build-bitcoin-images-k8s.sh
scripts/ build-bitcoin-images.sh
scripts/build-k8s-rpc.sh
```

and rework all builds to use a single script, and both docker and k8s to use the unified image