### PR TITLE
add sim-ln service

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,6 +4,12 @@ set shell := ["bash", "-uc"]
 default:
     just --list
 
+cluster:
+    kubectl apply -f src/templates/rpc/namespace.yaml
+    kubectl apply -f src/templates/rpc/rbac-config.yaml
+    kubectl apply -f src/templates/rpc/warnet-rpc-service.yaml
+    kubectl apply -f src/templates/rpc/warnet-rpc-statefulset.yaml
+
 # Setup and start the RPC in dev mode with minikube
 start:
     #!/usr/bin/env bash

--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -110,6 +110,13 @@ class BackendInterface(ABC):
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
+    def get_lnnode_hostname(self, index: int) -> str:
+        """
+        Get the hostname assigned to a lnnode attached to a tank from the backend
+        """
+        raise NotImplementedError("This method should be overridden by child class")
+
+    @abstractmethod
     def wait_for_healthy_tanks(self, warnet, timeout=60) -> bool:
         """
         Wait for healthy status on all bitcoind nodes

--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -115,11 +115,3 @@ class BackendInterface(ABC):
         Wait for healthy status on all bitcoind nodes
         """
         raise NotImplementedError("This method should be overridden by child class")
-
-
-    @abstractmethod
-    def service_from_json(self, json: dict) -> dict:
-        """
-        Create a single container from a JSON object of settings
-        """
-        raise NotImplementedError("This method should be overridden by child class")

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -356,9 +356,12 @@ class ComposeBackend(BackendInterface):
                 "networks": [tank.network_name],
             }
 
+    def get_lnnode_hostname(self, index: int) -> str:
+        return self.get_container_name(index, ServiceType.LIGHTNING)
+
     def add_lnd_service(self, tank, compose):
         services = compose["services"]
-        ln_container_name = self.get_container_name(tank.index, ServiceType.LIGHTNING)
+        ln_container_name = self.get_lnnode_hostname(tank.index)
         ln_cb_container_name = self.get_container_name(tank.index, ServiceType.CIRCUITBREAKER)
         bitcoin_container_name = self.get_container_name(tank.index, ServiceType.BITCOIN)
         # These args are appended to the Dockerfile `ENTRYPOINT ["lnd"]`
@@ -475,5 +478,10 @@ class ComposeBackend(BackendInterface):
             "devices": obj.get("devices", []),
             "command": obj.get("args", []),
             "environment": obj.get("environment", []),
+            "restart": "on-failure",
             "networks": [self.network_name]
         }
+
+    def restart_service_container(self, service_name: str):
+        container = self.client.containers.get(self.get_service_container_name(service_name))
+        container.restart()

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -266,7 +266,7 @@ class ComposeBackend(BackendInterface):
         # Initialize services and add them to the compose
         for service_name in warnet.services:
             if "compose" in services[service_name]["backends"]:
-                compose["services"][service_name] = self.service_from_json(services[service_name])
+                compose["services"][service_name] = self.service_from_json(service_name)
 
         docker_compose_path = warnet.config_dir / "docker-compose.yml"
         try:
@@ -448,7 +448,11 @@ class ComposeBackend(BackendInterface):
 
         return healthy
 
-    def service_from_json(self, obj: dict) -> dict:
+    def get_service_container_name(self, service_name: str):
+        return f"{self.network_name}_{services[service_name]['container_name_suffix']}"
+
+    def service_from_json(self, service_name: str) -> object:
+        obj = services[service_name]
         volumes = obj.get("volumes", [])
         volumes += [f"{self.config_dir}" + filepath for filepath in obj.get("config_files", [])]
 
@@ -457,7 +461,7 @@ class ComposeBackend(BackendInterface):
             ports = [f"{obj['warnet_port']}:{obj['container_port']}"]
         return {
             "image": obj["image"],
-            "container_name": f"{self.network_name}_{obj['container_name_suffix']}",
+            "container_name": self.get_service_container_name(service_name),
             "ports": ports,
             "volumes": volumes,
             "privileged": obj.get("privileged", False),

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -442,12 +442,15 @@ class KubernetesBackend(BackendInterface):
             except ResourceNotFoundError:
                 continue
 
+    def get_lnnode_hostname(self, index: int) -> str:
+        return f"lightning-{index}.{self.namespace}"
+
     def create_lnd_container(
         self, tank, bitcoind_service_name, volume_mounts
     ) -> client.V1Container:
         # These args are appended to the Dockerfile `ENTRYPOINT ["lnd"]`
         bitcoind_rpc_host = f"{bitcoind_service_name}.{self.namespace}"
-        lightning_dns = f"lightning-{tank.index}.{self.namespace}"
+        lightning_dns = self.get_lnnode_hostname(tank.index)
         args = tank.lnnode.get_conf(lightning_dns, bitcoind_rpc_host)
         self.log.debug(f"Creating lightning container for tank {tank.index} using {args=:}")
         lightning_container = client.V1Container(

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -15,6 +15,7 @@ from kubernetes.client.rest import ApiException
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from kubernetes.stream import stream
+from warnet.services import services
 from warnet.status import RunningStatus
 from warnet.tank import Tank
 from warnet.utils import parse_raw_messages
@@ -72,6 +73,10 @@ class KubernetesBackend(BackendInterface):
                 self.client.delete_namespaced_pod(pod_name, self.namespace)
 
         self.remove_prometheus_service_monitors(warnet.tanks)
+
+        for service_name in warnet.services:
+            if "k8s" in services[service_name]["backends"]:
+                self.client.delete_namespaced_pod(f'{services[service_name]["container_name_suffix"]}-service', self.namespace)
 
         return True
 
@@ -668,6 +673,10 @@ class KubernetesBackend(BackendInterface):
         if self.check_logging_crds_installed():
             self.apply_prometheus_service_monitors(warnet.tanks)
 
+        for service_name in warnet.services:
+            if "k8s" in services[service_name]["backends"]:
+                self.service_from_json(services[service_name])
+
         self.log.debug("Containers and services created. Configuring IP addresses")
         # now that the pods have had a second to create,
         # get the ips and set them on the tanks
@@ -700,5 +709,73 @@ class KubernetesBackend(BackendInterface):
         """
         pass
 
-    def service_from_json(self, obj: dict) -> dict:
-        pass
+    def service_from_json(self, obj):
+        env = []
+        for pair in obj.get("environment", []):
+            name, value = pair.split("=")
+            env.append(client.V1EnvVar(name=name, value=value))
+        volume_mounts = []
+        volumes = []
+        for vol in obj.get("config_files", []):
+            volume_name, mount_path = vol.split(":")
+            volume_name = volume_name.replace("/", "")
+            volume_mounts.append(client.V1VolumeMount(name=volume_name, mount_path=mount_path))
+            volumes.append(client.V1Volume(name=volume_name, empty_dir=client.V1EmptyDirVolumeSource()))
+
+        service_container = client.V1Container(
+            name=obj["container_name_suffix"],
+            image=obj["image"],
+            env=env,
+            security_context=client.V1SecurityContext(
+                privileged=True,
+                capabilities=client.V1Capabilities(add=["NET_ADMIN", "NET_RAW"]),
+            ),
+            volume_mounts=volume_mounts
+        )
+        sidecar_container = client.V1Container(
+            name="sidecar",
+            image="pinheadmz/sidecar:latest",
+            volume_mounts=volume_mounts,
+            ports=[client.V1ContainerPort(container_port=22)],
+        )
+        service_pod = client.V1Pod(
+            api_version="v1",
+            kind="Pod",
+            metadata=client.V1ObjectMeta(
+                name=obj["container_name_suffix"],
+                namespace=self.namespace,
+                labels={
+                    "app": obj["container_name_suffix"],
+                    "network": self.network_name,
+                },
+            ),
+            spec=client.V1PodSpec(
+                restart_policy="OnFailure",
+                containers=[service_container, sidecar_container],
+                volumes=volumes,
+            ),
+        )
+
+        # Do not ever change this variable name. xoxo, --Zip
+        service_service = client.V1Service(
+            api_version="v1",
+            kind="Service",
+            metadata=client.V1ObjectMeta(
+                name=f'{obj["container_name_suffix"]}-service',
+                labels={
+                    "app": obj["container_name_suffix"],
+                    "network": self.network_name,
+                },
+            ),
+            spec=client.V1ServiceSpec(
+                selector={"app": obj["container_name_suffix"]},
+                publish_not_ready_addresses=True,
+                ports=[
+                    client.V1ServicePort(name="ssh", port=22, target_port=22),
+                ]
+            )
+        )
+
+        self.client.create_namespaced_pod(namespace=self.namespace, body=service_pod)
+        self.client.create_namespaced_service(namespace=self.namespace, body=service_service)
+

--- a/src/cli/network.py
+++ b/src/cli/network.py
@@ -143,8 +143,11 @@ def connected(network: str):
 
 @network.command()
 @click.option("--network", default="warnet", show_default=True)
-def export(network):
+@click.option("--activity", type=str)
+def export(network: str, activity: str):
     """
-    Export all [network] data for sim-ln to subdirectory
+    Export all [network] data for a "simln" service running in a container
+    on the network. Optionally add JSON string [activity] to simln config.
+    Returns True on success.
     """
-    print(rpc_call("network_export", {"network": network}))
+    print(rpc_call("network_export", {"network": network, "activity": activity}))

--- a/src/templates/Dockerfile_sidecar
+++ b/src/templates/Dockerfile_sidecar
@@ -1,0 +1,12 @@
+FROM alpine:latest
+
+RUN apk add openssh
+
+RUN echo "root:" | chpasswd
+
+RUN ssh-keygen -A
+
+CMD ["/usr/sbin/sshd", "-D", \
+  "-o", "PasswordAuthentication=yes", \
+  "-o", "PermitEmptyPasswords=yes", \
+  "-o", "PermitRootLogin=yes"]

--- a/src/templates/rpc/Dockerfile_rpc
+++ b/src/templates/rpc/Dockerfile_rpc
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 
 # Install procps, which includes pgrep
 RUN apt-get update && \
-    apt-get install -y procps && \
+    apt-get install -y procps openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container

--- a/src/templates/rpc/Dockerfile_rpc_dev
+++ b/src/templates/rpc/Dockerfile_rpc_dev
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 
 # Install procps, which includes pgrep
 RUN apt-get update && \
-    apt-get install -y procps && \
+    apt-get install -y procps openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container

--- a/src/warnet/lnnode.py
+++ b/src/warnet/lnnode.py
@@ -13,7 +13,8 @@ LND_CONFIG_BASE = " ".join([
     "--bitcoin.active",
     "--bitcoin.regtest",
     "--bitcoin.node=bitcoind",
-    "--maxpendingchannels=64"
+    "--maxpendingchannels=64",
+    "--trickledelay=1"
 ])
 
 class LNNode:

--- a/src/warnet/services.py
+++ b/src/warnet/services.py
@@ -31,7 +31,7 @@ services = {
         "container_name_suffix": "fork-observer",
         "warnet_port": "23001",
         "container_port": "2323",
-        "config_files": [f"/{FO_CONF_NAME}:/app/config.toml"],
+        "config_files": [f"{FO_CONF_NAME}:/app/config.toml"],
     },
     "grafana": {
         "backends": ["compose"],
@@ -43,8 +43,8 @@ services = {
             "grafana-storage:/var/lib/grafana"
         ],
         "config_files": [
-            f"/{GRAFANA_PROVISIONING}/datasources:/etc/grafana/provisioning/datasources",
-            f"/{GRAFANA_PROVISIONING}/dashboards:/etc/grafana/provisioning/dashboards",
+            f"{GRAFANA_PROVISIONING}/datasources:/etc/grafana/provisioning/datasources",
+            f"{GRAFANA_PROVISIONING}/dashboards:/etc/grafana/provisioning/dashboards",
         ],
         "environment": [
             "GF_LOG_LEVEL=debug",
@@ -76,7 +76,17 @@ services = {
         "container_name_suffix": "prometheus",
         "warnet_port": "23004",
         "container_port": "9090",
-        "config_files": [f"/{PROM_CONF_NAME}:/etc/prometheus/prometheus.yml"],
+        "config_files": [f"{PROM_CONF_NAME}:/etc/prometheus/prometheus.yml"],
         "args": ["--config.file=/etc/prometheus/prometheus.yml"]
-    }
+    },
+    "simln": {
+        "backends": ["compose", "k8s"],
+        "image": "bitcoindevproject/simln:0.2.0",
+        "container_name_suffix": "simln",
+        "environment": [
+            "LOG_LEVEL=debug",
+            "SIMFILE_PATH=/simln/sim.json"
+        ],
+        "config_files": ["simln/:/simln"]
+    },
 }

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -169,6 +169,6 @@ class Tank:
                 f"Error applying network conditions to tank {self.index}: `{self.netem}` ({e})"
             )
 
-    def export(self, config, subdir):
+    def export(self, config: object, tar_file):
         if self.lnnode is not None:
-            self.lnnode.export(config, subdir)
+            self.lnnode.export(config, tar_file)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -5,7 +5,6 @@ Warnet is the top-level class for a simulated network.
 import base64
 import json
 import logging
-import os
 import shutil
 from pathlib import Path
 
@@ -239,15 +238,9 @@ class Warnet:
         except Exception as e:
             logger.error(f"An error occurred while writing to {prometheus_path}: {e}")
 
-    def export(self, subdir):
-        if self.backend != "compose":
-            raise NotImplementedError("Export is only supported for compose backend")
-        config = {"nodes": []}
+    def export(self, config: object, tar_file):
         for tank in self.tanks:
-            tank.export(config, subdir)
-        config_path = os.path.join(subdir, "sim.json")
-        with open(config_path, "a") as f:
-            json.dump(config, f)
+            tank.export(config, tar_file)
 
     def wait_for_health(self):
         self.container_interface.wait_for_healthy_tanks(self)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -136,6 +136,8 @@ class Warnet:
         self.graph = networkx.read_graphml(Path(self.config_dir / self.graph_name), node_type=int, force_multigraph=True)
         validate_graph_schema(self.graph)
         self.tanks_from_graph()
+        if "services" in self.graph.graph:
+            self.services = self.graph.graph["services"].split()
         for tank in self.tanks:
             tank._ipv4 = self.container_interface.get_tank_ipv4(tank.index)
         return self

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key id="version"         attr.name="version"          attr.type="string"   for="node" />
+  <key id="services"        attr.name="services"         attr.type="string"   for="graph" />
   <key id="image"           attr.name="image"            attr.type="string"   for="node" />
   <key id="bitcoin_config"  attr.name="bitcoin_config"   attr.type="string"   for="node" />
   <key id="tc_netem"        attr.name="tc_netem"         attr.type="string"   for="node" />
@@ -14,6 +15,7 @@
   <key id="source_policy"   attr.name="source_policy"    attr.type="string"   for="edge" />
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
   <graph edgedefault="directed">
+    <data key="services">simln</data>
     <node id="0">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w0</data>

--- a/test/data/services.graphml
+++ b/test/data/services.graphml
@@ -20,6 +20,7 @@
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w0 -debug=validation</data>
         <data key="exporter">true</data>
+        <data key="ln">lnd</data>
     </node>
   </graph>
 </graphml>


### PR DESCRIPTION
This is a WIP, pushing commits slowly to bang on CI

Strategy:
- [x] Move the backend/compose/services directory up to src/
- [x] Add graphml options to add those services only when needed
- [x] refactor the BaseService to accomodate both backends
- [x] add sim-ln service that can be optionally added to any warnet with either backend
- [x] export network data into the simln container so it can do its thing

TODO:
 - [ ] DOCS (follow up PR)