### PR TITLE
Make k8s DNS service lookup non-absolute

### DIFF
--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -378,8 +378,8 @@ class KubernetesBackend(BackendInterface):
 
     def create_lnd_container(self, tank, bitcoind_service_name) -> client.V1Container:
         # These args are appended to the Dockerfile `ENTRYPOINT ["lnd"]`
-        bitcoind_rpc_host = f"{bitcoind_service_name}.{self.namespace}.svc.cluster.local"
-        lightning_dns = f"lightning-{tank.index}.{self.namespace}.svc.cluster.local"
+        bitcoind_rpc_host = f"{bitcoind_service_name}.{self.namespace}"
+        lightning_dns = f"lightning-{tank.index}.{self.namespace}"
         args = [
             "--noseedbackup",
             "--norest",


### PR DESCRIPTION
The cluster domain name can be changed. This is particular useful when running multiple cluster or meshing clusters just via DNS + VPNs.

It is common to change this for production clusters.

See [DNS for Services and Pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/) for details on DNS search domains.