### PR TITLE
docker: fix silly breaking docker change

### DIFF
--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -401,7 +401,7 @@ class ComposeBackend(BackendInterface):
                 "privileged": True,
                 "cap_add": ["NET_ADMIN", "NET_RAW"],
                 "healthcheck": {
-                    "test": ["CMD-SHELL", f"nc -z localhost {tank.rpc_port} || exit 1"],
+                    "test": ["CMD-SHELL", f"nc -z 127.0.0.1 {tank.rpc_port} || exit 1"],
                     "interval": "10s",  # Check every 10 seconds
                     "timeout": "1s",  # Give the check 1 second to complete
                     "start_period": "5s",  # Start checking after 5 seconds

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -393,7 +393,7 @@ class KubernetesBackend(BackendInterface):
             name="prometheus",
             image="jvstein/bitcoin-prometheus-exporter:latest",
             env=[
-                client.V1EnvVar(name="BITCOIN_RPC_HOST", value="localhost"),
+                client.V1EnvVar(name="BITCOIN_RPC_HOST", value="127.0.0.1"),
                 client.V1EnvVar(name="BITCOIN_RPC_PORT", value=str(tank.rpc_port)),
                 client.V1EnvVar(name="BITCOIN_RPC_USER", value=tank.rpc_user),
                 client.V1EnvVar(name="BITCOIN_RPC_PASSWORD", value=tank.rpc_password),
@@ -505,7 +505,7 @@ class KubernetesBackend(BackendInterface):
             image=tank.lnnode.cb,
             args=[
                 "--network=regtest",
-                f"--rpcserver=localhost:{tank.lnnode.rpc_port}",
+                f"--rpcserver=127.0.0.1:{tank.lnnode.rpc_port}",
                 f"--tlscertpath={LND_MOUNT_PATH}/tls.cert",
                 f"--macaroonpath={LND_MOUNT_PATH}/data/chain/bitcoin/regtest/admin.macaroon",
             ],

--- a/src/cli/rpc.py
+++ b/src/cli/rpc.py
@@ -19,7 +19,7 @@ class JSONRPCException(Exception):
 
 def rpc_call(rpc_method, params: dict[str, Any] | tuple[Any, ...] | None):
     payload = request(rpc_method, params)
-    url = f"http://localhost:{WARNET_SERVER_PORT}/api"
+    url = f"http://127.0.0.1:{WARNET_SERVER_PORT}/api"
     try:
         response = requests.post(url, json=payload)
     except ConnectionRefusedError as e:

--- a/test/ln_test.py
+++ b/test/ln_test.py
@@ -14,7 +14,7 @@ base.start_server()
 
 
 def get_cb_forwards(index):
-    cmd = "wget -q -O - localhost:9235/api/forwarding_history"
+    cmd = "wget -q -O - 127.0.0.1:9235/api/forwarding_history"
     res = base.wait_for_rpc(
         "exec_run", [index, ServiceType.CIRCUITBREAKER.value, cmd, base.network_name]
     )


### PR DESCRIPTION
Fixes: #318

No idea why, and don't plan on finding out. But `localhost` now does not work in a healthcheck.

Use 127.0.0.1 instead.