### PR TITLE
Wait for lightning balances to be distributed

### DIFF
--- a/src/scenarios/ln_init.py
+++ b/src/scenarios/ln_init.py
@@ -29,6 +29,20 @@ class LNInit(WarnetTestFramework):
             miner.sendtoaddress(addr, 50)
         self.generatetoaddress(self.nodes[3], 1, addr)
 
+        self.log.info("Waiting for funds to be spendable")
+        ready = False
+        while not ready:
+            sleep(1)
+            ready = True
+            for tank in self.warnet.tanks:
+                if tank.lnnode is None:
+                    continue
+                bal = tank.lnnode.get_wallet_balance()
+                if int(bal["confirmed_balance"]) >= 50:
+                    continue
+                ready = False
+                break
+
         self.log.info("Open channels")
         # TODO: This might belong in Warnet class as connect_ln_edges()
         #       but that would need to ensure spendable funds first.

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -34,6 +34,10 @@ class LNNode:
         res = json.loads(self.lncli("getinfo"))
         return res["uris"][0]
 
+    def get_wallet_balance(self):
+        res = json.loads(self.lncli("walletbalance"))
+        return res
+
     def open_channel_to_tank(self, index, amt):
         tank = self.warnet.tanks[index]
         [pubkey, host] = tank.lnnode.getURI().split("@")


### PR DESCRIPTION
Otherwise we might try to open channels from nodes that can't spend any fund yet.

[EDIT] rebased on main after #257, ln on k8s is passing.