### PR TITLE
cli: move all graph RPCs out of server, to warcli

### DIFF
--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -7,30 +7,23 @@ from test_base import TestBase
 from warnet.utils import DEFAULT_TAG
 
 base = TestBase()
-base.network = False
+
+# Does not require a running Warnet RPC server yet
+test_dir = tempfile.TemporaryDirectory()
+tf = f"{test_dir.name}/{str(uuid.uuid4())}.graphml"
+
+print(f"CLI tool writing test graph directly to {tf}")
+print(base.warcli(f"graph create 10 --outfile={tf} --version={DEFAULT_TAG}", network=False))
+base.wait_for_predicate(lambda: Path(tf).exists())
+
+# Validate the graph schema
+assert "invalid" not in base.warcli(f"graph validate {Path(tf)}", False)
+print(f"Graph at {tf} validated successfully")
+
+# Test that the graph actually works, now we need a server
 base.start_server()
-
-with tempfile.TemporaryDirectory() as dir:
-    tf = f"{dir}/{str(uuid.uuid4())}.graphml"
-    if base.backend == "compose":
-        print(f"Server writing test graph directly to {tf}")
-        print(base.warcli(f"graph create 10 --outfile={tf} --version={DEFAULT_TAG}", network=False))
-        base.wait_for_predicate(lambda: Path(tf).exists())
-    else:
-        print(f"Client retrieving test graph from RPC and writing to {tf}")
-        xml = base.warcli(f"graph create 10 --version={DEFAULT_TAG}", network=False)
-        print(xml)
-        with open(tf, "w") as file:
-            file.write(xml)
-
-    # Validate the graph schema
-    assert "invalid" not in base.warcli(f"graph validate {Path(tf)}", False)
-    print(f"Graph at {tf} validated successfully")
-
-    # Test that the graph actually works
-    print(base.warcli(f"network start {Path(tf)}"))
-    base.wait_for_all_tanks_status(target="running")
-    base.wait_for_all_edges()
-    base.warcli("rpc 0 getblockcount")
-
+print(base.warcli(f"network start {Path(tf)}"))
+base.wait_for_all_tanks_status(target="running")
+base.wait_for_all_edges()
+base.warcli("rpc 0 getblockcount")
 base.stop_server()


### PR DESCRIPTION
This also simplifies the graph test since operation is now the same for both backend.