### PR TITLE
server: make all connections with addnode

### DIFF
--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -107,3 +107,10 @@ class BackendInterface(ABC):
         Rebuild a warnet object from an active deployment
         """
         raise NotImplementedError("This method should be overridden by child class")
+
+    @abstractmethod
+    def wait_for_healthy_tanks(self, warnet, timeout=60) -> bool:
+        """
+        Wait for healthy status on all bitcoind nodes
+        """
+        raise NotImplementedError("This method should be overridden by child class")

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -49,7 +49,8 @@ class ComposeBackend(BackendInterface):
     def __init__(self, config_dir: Path, network_name: str) -> None:
         super().__init__(config_dir)
         self.network_name = network_name
-        self.client = docker.DockerClient = docker.from_env()
+        self.client: docker.DockerClient = docker.from_env()
+        self._apiclient: docker.APIClient = docker.APIClient(base_url='unix://var/run/docker.sock')
 
     def build(self) -> bool:
         command = ["docker", "compose", "build"]

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -391,7 +391,7 @@ class ComposeBackend(BackendInterface):
                 "privileged": True,
                 "cap_add": ["NET_ADMIN", "NET_RAW"],
                 "healthcheck": {
-                    "test": ["CMD", "pidof", "bitcoind"],
+                    "test": ["CMD-SHELL", f"nc -z localhost {tank.rpc_port} || exit 1"],
                     "interval": "10s",  # Check every 10 seconds
                     "timeout": "1s",  # Give the check 1 second to complete
                     "start_period": "5s",  # Start checking after 5 seconds

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -532,3 +532,16 @@ class ComposeBackend(BackendInterface):
 
         return status[0] == "healthy" and all(i == status[0] for i in status)
 
+    def wait_for_healthy_tanks(self, warnet, timeout=60) -> bool:
+        start = time.time()
+        healthy = False
+        logger.debug("Waiting for all tanks to reach healthy")
+
+        while not healthy and (time.time() < start + timeout):
+            healthy = self.check_health_all_bitcoind(warnet)
+            time.sleep(2)
+
+        if not healthy:
+            raise Exception(f"Tanks did not reach healthy status in {timeout} seconds")
+
+        return healthy

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -703,3 +703,9 @@ class KubernetesBackend(BackendInterface):
                 yaml.dump(pod.to_dict(), f)
                 f.write("---\n")  # separator for multiple resources
             self.log.info("Pod definitions saved to warnet-tanks.yaml")
+
+    def wait_for_healthy_tanks(self, warnet, timeout=30):
+        """
+        Wait for healthy status on all bitcoind nodes
+        """
+        pass

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -351,6 +351,7 @@ class Server:
                 # Update warnet from docker here to get ip addresses
                 wn = Warnet.from_network(network, self.backend)
                 wn.apply_network_conditions()
+                wn.wait_for_health()
                 wn.connect_edges()
                 self.logger.info(
                     f"Resumed warnet named '{network}' from config dir {wn.config_dir}"
@@ -384,6 +385,7 @@ class Server:
                     # wn.write_fork_observer_config()
                     wn.warnet_build()
                     wn.warnet_up()
+                    wn.wait_for_health()
                     wn.apply_network_conditions()
                     wn.connect_edges()
                 except Exception as e:

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -372,34 +372,6 @@ def remove_version_prefix(version_str):
     return version_str
 
 
-def version_cmp_ge(version_str, target_str):
-    parsed_version_str = remove_version_prefix(version_str)
-    parsed_target_str = remove_version_prefix(target_str)
-
-    try:
-        version_parts = list(map(int, parsed_version_str.split(".")))
-        target_parts = list(map(int, parsed_target_str.split(".")))
-
-        # Pad the shorter version with zeros
-        while len(version_parts) < len(target_parts):
-            version_parts.append(0)
-        while len(target_parts) < len(version_parts):
-            target_parts.append(0)
-
-    # handle custom versions
-    except ValueError:
-        logger.debug(
-            ValueError(
-                f"Unknown version string: {version_str} or {target_str} could not be compared"
-            )
-        )
-        logger.debug("Assuming custom version can use `addpeeraddress`")
-        # assume that custom versions are recent
-        return True
-
-    return version_parts >= target_parts
-
-
 def set_execute_permission(file_path):
     current_permissions = os.stat(file_path).st_mode
     os.chmod(file_path, current_permissions | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -224,3 +224,6 @@ class Warnet:
         config_path = os.path.join(subdir, "sim.json")
         with open(config_path, "a") as f:
             json.dump(config, f)
+
+    def wait_for_health(self):
+        self.container_interface.wait_for_healthy_tanks(self)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -13,7 +13,7 @@ import networkx
 from backends import ComposeBackend, KubernetesBackend
 from templates import TEMPLATES
 from warnet.tank import Tank
-from warnet.utils import gen_config_dir, version_cmp_ge
+from warnet.utils import gen_config_dir
 
 logger = logging.getLogger("warnet")
 FO_CONF_NAME = "fork_observer_config.toml"
@@ -172,14 +172,8 @@ class Warnet:
                 continue
             src_tank = self.tanks[src]
             dst_ip = self.tanks[dst].ipv4
-            # <= 20.2 doesn't have addpeeraddress
-            res = version_cmp_ge(src_tank.version, "0.21.0")
-            if res:
-                cmd = f"bitcoin-cli -regtest -rpcuser={src_tank.rpc_user} -rpcpassword={src_tank.rpc_password} addpeeraddress {dst_ip} 18444"
-                logger.info(f"Using `{cmd}` to connect tanks {src} to {dst}")
-            else:
-                cmd = f'bitcoin-cli -regtest -rpcuser={src_tank.rpc_user} -rpcpassword={src_tank.rpc_password} addnode "{dst_ip}:18444" onetry'
-                logger.info(f"Using `{cmd}` to connect tanks {src} to {dst}")
+            cmd = f"bitcoin-cli -regtest -rpcuser={src_tank.rpc_user} -rpcpassword={src_tank.rpc_password} addnode {dst_ip}:18444 onetry"
+            logger.info(f"Using `{cmd}` to connect tanks {src} to {dst}")
             src_tank.exec(cmd=cmd)
 
     def warnet_build(self):


### PR DESCRIPTION
using `addpeeraddress` sounds better, but it does not guarantee that all nodes have connections made to them in the end. This causes issues on large graphs. We have observed on n=100 graphs, often there exist ~5 nodes which end up with no connections.

First, add a more accurate healthcheck for compose backend, which will not return true until `bitcoind` RPC server is listening.

Next add a wait for healthy to startup, on k8s this is currently inactive (although notable k8s does use a "port listen" healthcheck already).

Finally remove the `addpeeraddress` connection type.