### PR TITLE
fixup get_messages to use tank indexes

### DIFF
--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -80,9 +80,9 @@ class BackendInterface(ABC):
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
-    def get_messages(self, tank_index: int, b_ipv4: str, bitcoin_network: str = "regtest"):
+    def get_messages(self, a_index: int, b_index: int, bitcoin_network: str = "regtest"):
         """
-        Get bitcoin messages between containers [tank_index] and [b_ipv4] on [bitcoin_network]
+        Get bitcoin messages between containers [a_index] and [b_index] on [bitcoin_network]
         """
         raise NotImplementedError("This method should be overridden by child class")
 

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -501,3 +501,10 @@ class ComposeBackend(BackendInterface):
             tank.lnnode = LNNode(warnet, tank, labels["lnnode_impl"], self)
             tank.lnnode.ipv4 = labels.get("lnnode_ipv4_address")
         return tank
+
+    def get_ipv4_address(self, container: Container) -> str:
+        """
+        Fetches the IPv4 address of a given container.
+        """
+        container_inspect = self.client.containers.get(container.id).attrs
+        return container_inspect['NetworkSettings']['Networks'][self.network_name]['IPAddress']

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -202,7 +202,7 @@ class Server:
             messages = [
                 msg
                 for msg in wn.container_interface.get_messages(
-                    wn.tanks[node_a].index, wn.tanks[node_b].ipv4, wn.bitcoin_network
+                    wn.tanks[node_a].index, wn.tanks[node_b].index, wn.bitcoin_network
                 )
                 if msg is not None
             ]

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -36,4 +36,7 @@ count = all_logs.count("Enqueuing TransactionAddedToMempool")
 # should be at least more than one node
 assert count > 1
 
+msgs = base.warcli("messages 0 1")
+assert "verack" in msgs
+
 base.stop_server()


### PR DESCRIPTION
Adds a (compose) get_ipv4_address func and then switches up `get_messages()` to use two tank indexes, rather than an ipv4 address.

Also fixup k8s `get_file()` while we're here and need to use it.