### PR TITLE
Added log aggregation to k8s

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -35,7 +35,21 @@ This can be done using:
 kubectl delete statefulset
 ```
 
-## Docker
+### Install logging infrastructure
+
+First make sure you have `helm` installed, then simply run the following script:
+
+```bash
+./src/templates/k8s/install_logging.sh
+```
+
+To forward port to view Grafana dashbaord:
+
+```bash
+./src/templates/k8s/connect_logging.sh
+```
+
+## Compose
 
 To start the server in the foreground simply run:
 

--- a/justfile
+++ b/justfile
@@ -23,6 +23,7 @@ start:
     kubectl apply -f src/templates/rpc/rbac-config.yaml
     kubectl apply -f src/templates/rpc/warnet-rpc-service.yaml
     kubectl apply -f src/templates/rpc/warnet-rpc-statefulset-dev.yaml
+    just installlogging
     kubectl config set-context --current --namespace=warnet
 
     echo waiting for rpc to come online
@@ -37,6 +38,7 @@ stop:
     set -euxo pipefail
 
     kubectl delete namespace warnet
+    kubectl delete namespace warnet-logging
     kubectl config set-context --current --namespace=default
 
     # Fetch job ID of `minikube mount $PWD:/mnt/src` from saved PID file
@@ -56,6 +58,7 @@ startd:
     kubectl apply -f src/templates/rpc/rbac-config.yaml
     kubectl apply -f src/templates/rpc/warnet-rpc-service.yaml
     sed 's?/mnt/src?'`PWD`'?g' src/templates/rpc/warnet-rpc-statefulset-dev.yaml | kubectl apply -f -
+    just installlogging
     kubectl config set-context --current --namespace=warnet
 
     echo waiting for rpc to come online
@@ -67,6 +70,7 @@ startd:
 stopd:
     # Delete all resources
     kubectl delete namespace warnet
+    kubectl delete namespace warnet-logging
     kubectl config set-context --current --namespace=default
 
     echo Done...
@@ -84,3 +88,9 @@ load := "load"
 # Build docker image and optionally push to registry
 build branch tag registry=registry repo=repo build-args=build-args action=load:
     warcli image build --registry={{registry}} --repo={{repo}} --branch={{branch}} --arches={{arches}} --tag={{tag}} --build-args="{{build-args}}" --action={{action}}
+
+installlogging:
+    ./src/templates/k8s/install_logging.sh
+
+connectlogging:
+    ./src/templates/k8s/connect_logging.sh

--- a/src/templates/k8s/connect_logging.sh
+++ b/src/templates/k8s/connect_logging.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+POD_NAME=$(kubectl get pods --namespace warnet-logging -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=loki-grafana" -o jsonpath="{.items[0].metadata.name}")
+
+GRAFANA_PASSWORD=$(kubectl get secret --namespace warnet-logging loki-grafana -o jsonpath="{.data.admin-password}" | base64 --decode || true)
+
+echo "Go to http://localhost:3000 and login with the username 'admin' and the password '${GRAFANA_PASSWORD}' to see your logs"
+
+kubectl --namespace warnet-logging port-forward "${POD_NAME}" 3000

--- a/src/templates/k8s/install_logging.sh
+++ b/src/templates/k8s/install_logging.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+
+helm upgrade --install --namespace warnet-logging --create-namespace --values "${SCRIPT_DIR}/loki/values.yaml" loki grafana/loki
+helm upgrade --install --namespace warnet-logging promtail grafana/promtail
+helm upgrade --install --namespace warnet-logging loki-grafana grafana/grafana

--- a/src/templates/k8s/loki/values.yaml
+++ b/src/templates/k8s/loki/values.yaml
@@ -1,0 +1,10 @@
+loki:
+    auth_enabled: false
+minio:
+  enabled: true
+write:
+  affinity: {}
+read:
+  affinity: {}
+backend:
+  affinity: {}

--- a/src/templates/k8s/loki/values.yaml
+++ b/src/templates/k8s/loki/values.yaml
@@ -8,3 +8,8 @@ read:
   affinity: {}
 backend:
   affinity: {}
+monitoring:
+  selfMonitoring:
+    enabled: false
+test:
+  enabled: false

--- a/src/templates/k8s/loki/values.yaml
+++ b/src/templates/k8s/loki/values.yaml
@@ -3,11 +3,11 @@ loki:
 minio:
   enabled: true
 write:
-  affinity: {}
+  affinity: []
 read:
-  affinity: {}
+  affinity: []
 backend:
-  affinity: {}
+  affinity: []
 monitoring:
   selfMonitoring:
     enabled: false


### PR DESCRIPTION
A prerequisite is to have `helm` installed on your local machine.

To install the logging infrastructure:

```shell
./src/templates/k8s/install_logging.sh
```

To view Grafana dashboard:

```shell
./src/templates/k8s/connect_logging.sh
```

When on the dashboard  (http://localhost:3000) connect to Loki datasource using the url `http://loki-gateway.warnet-logging.svc.cluster.local` and view some logs with `{pod="warnet-tank-000001"}` query.

Next steps are:

- Having the Loki datasource automatically connect in Grafana
- Adding Prometheus metrics and connecting that to Grafana
- Creating default dashboard for Warnet

But these can come in their own PRs