### PR TITLE
re-enable fork observer on compose

### DIFF
--- a/src/graphs/default.graphml
+++ b/src/graphs/default.graphml
@@ -5,6 +5,7 @@
   <key attr.name="build_args" attr.type="string" for="node" id="build_args"/>
   <key attr.name="exporter" attr.type="boolean" for="node" id="exporter"/>
   <key attr.name="collect_logs" attr.type="boolean" for="node" id="collect_logs"/>
+  <key attr.name="fork_observer" attr.type="boolean" for="node" id="fork_observer"/>
   <key attr.name="image" attr.type="string" for="node" id="image"/>
   <graph edgedefault="directed">
     <node id="0">
@@ -12,28 +13,33 @@
         <data key="bitcoin_config">-uacomment=w0</data>
         <data key="exporter">true</data>
         <data key="collect_logs">true</data>
+        <data key="fork_observer">true</data>
     </node>
     <node id="1">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w1</data>
         <data key="exporter">true</data>
         <data key="collect_logs">true</data>
+        <data key="fork_observer">true</data>
     </node>
     <node id="2">
         <data key="image">bitcoindevproject/bitcoin:26.0</data>
         <data key="bitcoin_config">-uacomment=w2 -debug=mempool</data>
         <data key="exporter">true</data>
         <data key="collect_logs">true</data>
+        <data key="fork_observer">true</data>
     </node>
     <node id="3">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w3</data>
         <data key="exporter">true</data>
+        <data key="fork_observer">true</data>
     </node>
     <node id="4">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w4</data>
         <data key="exporter">true</data>
+        <data key="fork_observer">true</data>
     </node>
     <node id="5">
         <data key="version">26.0</data>
@@ -63,6 +69,7 @@
     <node id="11">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w11</data>
+        <data key="fork_observer">true</data>
     </node>
     <!-- connect the nodes in a ring to start -->
     <edge id="1" source="0" target="1"></edge>

--- a/src/schema/graph_schema.json
+++ b/src/schema/graph_schema.json
@@ -23,6 +23,10 @@
         "type": "boolean",
         "default": false,
         "comment": "Whether to collect Bitcoin Core debug logs with Promtail"},
+      "fork_observer": {
+        "type": "boolean",
+        "default": false,
+        "comment": "Whether it should be monitored with Fork Observer."},
       "build_args": {
         "type": "string",
         "default": "",

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -30,7 +30,8 @@ CONFIG_BASE = " ".join([
     "-rpcallowip=0.0.0.0/0",
     "-rpcbind=0.0.0.0",
     "-fallbackfee=0.00001000",
-    "-listen=1"
+    "-listen=1",
+    "-rest"
 ])
 
 class Tank:

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -30,8 +30,7 @@ CONFIG_BASE = " ".join([
     "-rpcallowip=0.0.0.0/0",
     "-rpcbind=0.0.0.0",
     "-fallbackfee=0.00001000",
-    "-listen=1",
-    "-rest"
+    "-listen=1"
 ])
 
 class Tank:
@@ -61,6 +60,7 @@ class Tank:
         # index of integers imported from graph file
         # indicating which tanks to initially connect to
         self.init_peers = []
+        self.fork_observer = False
 
     def _parse_version(self, version):
         if not version:
@@ -95,6 +95,9 @@ class Tank:
                 "ln_config": node.get("ln_config", "")
             }
             self.lnnode = LNNode(self.warnet, self, self.warnet.container_interface, options)
+
+        if self.fork_observer:
+            self.bitcoin_config += " -rest"
 
         logger.debug(
             f"Parsed graph node: {self.index} with attributes: {[f'{key}={value}' for key, value in graph_properties.items()]}"

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -181,18 +181,19 @@ class Warnet:
         shutil.copy(TEMPLATES / FO_CONF_NAME, self.fork_observer_config)
         with open(self.fork_observer_config, "a") as f:
             for tank in self.tanks:
-                f.write(
-                    f"""
-                    [[networks.nodes]]
-                    id = {tank.index}
-                    name = "Node {tank.index}"
-                    description = "Warnet tank {tank.index}"
-                    rpc_host = "{tank.ipv4}"
-                    rpc_port = {tank.rpc_port}
-                    rpc_user = "{tank.rpc_user}"
-                    rpc_password = "{tank.rpc_password}"
-                """
-                )
+                if tank.fork_observer:
+                    f.write(
+                        f"""
+                        [[networks.nodes]]
+                        id = {tank.index}
+                        name = "Node {tank.index}"
+                        description = "Warnet tank {tank.index}"
+                        rpc_host = "{tank.ipv4}"
+                        rpc_port = {tank.rpc_port}
+                        rpc_user = "{tank.rpc_user}"
+                        rpc_password = "{tank.rpc_password}"
+                    """
+                    )
         logger.info(f"Wrote file: {self.fork_observer_config}")
 
     def export(self, subdir):


### PR DESCRIPTION
Uses a new graph attribute to selectively enable fork observer on compose only (for now).