### PR TITLE
Tidy up logging

### DIFF
--- a/src/logging_config/config.json
+++ b/src/logging_config/config.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "simple": {
+      "format": " %(asctime)s - %(levelname)s - %(message)s",
+      "datefmt": "%Y-%m-%dT%H:%M:%S%z"
+    },
+    "detailed": {
+      "format": " %(asctime)s - %(levelname)s - [%(module)s|L%(lineno)d] - %(message)s",
+      "datefmt": "%Y-%m-%dT%H:%M:%S%z"
+    }
+  },
+  "filters": {
+    "no_errors": {
+      "()": "warnet.utils.NonErrorFilter"
+    }
+  },
+  "handlers": {
+    "stdout": {
+      "class": "logging.StreamHandler",
+      "level": "DEBUG",
+      "formatter": "simple",
+      "filters": ["no_errors"],
+      "stream": "ext://sys.stdout"
+    },
+    "stderr": {
+      "class": "logging.StreamHandler",
+      "level": "WARNING",
+      "formatter": "simple",
+      "stream": "ext://sys.stderr"
+    },
+    "file": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "level": "DEBUG",
+      "formatter": "detailed",
+      "filename": "warnet.log",
+      "maxBytes": 16000000,
+      "backupCount": 3
+    }
+  },
+  "loggers": {
+    "root": {
+      "level": "DEBUG",
+      "handlers": [
+        "stdout",
+        "stderr",
+        "file"
+      ]
+    },
+    "urllib3.connectionpool": {
+        "level": "WARNING",
+        "propagate": 1
+    },
+
+    "kubernetes.client.rest": {
+        "level": "WARNING",
+        "propagate": 1
+    }
+  }
+}

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -65,7 +65,6 @@ class Server:
         self.setup_logging()
         self.setup_rpc()
         self.logger.info("Started server")
-        self.app.add_url_rule("/-/healthy", view_func=self.healthy)
 
         # register a well known /-/healthy endpoint for liveness tests
         # we regard warnet as healthy if the http server is up
@@ -116,6 +115,8 @@ class Server:
         self.logger.info("Logging started")
 
         def log_request():
+            if "healthy" in request.path:
+                return # No need to log all these
             if not request.path.startswith("/api/"):
                 self.logger.debug(request.path)
             else:

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -62,12 +62,13 @@ class Tank:
 
     def parse_graph_node(self, node):
         # Dynamically parse properties based on the schema
+        graph_properties = {}
         for property, specs in self.warnet.node_schema["properties"].items():
             value = node.get(property, specs.get("default"))
             if property == "version":
                 self._parse_version()
             setattr(self, property, value)
-            logger.debug(f"{property}={value}")
+            graph_properties[property] = value
 
         if self.version and self.image:
             raise Exception(
@@ -83,7 +84,8 @@ class Tank:
 
         self.config_dir = self.warnet.config_dir / str(self.suffix)
         self.config_dir.mkdir(parents=True, exist_ok=True)
-        logger.debug(f"{self=:}")
+
+        logger.debug(f"Parsed graph node: {self.index} with attributes: {[f'{key}={value}' for key, value in graph_properties.items()]}")
 
     @classmethod
     def from_graph_node(cls, index, warnet, tank=None):

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -36,6 +36,12 @@ WEIGHTED_TAGS = [
 NODE_SCHEMA_PATH = SCHEMA / "node_schema.json"
 
 
+class NonErrorFilter(logging.Filter):
+
+    def filter(self, record: logging.LogRecord) -> bool | logging.LogRecord:
+        return record.levelno <= logging.INFO
+
+
 def exponential_backoff(max_retries=5, base_delay=1, max_delay=32):
     """
     A decorator for exponential backoff.


### PR DESCRIPTION
* Tidy up the overly-verbose tank logging.

* Modernise config with `dictConfig` style logging from json config file:
  * Send DEBUG <= n < WARNING to `stdout`
  * Send >= WARNING to `stderr`
  * Write >= DEBUG to `log_file`, with extra info