### PR TITLE
debug logs and hot reload server

### DIFF
--- a/test/test_base.py
+++ b/test/test_base.py
@@ -122,7 +122,7 @@ class TestBase:
             print(f"\nStarting Warnet server, logging to: {self.logfilepath}")
 
             self.server = Popen(
-                ["warnet", "--backend", self.backend],
+                ["warnet", "--backend", self.backend, "--debug"],
                 stdout=PIPE,
                 stderr=STDOUT,
                 bufsize=1,


### PR DESCRIPTION
To enable debug logs you can:

1. Run `warnet --debug` which will enable debug logs only (currently default in tests)
2. Run `warnet --dev` which will enable hot reloads and debug logs