### PR TITLE
Added a new scenario cli command "run-file"

### DIFF
--- a/src/cli/scenarios.py
+++ b/src/cli/scenarios.py
@@ -1,3 +1,4 @@
+import base64
 import sys
 
 import click
@@ -47,6 +48,26 @@ def run(scenario, network, additional_args):
         "network": network,
     }
     print(rpc_call("scenarios_run", params))
+
+
+@scenarios.command(context_settings={"ignore_unknown_options": True})
+@click.argument("scenario_path", type=str)
+@click.argument("additional_args", nargs=-1, type=click.UNPROCESSED)
+@click.option("--network", default="warnet", show_default=True)
+def run_file(scenario_path, network, additional_args):
+    """
+    Run <scenario_path> from the Warnet Test Framework on <--network> with optional arguments
+    """
+    scenario_base64 = ""
+    with open(scenario_path, "rb") as f:
+        scenario_base64 = base64.b64encode(f.read()).decode("utf-8")
+
+    params = {
+        "scenario_base64": scenario_base64,
+        "additional_args": additional_args,
+        "network": network,
+    }
+    print(rpc_call("scenarios_run_file", params))
 
 
 @scenarios.command()

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -1,4 +1,5 @@
 import argparse
+import base64
 import logging
 import os
 import pkgutil
@@ -7,6 +8,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from datetime import datetime
@@ -123,7 +125,9 @@ class Server:
                     time_elapsed += check_interval
 
             # If we've reached here, the lock wasn't acquired in time
-            raise Exception(f"Failed to acquire the build lock within {timeout} seconds, aborting RPC.")
+            raise Exception(
+                f"Failed to acquire the build lock within {timeout} seconds, aborting RPC."
+            )
 
         self.app.before_request(log_request)
         self.app.before_request(build_check)
@@ -137,6 +141,7 @@ class Server:
         # Scenarios
         self.jsonrpc.register(self.scenarios_available)
         self.jsonrpc.register(self.scenarios_run)
+        self.jsonrpc.register(self.scenarios_run_file)
         self.jsonrpc.register(self.scenarios_stop)
         self.jsonrpc.register(self.scenarios_list_running)
         # Networks
@@ -268,6 +273,61 @@ class Server:
             return scenario_list
         except Exception as e:
             msg = f"Error listing scenarios: {e}"
+            self.logger.error(msg)
+            raise ServerError(message=msg) from e
+
+    def scenarios_run_file(
+        self, scenario_base64: str, additional_args: list[str], network: str = "warnet"
+    ) -> str:
+        scenario_path = None
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
+            scenario_path = temp_file.name
+
+            # decode base64 string to binary
+            scenario_bytes = base64.b64decode(scenario_base64)
+            # write binary to file
+            temp_file.write(scenario_bytes)
+
+        if not os.path.exists(scenario_path):
+            raise ServerError(f"Scenario not found at {scenario_path}.")
+
+        try:
+            run_cmd = (
+                [sys.executable, scenario_path]
+                + additional_args
+                + [f"--network={network}", f"--backend={self.backend}"]
+            )
+            self.logger.debug(f"Running {run_cmd}")
+
+            proc = subprocess.Popen(
+                run_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            def proc_logger():
+                while not proc.stdout:
+                    time.sleep(0.1)
+                for line in proc.stdout:
+                    self.logger.info(line.decode().rstrip())
+
+            t = threading.Thread(target=lambda: proc_logger())
+            t.daemon = True
+            t.start()
+
+            self.running_scenarios.append(
+                {
+                    "pid": proc.pid,
+                    "cmd": f"{scenario_path} {' '.join(additional_args)}",
+                    "proc": proc,
+                    "network": network,
+                }
+            )
+
+            return f"Running scenario with PID {proc.pid} in the background..."
+
+        except Exception as e:
+            msg = f"Error running scenario: {e}"
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
@@ -428,7 +488,7 @@ class Server:
             bio = BytesIO()
             nx.write_graphml(graph, bio, named_key_ids=True)
             xml_data = bio.getvalue()
-            return xml_data.decode('utf-8')
+            return xml_data.decode("utf-8")
         except Exception as e:
             msg = f"Error generating graph: {e}"
             self.logger.error(msg)


### PR DESCRIPTION
This will base64 up the file and throw it over to the RPC where it can be run.

The existing scenarios and commands are unchanged but I'm not sure it makes sense to have both run and run-file.

Proposing this as an immediate enhancement to be able to run modified scenarios on k8s clusters without having to rebuild the RPC image and to spark debate on how scenarios should run in the future.

To test:

```
warcli scenarios run-file src/scenarios/tx_flood.py
warcli scenarios stop <PID>`
```
