### PR TITLE
Allow custom LN images

### DIFF
--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -443,7 +443,7 @@ class ComposeBackend(BackendInterface):
         ]
         services[ln_container_name] = {
             "container_name": ln_container_name,
-            "image": "lightninglabs/lnd:v0.17.0-beta",
+            "image": tank.lnnode.image,
             "command": " ".join(args),
             "networks": {
                 tank.network_name: {
@@ -464,6 +464,7 @@ class ComposeBackend(BackendInterface):
                     "lnnode_container_name": ln_container_name,
                     "lnnode_ipv4_address": tank.lnnode.ipv4,
                     "lnnode_impl": tank.lnnode.impl,
+                    "lnnode_image": tank.lnnode.image,
                 }
             }
         )
@@ -502,7 +503,7 @@ class ComposeBackend(BackendInterface):
 
         labels = service.get("labels", {})
         if "lnnode_impl" in labels:
-            tank.lnnode = LNNode(warnet, tank, labels["lnnode_impl"], self)
+            tank.lnnode = LNNode(warnet, tank, labels["lnnode_impl"], labels["lnnode_image"], self)
             tank.lnnode.ipv4 = labels.get("lnnode_ipv4_address")
         return tank
 

--- a/src/templates/node_schema.json
+++ b/src/templates/node_schema.json
@@ -11,7 +11,8 @@
     "exporter": {"type": "boolean", "default": false},
     "collect_logs": {"type": "boolean", "default": false},
     "build_args": {"type": "string"},
-    "ln": {"type": "string"}
+    "ln": {"type": "string"},
+    "ln-image": {"type": "string"}
   },
   "additionalProperties": false,
   "oneOf": [

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -7,11 +7,14 @@ from .status import RunningStatus
 
 
 class LNNode:
-    def __init__(self, warnet, tank, impl, backend: BackendInterface):
+    def __init__(self, warnet, tank, impl, image, backend: BackendInterface):
         self.warnet = warnet
         self.tank = tank
         assert impl == "lnd"
         self.impl = impl
+        self.image = "lightninglabs/lnd:v0.17.0-beta"
+        if image:
+            self.image = image
         self.backend = backend
         self.ipv4 = generate_ipv4_addr(self.warnet.subnet)
         self.rpc_port = 10009

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -73,7 +73,9 @@ class Tank:
 
         # Special handling for complex properties
         if "ln" in node:
-            self.lnnode = LNNode(self.warnet, self, node["ln"], self.warnet.container_interface)
+            impl = node["ln"]
+            image = node.get("ln-image", None)
+            self.lnnode = LNNode(self.warnet, self, impl, image, self.warnet.container_interface)
 
         self.config_dir = self.warnet.config_dir / str(self.suffix)
         self.config_dir.mkdir(parents=True, exist_ok=True)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -41,14 +41,15 @@ class Warnet:
     def __str__(self) -> str:
         # TODO: bitcoin_conf and tc_netem can be added back in to this table
         #       if we write a helper function that can text-wrap inside a column
-        template = "\t" + "%-8.8s" + "%-25.24s" + "%-18.18s" + "%-18.18s" + "%-18.18s" + "\n"
-        tanks_str = template % ("Index", "Version", "IPv4", "LN", "LN IPv4")
+        template = "\t" + "%-8.8s" + "%-25.24s" + "%-18.18s" + "%-18.18s" + "%-18.18s" + "%-18.18s" + "\n"
+        tanks_str = template % ("Index", "Version", "IPv4", "LN", "LN Image", "LN IPv4")
         for tank in self.tanks:
             tanks_str += template % (
                 tank.index,
                 tank.version,
                 tank.ipv4,
                 tank.lnnode.impl if tank.lnnode is not None else None,
+                tank.lnnode.image if tank.lnnode is not None else None,
                 tank.lnnode.ipv4 if tank.lnnode is not None else None,
             )
         return (
@@ -82,7 +83,7 @@ class Warnet:
         ]
 
         # Tanks
-        tank_headers = ["Index", "Version", "IPv4", "bitcoin conf", "tc_netem", "LN", "LN IPv4"]
+        tank_headers = ["Index", "Version", "IPv4", "bitcoin conf", "tc_netem", "LN", "LN Image", "LN IPv4"]
         has_ln = any(tank.lnnode and tank.lnnode.impl for tank in self.tanks)
         tanks = []
         for tank in self.tanks:
@@ -91,6 +92,7 @@ class Warnet:
                 tank_data.extend(
                     [
                         tank.lnnode.impl if tank.lnnode else "",
+                        tank.lnnode.image if tank.lnnode else "",
                         tank.lnnode.ipv4 if tank.lnnode else "",
                     ]
                 )

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -3,6 +3,7 @@
   <key attr.name="bitcoin_config" attr.type="string" for="node" id="bitcoin_config"/>
   <key attr.name="tc_netem"       attr.type="string" for="node" id="tc_netem"/>
   <key attr.name="ln"             attr.type="string" for="node" id="ln"/>
+  <key attr.name="ln-image"       attr.type="string" for="node" id="ln-image"/>
   <key attr.name="channel"        attr.type="string" for="edge" id="channel"/>
   <key attr.name="collect_logs"   attr.type="boolean" for="node" id="collect_logs"/>
   <key attr.name="image"          attr.type="string" for="node" id="image"/>
@@ -17,6 +18,7 @@
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w1</data>
         <data key="ln">lnd</data>
+        <data key="ln-image">lightninglabs/lnd:v0.15.5-beta</data>
         <data key="collect_logs">true</data>
     </node>
     <node id="2">


### PR DESCRIPTION
Closes https://github.com/bitcoin-dev-project/warnet/issues/226

Adds to the graphml schema a new data element for tanks: `ln-image`.
If the element `ln` is missing, then `ln-image` is ignored and the tank will not get an ln node.
If `ln-image` is missing, the current default value (set in lnnode.py) is `"lightninglabs/lnd:v0.17.0-beta"`

Example of two tanks, one using the default image and the other specifying v15.5



```
    <node id="0">
        <data key="version">26.0</data>
        <data key="bitcoin_config">-uacomment=w0</data>
        <data key="ln">lnd</data>
        <data key="collect_logs">true</data>
    </node>
    <node id="1">
        <data key="version">26.0</data>
        <data key="bitcoin_config">-uacomment=w1</data>
        <data key="ln">lnd</data>
        <data key="ln-image">lightninglabs/lnd:v0.15.5-beta</data>
        <data key="collect_logs">true</data>
    </node>
```