### PR TITLE
Add prometheus to logging stack

### DIFF
--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -276,6 +276,7 @@ class KubernetesBackend(BackendInterface):
             try:
                 log_stream = self.client.read_namespaced_pod_log(
                     name=pod.metadata.name,
+                    container=BITCOIN_CONTAINER_NAME,
                     namespace=self.namespace,
                     timestamps=True,
                     _preload_content=False,

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -9,15 +9,14 @@ import yaml
 from backends import BackendInterface, ServiceType
 from cli.image import build_image
 from kubernetes import client, config
-from kubernetes.dynamic import DynamicClient
 from kubernetes.client.models.v1_pod import V1Pod
 from kubernetes.client.rest import ApiException
+from kubernetes.dynamic import DynamicClient
 from kubernetes.stream import stream
 from warnet.lnnode import LNNode
 from warnet.status import RunningStatus
 from warnet.tank import Tank
 from warnet.utils import default_bitcoin_conf_args, parse_raw_messages
-
 
 DOCKER_REGISTRY_CORE = "bitcoindevproject/bitcoin"
 DOCKER_REGISTRY_LND = "lightninglabs/lnd:v0.17.0-beta"

--- a/src/templates/k8s/connect_logging.sh
+++ b/src/templates/k8s/connect_logging.sh
@@ -3,8 +3,6 @@ set -e
 
 POD_NAME=$(kubectl get pods --namespace warnet-logging -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=loki-grafana" -o jsonpath="{.items[0].metadata.name}")
 
-GRAFANA_PASSWORD=$(kubectl get secret --namespace warnet-logging loki-grafana -o jsonpath="{.data.admin-password}" | base64 --decode || true)
-
-echo "Go to http://localhost:3000 and login with the username 'admin' and the password '${GRAFANA_PASSWORD}' to see your logs"
+echo "Go to http://localhost:3000 and login with the username 'admin' and the password 'password' to see your logs"
 
 kubectl --namespace warnet-logging port-forward "${POD_NAME}" 3000

--- a/src/templates/k8s/grafana/values.yaml
+++ b/src/templates/k8s/grafana/values.yaml
@@ -1,0 +1,10 @@
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      url: http://prometheus-kube-prometheus-prometheus.warnet-logging:9090
+    - name: Loki
+      type: loki
+      url: http://loki-gateway.warnet-logging:80

--- a/src/templates/k8s/grafana/values.yaml
+++ b/src/templates/k8s/grafana/values.yaml
@@ -1,3 +1,6 @@
+adminUser: admin
+adminPassword: password
+admin: {}
 datasources:
   datasources.yaml:
     apiVersion: 1

--- a/src/templates/k8s/install_logging.sh
+++ b/src/templates/k8s/install_logging.sh
@@ -8,4 +8,5 @@ helm repo update
 
 helm upgrade --install --namespace warnet-logging --create-namespace --values "${SCRIPT_DIR}/loki/values.yaml" loki grafana/loki
 helm upgrade --install --namespace warnet-logging promtail grafana/promtail
-helm upgrade --install --namespace warnet-logging loki-grafana grafana/grafana
+helm upgrade --install --namespace warnet-logging prometheus prometheus-community/kube-prometheus-stack --namespace warnet-logging --set grafana.enabled=false
+helm upgrade --install --namespace warnet-logging loki-grafana grafana/grafana --values "${SCRIPT_DIR}/grafana/values.yaml"

--- a/src/templates/k8s/install_logging.sh
+++ b/src/templates/k8s/install_logging.sh
@@ -4,6 +4,7 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 helm repo add grafana https://grafana.github.io/helm-charts
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 
 helm upgrade --install --namespace warnet-logging --create-namespace --values "${SCRIPT_DIR}/loki/values.yaml" loki grafana/loki

--- a/src/templates/rpc/namespace.yaml
+++ b/src/templates/rpc/namespace.yaml
@@ -4,3 +4,10 @@ metadata:
   name: warnet
   labels:
     name: warnet
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: warnet-logging
+  labels:
+    name: warnet-logging

--- a/src/templates/rpc/rbac-config.yaml
+++ b/src/templates/rpc/rbac-config.yaml
@@ -5,17 +5,20 @@ metadata:
   name: pod-reader-exec
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "create", "update", "patch", "delete"]
+  resources: [pods]
+  verbs: [get, list, create, update, patch, delete]
 - apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get", "list", "create", "update", "patch", "delete"]
+  resources: [services]
+  verbs: [get, list, create, update, patch, delete]
 - apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create", "get"]
+  resources: [pods/exec]
+  verbs: [create, get]
 - apiGroups: [""]
-  resources: ["pods/log"]  # Granting permission to access pod logs
-  verbs: ["get"]
+  resources: [pods/log]  # Granting permission to access pod logs
+  verbs: [get]
+- apiGroups: [monitoring.coreos.com]
+  resources: [servicemonitors]
+  verbs: [get, list, create, update, patch, delete]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
To test:

```shell
just start(d)
warcli network start
just connectlogging
```

Browse to localhost:3000 (username: admin, password: password)

See that we have Loki and Prometheus data sources already configured and that we have data for Loki and Prometheus. Prometheus bitcoin metrics can take a couple of minutes to appear.