### PR TITLE
Disable debug default

### DIFF
--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -347,12 +347,12 @@ class KubernetesBackend(BackendInterface):
             container_image = tank.image
         # On-demand built image
         elif "/" and "#" in tank.version:
-        # We don't have docker installed on the RPC server, where this code will be run from,
-        # and it's currently unclear to me if having the RPC pod build images is a good idea.
-        # Don't support this for now in CI by disabling in the workflow.
+            # We don't have docker installed on the RPC server, where this code will be run from,
+            # and it's currently unclear to me if having the RPC pod build images is a good idea.
+            # Don't support this for now in CI by disabling in the workflow.
 
-        # This can be re-enabled by enabling in the workflow file and installing docker and
-        # docker-buildx on the rpc server image.
+            # This can be re-enabled by enabling in the workflow file and installing docker and
+            # docker-buildx on the rpc server image.
 
             # it's a git branch, building step is necessary
             repo, branch = tank.version.split("#")
@@ -368,9 +368,9 @@ class KubernetesBackend(BackendInterface):
         else:
             container_image = f"{DOCKER_REGISTRY_CORE}:{tank.version}"
 
-        container_env = [
-            client.V1EnvVar(name="BITCOIN_ARGS", value=self.default_bitcoind_config_args(tank))
-        ]
+        bitcoind_options = self.default_bitcoind_config_args(tank)
+        bitcoind_options += tank.conf
+        container_env = [client.V1EnvVar(name="BITCOIN_ARGS", value=bitcoind_options)]
 
         return client.V1Container(
             name=container_name,

--- a/src/graphs/default.graphml
+++ b/src/graphs/default.graphml
@@ -21,7 +21,7 @@
     </node>
     <node id="2">
         <data key="image">bitcoindevproject/bitcoin:26.0</data>
-        <data key="bitcoin_config">-uacomment=w2</data>
+        <data key="bitcoin_config">-uacomment=w2 -debug=mempool</data>
         <data key="exporter">true</data>
         <data key="collect_logs">true</data>
     </node>

--- a/src/templates/bitcoin.conf
+++ b/src/templates/bitcoin.conf
@@ -1,15 +1,9 @@
 regtest=1
 
-debug=1
 debuglogfile=0
 logips=1
 logtimemicros=1
 capturemessages=1
-debugexclude=libevent
-debugexclude=leveldb
-debugexclude=rand
-debugexclude=addrman
-debugexclude=bench
 
 rpcallowip=0.0.0.0/0
 rpcbind=0.0.0.0

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -17,6 +17,9 @@ class LNNode:
         self.ipv4 = generate_ipv4_addr(self.warnet.subnet)
         self.rpc_port = 10009
 
+    def __str__(self):
+        return f"LNNode: index={self.tank.index}, ipv4={self.ipv4}, rpc_port={self.rpc_port}"
+
     @property
     def status(self) -> RunningStatus:
         return self.warnet.container_interface.get_status(self.tank.index, ServiceType.LIGHTNING)

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -50,16 +50,7 @@ class Tank:
         self.zmqtxport = 28333
 
     def __str__(self) -> str:
-        return (
-            f"Tank(\n"
-            f"\tIndex: {self.index}\n"
-            f"\tVersion: {self.version}\n"
-            f"\tConf: {self.conf}\n"
-            f"\tConf File: {self.conf_file}\n"
-            f"\tNetem: {self.netem}\n"
-            f"\tIPv4: {self._ipv4}\n"
-            f"\t)"
-        )
+        return f"Tank(index: {self.index}, version: {self.version}, conf: {self.conf}, conf file: {self.conf_file}, netem: {self.netem}, IPv4: {self._ipv4})"
 
     def parse_version(self, node):
         version = node.get("version", "")

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -9,24 +9,24 @@
   <graph edgedefault="directed">
     <node id="0">
         <data key="version">26.0</data>
-        <data key="bitcoin_config">uacomment=w0</data>
+        <data key="bitcoin_config">-uacomment=w0</data>
         <data key="ln">lnd</data>
         <data key="collect_logs">true</data>
     </node>
     <node id="1">
         <data key="version">26.0</data>
-        <data key="bitcoin_config">uacomment=w1</data>
+        <data key="bitcoin_config">-uacomment=w1</data>
         <data key="ln">lnd</data>
         <data key="collect_logs">true</data>
     </node>
     <node id="2">
         <data key="version">26.0</data>
-        <data key="bitcoin_config">uacomment=w2</data>
+        <data key="bitcoin_config">-uacomment=w2</data>
         <data key="ln">lnd</data>
     </node>
     <node id="3">
         <data key="version">26.0</data>
-        <data key="bitcoin_config">uacomment=w3</data>
+        <data key="bitcoin_config">-uacomment=w3</data>
     </node>
     <edge id="1" source="0" target="1"></edge>
     <edge id="2" source="1" target="2"></edge>

--- a/test/data/v25_x_12.graphml
+++ b/test/data/v25_x_12.graphml
@@ -6,15 +6,15 @@
   <graph edgedefault="directed">
     <node id="0">
         <data key="version">26.0</data>
-        <data key="bitcoin_config">-uacomment=w0</data>
+        <data key="bitcoin_config">-uacomment=w0 -debug=validation</data>
     </node>
     <node id="1">
         <data key="version">26.0</data>
-        <data key="bitcoin_config">-uacomment=w1</data>
+        <data key="bitcoin_config">-uacomment=w1 -debug=validation</data>
     </node>
     <node id="2">
         <data key="version">26.0</data>
-        <data key="bitcoin_config">-uacomment=w2</data>
+        <data key="bitcoin_config">-uacomment=w2 -debug=validation</data>
     </node>
     <node id="3">
         <data key="version">26.0</data>


### PR DESCRIPTION
Closes: #266 

This logging is overly verbose, disable it by default.
Add a demo debug category to default graph config.

Also include a commit to have k8s actually use bitcoind options from the graph (doh!). We now indirectly test this by having debug logging disabled and _requiring_ debug=validation to come from a test graph.

Finally add some logging to the k8s backend so we can see what's going on better