### PR TITLE
Add circuitbreaker to lnd

### DIFF
--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -6,6 +6,7 @@ from pathlib import Path
 class ServiceType(Enum):
     BITCOIN = 1
     LIGHTNING = 2
+    CIRCUITBREAKER = 3
 
 
 class BackendInterface(ABC):

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -93,7 +93,7 @@ class ComposeBackend(BackendInterface):
             )
 
     def down(self, warnet):
-        command = ["docker", "compose", "down"]
+        command = ["docker", "compose", "down", "-v"]
         try:
             with subprocess.Popen(
                 command,
@@ -101,7 +101,7 @@ class ComposeBackend(BackendInterface):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             ) as process:
-                logger.debug(f"Running docker compose down with PID {process.pid}")
+                logger.debug(f"Running 'docker compose down -v' with PID {process.pid}")
                 if process.stdout:
                     for line in process.stdout:
                         logger.info(line.decode().rstrip())

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -23,8 +23,10 @@ LOCAL_REGISTRY = "warnet/bitcoin-core"
 POD_PREFIX = "tank"
 BITCOIN_CONTAINER_NAME = "bitcoin"
 LN_CONTAINER_NAME = "ln"
+LN_CB_CONTAINER_NAME = "ln-cb"
 MAIN_NAMESPACE = "warnet"
 PROMETHEUS_METRICS_PORT = 9332
+LND_MOUNT_PATH = '/root/.lnd'
 
 
 logger = logging.getLogger("KubernetesBackend")
@@ -432,7 +434,7 @@ class KubernetesBackend(BackendInterface):
                 if e.status != 404:
                     raise e
 
-    def create_lnd_container(self, tank, bitcoind_service_name) -> client.V1Container:
+    def create_lnd_container(self, tank, bitcoind_service_name, volume_mounts) -> client.V1Container:
         # These args are appended to the Dockerfile `ENTRYPOINT ["lnd"]`
         bitcoind_rpc_host = f"{bitcoind_service_name}.{self.namespace}"
         lightning_dns = f"lightning-{tank.index}.{self.namespace}"
@@ -475,12 +477,33 @@ class KubernetesBackend(BackendInterface):
                 privileged=True,
                 capabilities=client.V1Capabilities(add=["NET_ADMIN", "NET_RAW"]),
             ),
+            volume_mounts=volume_mounts,
         )
         self.log.debug(f"Created lightning container for tank {tank.index}")
         return lightning_container
 
+    def create_circuitbreaker_container(self, tank, volume_mounts) -> client.V1Container:
+        self.log.debug(f"Creating circuitbreaker container for tank {tank.index}")
+        cb_container = client.V1Container(
+            name=LN_CB_CONTAINER_NAME,
+            image=tank.lnnode.cb,
+            args=[
+                "--network=regtest",
+                f"--rpcserver=localhost:{tank.lnnode.rpc_port}",
+                f"--tlscertpath={LND_MOUNT_PATH}/tls.cert",
+                f"--macaroonpath={LND_MOUNT_PATH}/data/chain/bitcoin/regtest/admin.macaroon"
+            ],
+            security_context=client.V1SecurityContext(
+                privileged=True,
+                capabilities=client.V1Capabilities(add=["NET_ADMIN", "NET_RAW"]),
+            ),
+            volume_mounts=volume_mounts,
+        )
+        self.log.debug(f"Created circuitbreaker container for tank {tank.index}")
+        return cb_container
+
     def create_pod_object(
-        self, tank: Tank, container: client.V1Container, name: str
+        self, tank: Tank, containers: list[client.V1Container], volumes: list[client.V1Volume], name: str
     ) -> client.V1Pod:
         # Create and return a Pod object
         # TODO: pass a custom namespace , e.g. different warnet sims can be deployed into diff namespaces
@@ -500,7 +523,8 @@ class KubernetesBackend(BackendInterface):
                 # Might need some more thinking on the pod restart policy, setting to Never for now
                 # This means if a node has a problem it dies
                 restart_policy="OnFailure",
-                containers=[container],
+                containers=containers,
+                volumes=volumes,
             ),
         )
 
@@ -588,7 +612,7 @@ class KubernetesBackend(BackendInterface):
             # Create and deploy bitcoind pod and service
             bitcoind_container = self.create_bitcoind_container(tank)
             bitcoind_pod = self.create_pod_object(
-                tank, bitcoind_container, self.get_pod_name(tank.index, ServiceType.BITCOIN)
+                tank, [bitcoind_container], [], self.get_pod_name(tank.index, ServiceType.BITCOIN)
             )
 
             if tank.exporter and self.check_logging_crds_installed():
@@ -609,11 +633,30 @@ class KubernetesBackend(BackendInterface):
 
             # Create and deploy LND pod
             if tank.lnnode:
-                lnd_container = self.create_lnd_container(tank, bitcoind_service.metadata.name)
+                conts = []
+                vols = []
+                volume_mounts = []
+                if tank.lnnode.cb:
+                    # Create a shared volume between containers in the pod
+                    volume_name = f"ln-cb-data-{tank.index}"
+                    vols.append(client.V1Volume(
+                        name=volume_name,
+                        empty_dir=client.V1EmptyDirVolumeSource()
+                    ))
+                    volume_mounts.append(client.V1VolumeMount(
+                        name=volume_name,
+                        mount_path=LND_MOUNT_PATH,
+                    ))
+                    # Add circuit breaker container
+                    conts.append(self.create_circuitbreaker_container(tank, volume_mounts))
+                # Add lnd container
+                conts.append(self.create_lnd_container(tank, bitcoind_service.metadata.name, volume_mounts))
+                # Put it all together in a pod
                 lnd_pod = self.create_pod_object(
-                    tank, lnd_container, self.get_pod_name(tank.index, ServiceType.LIGHTNING)
+                    tank, conts, vols, self.get_pod_name(tank.index, ServiceType.LIGHTNING)
                 )
                 self.client.create_namespaced_pod(namespace=self.namespace, body=lnd_pod)
+                # Create service for the pod
                 lightning_service = self.create_lightning_service(tank)
                 try:
                     self.client.delete_namespaced_service(

--- a/src/cli/network.py
+++ b/src/cli/network.py
@@ -122,9 +122,12 @@ def status(network: str):
     assert isinstance(result, list), "Result is not a list"  # Make mypy happy
     for tank in result:
         lightning_status = ""
+        circuitbreaker_status = ""
         if "lightning_status" in tank:
             lightning_status = f"\tLightning: {tank['lightning_status']}"
-        print(f"Tank: {tank['tank_index']} \tBitcoin: {tank['bitcoin_status']}{lightning_status}")
+        if "circuitbreaker_status" in tank:
+            circuitbreaker_status = f"\tCircuit Breaker: {tank['circuitbreaker_status']}"
+        print(f"Tank: {tank['tank_index']} \tBitcoin: {tank['bitcoin_status']}{lightning_status}{circuitbreaker_status}")
 
 
 @network.command()

--- a/src/templates/node_schema.json
+++ b/src/templates/node_schema.json
@@ -12,7 +12,8 @@
     "collect_logs": {"type": "boolean", "default": false},
     "build_args": {"type": "string"},
     "ln": {"type": "string"},
-    "ln-image": {"type": "string"}
+    "ln-image": {"type": "string"},
+    "ln-cb-image": {"type": "string"}
   },
   "additionalProperties": false,
   "oneOf": [

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -27,6 +27,12 @@ class LNNode:
     def status(self) -> RunningStatus:
         return self.warnet.container_interface.get_status(self.tank.index, ServiceType.LIGHTNING)
 
+    @property
+    def cb_status(self) -> RunningStatus:
+        if not self.cb:
+            return None
+        return self.warnet.container_interface.get_status(self.tank.index, ServiceType.CIRCUITBREAKER)
+
     @exponential_backoff(max_retries=20, max_delay=300)
     @handle_json
     def lncli(self, cmd) -> dict:

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -7,7 +7,7 @@ from .status import RunningStatus
 
 
 class LNNode:
-    def __init__(self, warnet, tank, impl, image, backend: BackendInterface):
+    def __init__(self, warnet, tank, impl, image, backend: BackendInterface, cb=None):
         self.warnet = warnet
         self.tank = tank
         assert impl == "lnd"
@@ -16,6 +16,7 @@ class LNNode:
         if image:
             self.image = image
         self.backend = backend
+        self.cb = cb
         self.ipv4 = generate_ipv4_addr(self.warnet.subnet)
         self.rpc_port = 10009
 

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -565,6 +565,8 @@ class Server:
                 status = {"tank_index": tank.index, "bitcoin_status": tank.status.name.lower()}
                 if tank.lnnode is not None:
                     status["lightning_status"] = tank.lnnode.status.name.lower()
+                    if tank.lnnode.cb is not None:
+                        status["circuitbreaker_status"] = tank.lnnode.cb_status.name.lower()
                 stats.append(status)
             return stats
         except Exception as e:

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import jsonschema
 import networkx as nx
 import scenarios
+from backends import ServiceType
 from flask import Flask, jsonify, request
 from flask_jsonrpc.app import JSONRPC
 from flask_jsonrpc.exceptions import ServerError
@@ -180,6 +181,7 @@ class Server:
         self.jsonrpc.register(self.graph_validate)
         # Debug
         self.jsonrpc.register(self.generate_deployment)
+        self.jsonrpc.register(self.exec_run)
         # Server
         self.jsonrpc.register(self.server_stop)
         # Logs
@@ -611,6 +613,14 @@ class Server:
             msg = f"Error grepping logs using pattern {pattern}: {e}"
             self.logger.error(msg)
             raise ServerError(message=msg) from e
+
+    def exec_run(self, index: int, service_type: int, cmd: str, network: str = "warnet") -> str:
+        """
+        Execute an arbitrary command in an arbitrary container,
+        identified by tank index and ServiceType
+        """
+        wn = Warnet.from_network(network, self.backend)
+        return wn.container_interface.exec_run(index, ServiceType(service_type), cmd)
 
 
 def run_server():

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -75,7 +75,8 @@ class Tank:
         if "ln" in node:
             impl = node["ln"]
             image = node.get("ln-image", None)
-            self.lnnode = LNNode(self.warnet, self, impl, image, self.warnet.container_interface)
+            cb_image = node.get("ln-cb-image", None)
+            self.lnnode = LNNode(self.warnet, self, impl, image, self.warnet.container_interface, cb_image)
 
         self.config_dir = self.warnet.config_dir / str(self.suffix)
         self.config_dir.mkdir(parents=True, exist_ok=True)

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -4,6 +4,7 @@
   <key attr.name="tc_netem"       attr.type="string" for="node" id="tc_netem"/>
   <key attr.name="ln"             attr.type="string" for="node" id="ln"/>
   <key attr.name="ln-image"       attr.type="string" for="node" id="ln-image"/>
+  <key attr.name="ln-cb-image"    attr.type="string" for="node" id="ln-cb-image"/>
   <key attr.name="channel"        attr.type="string" for="edge" id="channel"/>
   <key attr.name="collect_logs"   attr.type="boolean" for="node" id="collect_logs"/>
   <key attr.name="image"          attr.type="string" for="node" id="image"/>
@@ -19,12 +20,14 @@
         <data key="bitcoin_config">-uacomment=w1</data>
         <data key="ln">lnd</data>
         <data key="ln-image">lightninglabs/lnd:v0.15.5-beta</data>
+        <data key="ln-cb-image">carlakirkcohen/circuitbreaker:endorsement-experiment</data>
         <data key="collect_logs">true</data>
     </node>
     <node id="2">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w2</data>
         <data key="ln">lnd</data>
+        <data key="ln-cb-image">carlakirkcohen/circuitbreaker:endorsement-experiment</data>
     </node>
     <node id="3">
         <data key="version">26.0</data>

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -20,14 +20,14 @@
         <data key="bitcoin_config">-uacomment=w1</data>
         <data key="ln">lnd</data>
         <data key="ln-image">lightninglabs/lnd:v0.15.5-beta</data>
-        <data key="ln-cb-image">carlakirkcohen/circuitbreaker:endorsement-experiment</data>
+        <data key="ln-cb-image">pinheadmz/circuitbreaker:278737d</data>
         <data key="collect_logs">true</data>
     </node>
     <node id="2">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w2</data>
         <data key="ln">lnd</data>
-        <data key="ln-cb-image">carlakirkcohen/circuitbreaker:endorsement-experiment</data>
+        <data key="ln-cb-image">pinheadmz/circuitbreaker:278737d</data>
     </node>
     <node id="3">
         <data key="version">26.0</data>

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -175,6 +175,12 @@ class TestBase:
                     if lightning_status not in stats:
                         stats[lightning_status] = 0
                     stats[lightning_status] += 1
+                if "circuitbreaker_status" in tank:
+                    stats["total"] += 1
+                    circuitbreaker_status = tank["circuitbreaker_status"]
+                    if circuitbreaker_status not in stats:
+                        stats[circuitbreaker_status] = 0
+                    stats[circuitbreaker_status] += 1
             print(f"Waiting for all tanks to reach '{target}': {stats}")
             # All tanks are running, proceed
             return target in stats and stats[target] == stats["total"]


### PR DESCRIPTION
Closes: https://github.com/bitcoin-dev-project/warnet/issues/228
Requires (based on) https://github.com/bitcoin-dev-project/warnet/pull/287

Adds one more data element to tanks in the graphml file:

```
 <data key="ln-cb-image">carlakirkcohen/circuitbreaker:endorsement-experiment</data>
```

This adds a container running circuit breaker, and connects it to the corresponding lnd container. In K8s, both containers are in the same pod so they can interact via `localhost` and share a volume at `/root/.lnd` in both containers. In docker they also share a volume with that same path (this is needed to pass circuitbreaker the credentials generated by lnd).

~I'm not sure how else to test circuit breaker~, but the logs look promising. It keeps retrying to connect until it finally does:

```
2024-02-27 12:55:38 2024-02-27T17:55:38.313Z    INFO    Circuit Breaker starting        {"version": ""}
2024-02-27 12:55:38 2024-02-27T17:55:38.313Z    INFO    Opening database        {"path": "/root/.circuitbreaker/circuitbreaker.db"}
2024-02-27 12:55:38 2024-02-27T17:55:38.314Z    ERROR   Unexpected exit {"err": "open /root/.lnd/tls.cert: no such file or directory"}
2024-02-27 12:55:38 main.main
2024-02-27 12:55:38     /src/main.go:144
2024-02-27 12:55:38 runtime.main
2024-02-27 12:55:38     /usr/local/go/src/runtime/proc.go:250
2024-02-27 12:55:44 2024-02-27T17:55:44.878Z    INFO    Circuit Breaker starting        {"version": ""}
2024-02-27 12:55:44 2024-02-27T17:55:44.878Z    INFO    Opening database        {"path": "/root/.circuitbreaker/circuitbreaker.db"}
2024-02-27 12:55:44 2024-02-27T17:55:44.884Z    INFO    Press ctrl-c to exit
2024-02-27 12:55:44 2024-02-27T17:55:44.884Z    INFO    Grpc server starting    {"listenAddress": "127.0.0.1:9234"}
2024-02-27 12:55:44 2024-02-27T17:55:44.884Z    INFO    CircuitBreaker started
2024-02-27 12:55:44 2024-02-27T17:55:44.884Z    INFO    HTTP server starting    {"listenAddress": "127.0.0.1:9235"}
2024-02-27 12:55:44 2024-02-27T17:55:44.886Z    INFO    Connected to lnd node   {"pubkey": "0378b895ecaff7d8a140a1626c46b0d006cd0107dcec2aa261749e338bfc3c17fa"}
2024-02-27 12:55:44 2024-02-27T17:55:44.887Z    INFO    Interceptor/notification handlers registered
```

UPDATE: add rpc `exec_run` to make a request from the circuit breaker local API and check the forwards.

reference:

```
wget -q -O - localhost:9235/api/forwarding_history

{
  "forwards":
  [
    {
      "addTimeNs": "1709062043928206045",
      "resolveTimeNs": "1709062044022878253",
      "settled": true,
      "incomingAmount": "11000",
      "outgoingAmount": "10000",
      "incomingPeer": "000000000000000000000000000000000000000000000000000000000000000000",
      "incomingCircuit":
      {
        "shortChannelId": "123145302441984",
        "htlcIndex": 0
      },
      "outgoingPeer": "000000000000000000000000000000000000000000000000000000000000000000",
      "outgoingCircuit":
      {
        "shortChannelId": "123145302376448",
        "htlcIndex": 0
      },
      "incomingEndorsed": false,
      "outgoingEndorsed": false,
      "cltvDelta": 40
    }
  ]
}
```



