### PR TITLE
No more `from_deployment()`

### DIFF
--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -102,6 +102,13 @@ class BackendInterface(ABC):
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
+    def get_tank_ipv4(self, index: int) -> str:
+        """
+        Get the ipv4 address assigned to a bitcoind tank from the backend
+        """
+        raise NotImplementedError("This method should be overridden by child class")
+
+    @abstractmethod
     def wait_for_healthy_tanks(self, warnet, timeout=60) -> bool:
         """
         Wait for healthy status on all bitcoind nodes

--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -102,13 +102,6 @@ class BackendInterface(ABC):
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
-    def warnet_from_deployment(self, warnet):
-        """
-        Rebuild a warnet object from an active deployment
-        """
-        raise NotImplementedError("This method should be overridden by child class")
-
-    @abstractmethod
     def wait_for_healthy_tanks(self, warnet, timeout=60) -> bool:
         """
         Wait for healthy status on all bitcoind nodes

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -185,9 +185,17 @@ class ComposeBackend(BackendInterface):
         out = out[: stat["size"]]
         return out
 
+    def get_tank_ipv4(self, index: int) -> str:
+        c = self.get_container(index, ServiceType.BITCOIN)
+        if c:
+            return self.get_ipv4_address(c)
+        else:
+            return None
+
+
     def get_messages(self, a_index: int, b_index: int, bitcoin_network: str = "regtest"):
         # Find the ip of peer B
-        b_ipv4 = self.get_ipv4_address(self.get_container(b_index, ServiceType.BITCOIN))
+        b_ipv4 = self.get_tank_ipv4(b_index)
 
         # find the corresponding message capture folder
         # (which may include the internal port if connection is inbound)

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -13,7 +13,6 @@ from backends import BackendInterface, ServiceType
 from cli.image import build_image
 from docker.models.containers import Container
 from templates import TEMPLATES
-from warnet.lnnode import LNNode
 from warnet.status import RunningStatus
 from warnet.tank import Tank
 from warnet.utils import (
@@ -470,42 +469,6 @@ class ComposeBackend(BackendInterface):
         )
         if tank.collect_logs:
             services[ln_container_name]["labels"].update({"collect_logs": True})
-
-    def warnet_from_deployment(self, warnet):
-        # Get tank names, versions and IP addresses from docker-compose
-        docker_compose_path = warnet.config_dir / DOCKER_COMPOSE_NAME
-        compose = None
-        with open(docker_compose_path) as file:
-            compose = yaml.safe_load(file)
-        for service_name in compose["services"]:
-            tank = self.tank_from_deployment(compose["services"][service_name], warnet)
-            if tank is not None:
-                warnet.tanks.append(tank)
-
-    def tank_from_deployment(self, service, warnet):
-        rex = rf"{warnet.network_name}-{CONTAINER_PREFIX_BITCOIND}-([0-9]{{6}})"
-        # Not a tank, maybe a scaled service
-        if "container_name" not in service:
-            return None
-        match = re.match(rex, service["container_name"])
-        if match is None:
-            return None
-
-        index = int(match.group(1))
-        tank = Tank(index, warnet.config_dir, warnet)
-        tank._ipv4 = service["networks"][tank.network_name]["ipv4_address"]
-        if "image" in service:
-            tank.version = service["image"].split(":")[1]
-        else:
-            tank.version = (
-                f"{service['build']['args']['REPO']}#{service['build']['args']['BRANCH']}"
-            )
-
-        labels = service.get("labels", {})
-        if "lnnode_impl" in labels:
-            tank.lnnode = LNNode(warnet, tank, labels["lnnode_impl"], labels["lnnode_image"], self)
-            tank.lnnode.ipv4 = labels.get("lnnode_ipv4_address")
-        return tank
 
     def get_ipv4_address(self, container: Container) -> str:
         """

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -507,6 +507,14 @@ class KubernetesBackend(BackendInterface):
     def get_service_name(self, tank_index: int) -> str:
         return f"bitcoind-{POD_PREFIX}-{tank_index:06d}"
 
+    def get_tank_ipv4(self, index: int) -> str:
+        pod_name = self.get_pod_name(index, ServiceType.BITCOIN)
+        pod = self.get_pod(pod_name)
+        if pod:
+            return pod.status.pod_ip
+        else:
+            return None
+
     def create_bitcoind_service(self, tank) -> client.V1Service:
         service_name = self.get_service_name(tank.index)
         self.log.debug(f"Creating bitcoind service {service_name} for tank {tank.index}")

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -145,6 +145,8 @@ class Warnet:
         self.graph = networkx.read_graphml(Path(self.config_dir / self.graph_name), node_type=int)
         validate_graph_schema(self.node_schema, self.graph)
         self.tanks_from_graph()
+        for tank in self.tanks:
+            tank._ipv4 = self.container_interface.get_tank_ipv4(tank.index)
         return self
 
     @property

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -141,12 +141,10 @@ class Warnet:
         config_dir = gen_config_dir(network_name)
         self = cls(config_dir, backend, network_name)
         self.network_name = network_name
-        self.container_interface.warnet_from_deployment(self)
         # Get network graph edges from graph file (required for network restarts)
         self.graph = networkx.read_graphml(Path(self.config_dir / self.graph_name), node_type=int)
         validate_graph_schema(self.node_schema, self.graph)
-        if self.tanks == []:
-            self.tanks_from_graph()
+        self.tanks_from_graph()
         return self
 
     @property


### PR DESCRIPTION
The graphml has everything we need, except IP addresses. We can get those from the backend, but that's only actually needed for scenarios currently.

#254 and #278 are already cleaning up IP stuff... ultimately we should be able to get rid of a lot of the metadata we dump in the compose file in `environment` variables and `labels` and in the kubernetes deployment several `V1EnvVar` are set just for the sake of recovering "from deployment".

This also means initiatives like #285 and #288 will be easier to build since we wont need to add extra metadata in the deployments.