### PR TITLE
Make logging stack optional

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,7 +23,6 @@ start:
     kubectl apply -f src/templates/rpc/rbac-config.yaml
     kubectl apply -f src/templates/rpc/warnet-rpc-service.yaml
     kubectl apply -f src/templates/rpc/warnet-rpc-statefulset-dev.yaml
-    just installlogging
     kubectl config set-context --current --namespace=warnet
 
     echo waiting for rpc to come online
@@ -58,7 +57,6 @@ startd:
     kubectl apply -f src/templates/rpc/rbac-config.yaml
     kubectl apply -f src/templates/rpc/warnet-rpc-service.yaml
     sed 's?/mnt/src?'`PWD`'?g' src/templates/rpc/warnet-rpc-statefulset-dev.yaml | kubectl apply -f -
-    just installlogging
     kubectl config set-context --current --namespace=warnet
 
     echo waiting for rpc to come online

--- a/src/templates/rpc/rbac-config.yaml
+++ b/src/templates/rpc/rbac-config.yaml
@@ -19,6 +19,9 @@ rules:
 - apiGroups: [monitoring.coreos.com]
   resources: [servicemonitors]
   verbs: [get, list, create, update, patch, delete]
+- apiGroups: [apiextensions.k8s.io]
+  resources: [customresourcedefinitions]
+  verbs: [get, list]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -32,4 +35,26 @@ subjects:
 roleRef:
   kind: Role
   name: pod-reader-exec
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-viewer
+rules:
+- apiGroups: [apiextensions.k8s.io]
+  resources: [customresourcedefinitions]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-viewer-binding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: warnet
+roleRef:
+  kind: ClusterRole
+  name: crd-viewer
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Now logging stack will not be created with `just start` and the kubernetes backend will be just fine with that and not install the prometheus exporters.

How to test:

```shell
just stop(d)
k delete crds --all
just start(d)
warcli network start --force
```

Observe that the containers do not have prometheus exporters and everything is happy

```shell
warcli network down
just installlogging
warcli network start --force
just connectlogging
```

Now when you browse to localhost:3000 (admin/password) Loki and prometheus should be present and working.