### PR TITLE
Only collect logs if graph has collect_logs set

### DIFF
--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -538,16 +538,20 @@ class KubernetesBackend(BackendInterface):
         # Create and return a Pod object
         # TODO: pass a custom namespace , e.g. different warnet sims can be deployed into diff namespaces
 
+        labels = {
+            "app": name,
+            "network": tank.warnet.network_name,
+        }
+        if tank.collect_logs:
+            labels.update({"collect_logs": "true"})
+
         return client.V1Pod(
             api_version="v1",
             kind="Pod",
             metadata=client.V1ObjectMeta(
                 name=name,
                 namespace=self.namespace,
-                labels={
-                    "app": name,
-                    "network": tank.warnet.network_name,
-                },
+                labels=labels,
             ),
             spec=client.V1PodSpec(
                 # Might need some more thinking on the pod restart policy, setting to Never for now

--- a/src/templates/k8s/install_logging.sh
+++ b/src/templates/k8s/install_logging.sh
@@ -8,6 +8,6 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 helm upgrade --install --namespace warnet-logging --create-namespace --values "${SCRIPT_DIR}/loki/values.yaml" loki grafana/loki
-helm upgrade --install --namespace warnet-logging promtail grafana/promtail
+helm upgrade --install --namespace warnet-logging promtail grafana/promtail --values "${SCRIPT_DIR}/promtail/values.yaml"
 helm upgrade --install --namespace warnet-logging prometheus prometheus-community/kube-prometheus-stack --namespace warnet-logging --set grafana.enabled=false
 helm upgrade --install --namespace warnet-logging loki-grafana grafana/grafana --values "${SCRIPT_DIR}/grafana/values.yaml"

--- a/src/templates/k8s/promtail/values.yaml
+++ b/src/templates/k8s/promtail/values.yaml
@@ -1,0 +1,45 @@
+config:
+  snippets:
+    scrapeConfigs: |
+      - job_name: tanks
+        pipeline_stages:
+          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
+        kubernetes_sd_configs:
+          - role: pod
+            selectors:
+              - role: pod
+                label: "collect_logs=true"
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_pod_controller_name
+            regex: ([0-9a-z-.]+?)(-[0-9a-f]{8,10})?
+            action: replace
+            target_label: __tmp_controller_name
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_name
+              - __meta_kubernetes_pod_label_app
+              - __tmp_controller_name
+              - __meta_kubernetes_pod_name
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: app
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+              - __meta_kubernetes_pod_label_instance
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: instance
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_component
+              - __meta_kubernetes_pod_label_component
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: component
+          {{- if .Values.config.snippets.addScrapeJobLabel }}
+          - replacement: kubernetes-pods
+            target_label: scrape_job
+          {{- end }}
+          {{- toYaml .Values.config.snippets.common | nindent 4 }}
+          {{- with .Values.config.snippets.extraRelabelConfigs }}
+          {{- toYaml . | nindent 4 }}
+          {{- end }}


### PR DESCRIPTION
How to test:

```shell
just start(d)
just installlogging
warcli network start --force
warcli rpc 2 'logging [\"all\"]'
warcli rpc 7 'logging [\"all\"]'
just connectlogging
```

Browse to `localhost:3000` (admin/password) and explore the loki data source. Using the label explorer, observe that many logs are available for `{pod="warnet-tank-000002"}` but none are available for `{pod="warnet-tank-000007"}` even though both have been set to log everything. This is because tank 02 has collect_logs set to true in it's graph but tank 07 does not.