### PR TITLE
test: raise exception on base.warcli() error

### DIFF
--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -24,7 +24,7 @@ with tempfile.TemporaryDirectory() as dir:
             file.write(xml)
 
     # Validate the graph schema
-    assert "invalid" not in base.warcli(f"graph validate {Path(tf)}")
+    assert "invalid" not in base.warcli(f"graph validate {Path(tf)}", False)
     print(f"Graph at {tf} validated successfully")
 
     # Test that the graph actually works

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -82,6 +82,9 @@ class TestBase:
         if network:
             cmd += ["--network", self.network_name]
         proc = run(cmd, capture_output=True)
+
+        if proc.stderr:
+            raise Exception(proc.stderr.decode().strip())
         return proc.stdout.decode().strip()
 
     # Execute a warnet RPC API call directly (may return dict or list)


### PR DESCRIPTION
Test Base was swallowing RPC errors and so we were never actually checking `graph validate` in `graph_test.py`