### PR TITLE
Replace connect_edges() with bitcoind -addnode args 

### DIFF
--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -352,6 +352,9 @@ class ComposeBackend(BackendInterface):
         defaults += f" -rpcport={tank.rpc_port}"
         defaults += f" -zmqpubrawblock=tcp://0.0.0.0:{tank.zmqblockport}"
         defaults += f" -zmqpubrawtx=tcp://0.0.0.0:{tank.zmqtxport}"
+        # connect to initial peers as defined in graph file
+        for dst_index in tank.init_peers:
+            defaults += f" -addnode={self.get_container_name(dst_index, ServiceType.BITCOIN)}"
         return defaults
 
     def copy_configs(self, tank):

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -306,6 +306,9 @@ class KubernetesBackend(BackendInterface):
         defaults += f" -rpcport={tank.rpc_port}"
         defaults += f" -zmqpubrawblock=tcp://0.0.0.0:{tank.zmqblockport}"
         defaults += f" -zmqpubrawtx=tcp://0.0.0.0:{tank.zmqtxport}"
+        # connect to initial peers as defined in graph file
+        for dst_index in tank.init_peers:
+            defaults += f" -addnode={self.get_service_name(dst_index)}"
         return defaults
 
     def create_bitcoind_container(self, tank: Tank) -> client.V1Container:

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -12,6 +12,7 @@ from kubernetes import client, config
 from kubernetes.client.models.v1_pod import V1Pod
 from kubernetes.client.rest import ApiException
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from kubernetes.stream import stream
 from warnet.status import RunningStatus
 from warnet.tank import Tank
@@ -431,9 +432,8 @@ class KubernetesBackend(BackendInterface):
                     name=f"warnet-tank-{tank.index:06d}",
                     namespace=MAIN_NAMESPACE,
                 )
-            except ApiException as e:
-                if e.status != 404:
-                    raise e
+            except ResourceNotFoundError:
+                continue
 
     def create_lnd_container(self, tank, bitcoind_service_name) -> client.V1Container:
         # These args are appended to the Dockerfile `ENTRYPOINT ["lnd"]`

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -532,7 +532,7 @@ class KubernetesBackend(BackendInterface):
                 selector={"app": self.get_pod_name(tank.index, ServiceType.BITCOIN)},
                 publish_not_ready_addresses=True,
                 ports=[
-                    # TODO: do we need to add 18444 here too?
+                    client.V1ServicePort(port=18444, target_port=18444, name="p2p"),
                     client.V1ServicePort(port=tank.rpc_port, target_port=tank.rpc_port, name="rpc"),
                     client.V1ServicePort(
                         port=tank.zmqblockport, target_port=tank.zmqblockport, name="zmqblock"

--- a/src/cli/network.py
+++ b/src/cli/network.py
@@ -129,7 +129,6 @@ def status(network: str):
 
 @network.command()
 @click.option("--network", default="warnet", show_default=True)
-@click.argument("threshold", type=int)
 def connected(network: str):
     """
     Indicate whether the all of the edges in the gaph file are connected in <network>

--- a/src/cli/network.py
+++ b/src/cli/network.py
@@ -129,6 +129,16 @@ def status(network: str):
 
 @network.command()
 @click.option("--network", default="warnet", show_default=True)
+@click.argument("threshold", type=int)
+def connected(network: str):
+    """
+    Indicate whether the all of the edges in the gaph file are connected in <network>
+    """
+    print(rpc_call("network_connected", {"network": network}))
+
+
+@network.command()
+@click.option("--network", default="warnet", show_default=True)
 def export(network):
     """
     Export all data for sim-ln to subdirectory

--- a/src/scenarios/miner_std.py
+++ b/src/scenarios/miner_std.py
@@ -31,6 +31,9 @@ class MinerStd(WarnetTestFramework):
         )
 
     def run_test(self):
+        while not self.warnet.network_connected():
+            sleep(1)
+
         current_miner = 0
 
         while True:

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -437,7 +437,6 @@ class Server:
                 wn = Warnet.from_network(network, self.backend)
                 wn.apply_network_conditions()
                 wn.wait_for_health()
-                wn.connect_edges()
                 self.logger.info(
                     f"Resumed warnet named '{network}' from config dir {wn.config_dir}"
                 )
@@ -472,7 +471,6 @@ class Server:
                     wn.warnet_up()
                     wn.wait_for_health()
                     wn.apply_network_conditions()
-                    wn.connect_edges()
                 except Exception as e:
                     trace = traceback.format_exc()
                     self.logger.error(f"Unhandled exception starting warnet: {e}\n{trace}")

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -14,7 +14,6 @@ import time
 import traceback
 from datetime import datetime
 from io import BytesIO
-from json import loads
 from logging import StreamHandler
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -570,24 +569,13 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
-
     def network_connected(self, network: str = "warnet") -> bool:
         """
-        Indicate whether the <threshold> of graph edges is connected in <network>
+        Indicate whether all of the graph edges are connected in <network>
         """
         try:
             wn = Warnet.from_network(network, self.backend)
-            for tank in wn.tanks:
-                peerinfo = loads(wn.container_interface.get_bitcoin_cli(tank, "getpeerinfo"))
-                manuals = 0
-                for peer in peerinfo:
-                    if peer["connection_type"] == "manual":
-                        manuals += 1
-                # Even if more edges are specifed, bitcoind only allows
-                # 8 manual outbound connections
-                if min(8, len(tank.init_peers)) > manuals:
-                    return False
-            return True
+            return wn.network_connected()
         except Exception as e:
             self.logger.error(f"{e}")
             return False

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -47,6 +47,9 @@ class Tank:
         self._suffix = None
         self._ipv4 = None
         self._exporter_name = None
+        # index of integers imported from graph file
+        # indicating which tanks to initially connect to
+        self.init_peers = []
 
     def __str__(self) -> str:
         return f"Tank(index: {self.index}, version: {self.version}, conf: {self.bitcoin_config}, conf file: {self.conf_file}, netem: {self.netem}, IPv4: {self._ipv4})"

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -410,17 +410,17 @@ def create_cycle_graph(
 
     # Graph is a simply cycle graph with all nodes connected in a loop, including both ends.
     # Ensure each node has at least 8 outbound connections by making 7 more outbound connections
-    for node in graph.nodes():
-        logger.debug(f"Creating additional connections for node {node}")
+    for src_node in graph.nodes():
+        logger.debug(f"Creating additional connections for node {src_node}")
         for _ in range(8):
             # Choose a random node to connect to
-            # Make sure it's not the same node and they aren't already connected
-            potential_nodes = [ node for node in range(n) if n != node and not graph.has_edge(node, n) ]
+            # Make sure it's not the same node and they aren't already connected in either direction
+            potential_nodes = [ dst_node for dst_node in range(n) if dst_node != src_node and not graph.has_edge(dst_node, src_node) and not graph.has_edge(src_node, dst_node) ]
             if potential_nodes:
                 chosen_node = random.choice(potential_nodes)
-                graph.add_edge(node, chosen_node)
-                logger.debug(f"Added edge: {node}:{chosen_node}")
-        logger.debug(f"Node {node} edges: {graph.edges(node)}")
+                graph.add_edge(src_node, chosen_node)
+                logger.debug(f"Added edge: {src_node}:{chosen_node}")
+        logger.debug(f"Node {src_node} edges: {graph.edges(src_node)}")
 
     # calculate degree
     degree_dict = dict(graph.degree(graph.nodes()))

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -221,3 +221,16 @@ class Warnet:
 
     def wait_for_health(self):
         self.container_interface.wait_for_healthy_tanks(self)
+
+    def network_connected(self):
+        for tank in self.tanks:
+            peerinfo = json.loads(self.container_interface.get_bitcoin_cli(tank, "getpeerinfo"))
+            manuals = 0
+            for peer in peerinfo:
+                if peer["connection_type"] == "manual":
+                    manuals += 1
+            # Even if more edges are specifed, bitcoind only allows
+            # 8 manual outbound connections
+            if min(8, len(tank.init_peers)) > manuals:
+                return False
+        return True

--- a/test/build_branch_test.py
+++ b/test/build_branch_test.py
@@ -12,6 +12,7 @@ base = TestBase()
 base.start_server()
 print(base.warcli(f"network start {graph_file_path}"))
 base.wait_for_all_tanks_status(target="running", timeout=10*60)
+base.wait_for_all_edges()
 
 print("\nWait for p2p connections")
 

--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -30,6 +30,7 @@ with tempfile.TemporaryDirectory() as dir:
     # Test that the graph actually works
     print(base.warcli(f"network start {Path(tf)}"))
     base.wait_for_all_tanks_status(target="running")
+    base.wait_for_all_edges()
     base.warcli("rpc 0 getblockcount")
 
 base.stop_server()

--- a/test/ln_test.py
+++ b/test/ln_test.py
@@ -12,7 +12,7 @@ base = TestBase()
 base.start_server()
 print(base.warcli(f"network start {graph_file_path}"))
 base.wait_for_all_tanks_status(target="running")
-
+base.wait_for_all_edges()
 
 if base.backend != "compose":
     print("\nSkipping network export test, only supported with compose backend")

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -11,6 +11,7 @@ base = TestBase()
 base.start_server()
 print(base.warcli(f"network start {graph_file_path}"))
 base.wait_for_all_tanks_status(target="running")
+base.wait_for_all_edges()
 
 # Exponential backoff will repeat this command until it succeeds.
 # That's when we are ready for commands

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -11,15 +11,10 @@ base = TestBase()
 base.start_server()
 print(base.warcli(f"network start {graph_file_path}"))
 base.wait_for_all_tanks_status(target="running")
-base.wait_for_all_edges()
 
 # Use rpc instead of warcli so we get raw JSON object
 scenarios = base.rpc("scenarios_available")
 assert len(scenarios) == 4
-
-# Exponential backoff will repeat this command until it succeeds.
-# That's when we are ready for scenarios
-base.warcli("rpc 0 getblockcount")
 
 # Start scenario
 base.warcli("scenarios run miner_std --allnodes --interval=1")

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -11,6 +11,7 @@ base = TestBase()
 base.start_server()
 print(base.warcli(f"network start {graph_file_path}"))
 base.wait_for_all_tanks_status(target="running")
+base.wait_for_all_edges()
 
 # Use rpc instead of warcli so we get raw JSON object
 scenarios = base.rpc("scenarios_available")

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -181,6 +181,13 @@ class TestBase:
 
         self.wait_for_predicate(check_status, timeout, interval)
 
+    # Ensure all tanks have all the connections they are supposed to have
+    # Block until all success
+    def wait_for_all_edges(self, timeout=20 * 60, interval=5):
+        def check_status():
+            return self.wait_for_rpc("network_connected", {"network": self.network_name})
+        self.wait_for_predicate(check_status, timeout, interval)
+
     def wait_for_all_scenarios(self):
         def check_scenarios():
             scns = self.rpc("scenarios_list_running")

--- a/test/v25_net_test.py
+++ b/test/v25_net_test.py
@@ -12,6 +12,7 @@ base = TestBase()
 base.start_server()
 print(base.warcli(f"network start {graph_file_path}"))
 base.wait_for_all_tanks_status(target="running")
+base.wait_for_all_edges()
 
 onion_addr = None
 


### PR DESCRIPTION
Goal:

Replace `connect_edges()` which was slow with `-addnode=...` args passed to bitcoind at startup

Method:

Add `init_peers` list to `Tank` objects which contains destination tank indexes imported from the graph file.

Requires:

- Since we don't know any tank IP addresses before we start up a network (especially in Kubernetes) we need to pass internal-network domain names to `addnode` instead.
- Since `connect_edges()` was also blocking, a new rpc is added and used in tests to determine if all expected graph edges have been established. The command is `warcli network connected` and it only ever returns `true` or `false`. Right now it checks that the number of `tank.init_peers` equals the number of bitcoin peers connected with type `"manual"`. As discussed, this RPC can be softened in a follow-up PR to accept some kind of threshold argument.

Fixes:
- In Kubernetes the *service* name is how we connect to bitcoin peers so the services need to forward the regtest p2p port 18444.
- This also means that internally each peer apparently has two IP addresses (the bitcoind container IP which may be unreliable and the service IP which is always resolved by the service name). So far I think the only problem with the 2-IPs thing is how we retrieve p2p messages with `warcli messages <a> <b>`, but we should also be aware in the future of connecting twice to the same node.
- During shutdown I noticed we did not handle missing prometheus exporters well because that method uses a different client with a different error type. Probably has just not been an issue before because the exporters were always there during shutdown. I'm not sure why that would be different now unless it has to do with tests running faster?
- `graph_generate` was adding edges to the graph that already existed in the opposite direction. That was breaking the `connect_edges` check since bitcoind would never actually make that connection

