### PR TITLE
graph: use pub_key over id in import-json

### DIFF
--- a/src/cli/graph.py
+++ b/src/cli/graph.py
@@ -62,7 +62,7 @@ def import_json(infile: Path, outfile: Path, cb: str):
     # Save a map of LN pubkey -> Tank index
     ln_ids = {}
     for index, node in enumerate(json_graph["nodes"]):
-        ln_ids[node["id"]] = index
+        ln_ids[node["pub_key"]] = index
 
     # Offset for edge IDs
     # Note create_cycle_graph() creates L1 edges all with the same id "0"

--- a/test/data/LN_10.json
+++ b/test/data/LN_10.json
@@ -1,117 +1,16 @@
 {
-    "directed": false,
-    "multigraph": false,
-    "graph": {},
     "nodes": [
         {
-            "last_update": 1710273330,
-            "alias": "speedupln.com",
+            "pub_key": "022e9a32023ba0975a08076006a91ffab8872f5efe35319c094949d17b267dd14a",
+            "last_update": 1710793870,
+            "alias": "LightningChat",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "52.27.151.162:9735"
+                    "addr": "52.152.225.172:9735"
                 }
             ],
-            "color": "#2fff00",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "6": {
-                    "name": "gossip-queries",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "22": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "29": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "39": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "023631624e30ef7bcb2887e600da8e59608a093718bc40d35b7a57145a0f3db9af"
-        },
-        {
-            "last_update": 1710854037,
-            "alias": "\u26a1G-Spot-21_69_420\u26a1",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "82.16.4.160:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "zacadqiqgi43tdv4ztjet2fh22f72ol2tokotp5cqdbszgx6tpyqdxad.onion:9735"
-                }
-            ],
-            "color": "#216942",
+            "color": "#009926",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -148,11 +47,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "23": {
                     "name": "anchors-zero-fee-htlc-tx",
                     "is_required": false,
@@ -173,117 +67,22 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "2023": {
                     "name": "script-enforced-lease",
                     "is_required": false,
                     "is_known": true
                 }
             },
-            "custom_records": {},
-            "id": "03c5528c628681aa17ab9e117aa3ee6f06c750dfb17df758ecabcd68f1567ad8c1"
+            "custom_records": {}
         },
         {
-            "last_update": 1710656670,
-            "alias": "ThunderHorse2",
+            "pub_key": "02ed2ba8e0138de3155fd33ba025c9840f0a409b221321140b838ba49fc3275b3b",
+            "last_update": 1710855326,
+            "alias": "02ed2ba8e0138de3155f",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "208.97.220.66:9735"
-                }
-            ],
-            "color": "#000000",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02f460ae6d3d3e104f8afe520ae0cff3d94c35c2ba8df66da89f3c8006a265b90a"
-        },
-        {
-            "last_update": 1710815292,
-            "alias": "03d8ef4620be554d8990",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "116.202.102.215:9735"
+                    "addr": "d4uvz72rchuskyiq5zi5g36dvmecingv55rjuizzjywyse6frfuxmqad.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -349,120 +148,20 @@
                     "is_known": true
                 }
             },
-            "custom_records": {},
-            "id": "03d8ef4620be554d89902bc9fde9498b67790f416833b84d76298e248e4fccef56"
+            "custom_records": {}
         },
         {
-            "last_update": 1710834653,
-            "alias": "RISE_AND_GRIND",
+            "pub_key": "027303a99a67e64858b9f5fc80943fc5288dabb6396b17dcb567afea2c9c39d54a",
+            "last_update": 1710856594,
+            "alias": "JoopTeun",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "93.95.227.109:9735"
+                    "addr": "45.147.160.80:9735"
                 },
                 {
                     "network": "tcp",
-                    "addr": "cjrlbqxazfy2bva7rouyqkmmjj6w7uzorgd65zhhn3oi57g7keopivqd.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "6": {
-                    "name": "gossip-queries",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "181": {
-                    "name": "simple-taproot-chans-x",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02826f50035eca93c7ebfbad4f9621a8eb201f4e28f994db5b6b5af32a65efb6b9"
-        },
-        {
-            "last_update": 1710640386,
-            "alias": "BetweenBits1",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "ahlrnon3m5dnn3v7ugjtz63dhiluuwp7g3hxnb4exzwmx65bogmewzad.onion:9735"
+                    "addr": "zb7zfxxxgoggqa47l27ww3jmqpoqgtav5la42vixouudvbgupxifulid.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -502,11 +201,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "23": {
                     "name": "anchors-zero-fee-htlc-tx",
                     "is_required": false,
@@ -527,26 +221,27 @@
                     "is_required": false,
                     "is_known": true
                 },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
                 "2023": {
                     "name": "script-enforced-lease",
                     "is_required": false,
                     "is_known": true
                 }
             },
-            "custom_records": {},
-            "id": "02a81f90ae5574dc84bc3ae2db50ff995f32c02a90f64ed1b5c5d74e91bbe72d0f"
+            "custom_records": {}
         },
         {
-            "last_update": 1706725119,
-            "alias": "xmrk",
+            "pub_key": "02b705ad9fff5b30e69dd3810d100372332c1a750db5a50edf7353c77ab486643e",
+            "last_update": 1710854344,
+            "alias": "sparksNode \ud83d\udca5",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "5.75.184.195:41787"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "7c5zeyzfbtwf3q7v7efduer5tnh7cp3rbzukleimwx5ldppwexfmu7ad.onion:9735"
+                    "addr": "w7ytfe7tms7ph7l6usancypopci254ztmlaqqwatpcu2pxjzxaj673id.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -622,19 +317,19 @@
                     "is_known": true
                 }
             },
-            "custom_records": {},
-            "id": "033878501f9a4ce97dba9a6bba4e540eca46cb129a322eb98ea1749ed18ab67735"
+            "custom_records": {}
         },
         {
-            "last_update": 1710746023,
-            "alias": "Chessa \u2728",
+            "pub_key": "0217603b3450466d08265399ea6a00d2f258f5fbe0f935746dbe9c3dd979ce24f2",
+            "last_update": 1710640320,
+            "alias": "PeaceLND",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "bymcbiwcleiyanmvuwcz2dgcppipqghhybnxca7uvvrwlgxhaihescid.onion:9735"
+                    "addr": "s4xgdywnerwyl477tvxljxnqyudpplbrvc6b5g7jagukskjfkkthfqyd.onion:9735"
                 }
             ],
-            "color": "#8413f5",
+            "color": "#e04ff8",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -671,11 +366,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "23": {
                     "name": "anchors-zero-fee-htlc-tx",
                     "is_required": false,
@@ -696,16 +386,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "55": {
                     "name": "keysend",
                     "is_required": false,
@@ -717,10 +397,10 @@
                     "is_known": true
                 }
             },
-            "custom_records": {},
-            "id": "03f4553a2e6092fb7c03e7c4041451d9946e7326f6bf2c852278dacbaff798a4b3"
+            "custom_records": {}
         },
         {
+            "pub_key": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba",
             "last_update": 1710852678,
             "alias": "nicehash-ln1",
             "addresses": [
@@ -797,10 +477,10 @@
                     "is_known": true
                 }
             },
-            "custom_records": {},
-            "id": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba"
+            "custom_records": {}
         },
         {
+            "pub_key": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
             "last_update": 1709977298,
             "alias": "ACINQ",
             "addresses": [
@@ -886,372 +566,468 @@
                     "is_known": true
                 }
             },
-            "custom_records": {},
-            "id": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+            "custom_records": {}
+        },
+        {
+            "pub_key": "02f4fc0975ac75696c3a06c91553256f9a39bcc8de93b091c0db3500847e3fc007",
+            "last_update": 1700608090,
+            "alias": "NP4TT",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "tha5nzxl3oepm5m5ozq2ib3v5vrn6wmpq6zr4lhdij7j4nvqs2pm2rad.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {}
+        },
+        {
+            "pub_key": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f",
+            "last_update": 1710852249,
+            "alias": "Bitrefill Routing",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "54.77.250.40:9735"
+                }
+            ],
+            "color": "#ff001c",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {}
+        },
+        {
+            "pub_key": "0353ca731df02320a40b57d35c3b27a2bdaf62a47190481cf6f9d1335651cc4490",
+            "last_update": 1710841118,
+            "alias": "xrevupx",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "eo336rnf7afm5dnbwwtqwggj2aptrswj7wmaxtcubzqwm4ofpuxcjqad.onion:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {}
         }
     ],
     "edges": [
         {
-            "channel_id": "905674324881047553",
-            "chan_point": "258b853b71b2897d678ea2a1c7455dab5a892132b7872d76689a5490daa4d5b2:1",
-            "last_update": 1710856681,
-            "capacity": "5000000",
+            "node1_pub": "027303a99a67e64858b9f5fc80943fc5288dabb6396b17dcb567afea2c9c39d54a",
+            "node2_pub": "0217603b3450466d08265399ea6a00d2f258f5fbe0f935746dbe9c3dd979ce24f2",
+            "channel_id": "846786681184911361",
+            "chan_point": "b039ca4473d31c75b420e0b695b21e78af0f8f86238810e3bf49d285740f7d02:1",
+            "last_update": 1710806578,
+            "capacity": "500000",
             "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1",
-                "fee_rate_milli_msat": "2",
-                "disabled": false,
-                "max_htlc_msat": "2048000000",
-                "last_update": 1710856681,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "2500000",
-                "fee_base_msat": "0",
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "250",
                 "fee_rate_milli_msat": "50",
                 "disabled": false,
-                "max_htlc_msat": "33554432",
-                "last_update": 1710856641,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023631624e30ef7bcb2887e600da8e59608a093718bc40d35b7a57145a0f3db9af",
-            "node2_pub": "02826f50035eca93c7ebfbad4f9621a8eb201f4e28f994db5b6b5af32a65efb6b9"
-        },
-        {
-            "channel_id": "916493519479963648",
-            "chan_point": "f537d97d9cd8e2be5e4fefe6a4c615f8e48cd602e75fcc7cf2d2de29f09aeafe:0",
-            "last_update": 1710851341,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1",
-                "fee_rate_milli_msat": "422",
-                "disabled": false,
-                "max_htlc_msat": "1024000000",
-                "last_update": 1710851341,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710792366,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "84",
+                "disabled": false,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710806578,
+                "custom_records": {}
+            },
+            "custom_records": {}
+        },
+        {
+            "node1_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba",
+            "node2_pub": "02f4fc0975ac75696c3a06c91553256f9a39bcc8de93b091c0db3500847e3fc007",
+            "channel_id": "856191903629639681",
+            "chan_point": "03b43e1001e2a3659d3157ff1fa9ef0fac574f4c990db864c9afdee3a4905f23:1",
+            "last_update": 1710826535,
+            "capacity": "12000000",
+            "node1_policy": {
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710778892,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023631624e30ef7bcb2887e600da8e59608a093718bc40d35b7a57145a0f3db9af",
-            "node2_pub": "03f4553a2e6092fb7c03e7c4041451d9946e7326f6bf2c852278dacbaff798a4b3"
-        },
-        {
-            "channel_id": "889654440513634305",
-            "chan_point": "56ca959ba09ef196db51d9d37210508096a690ffb479110d50fc23e8c147ca09:1",
-            "last_update": 1710854584,
-            "capacity": "21069420",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "3",
-                "disabled": false,
-                "max_htlc_msat": "20858726000",
-                "last_update": 1710854584,
+                "max_htlc_msat": "11880000000",
+                "last_update": 1708936377,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 420,
-                "min_htlc": "1000",
-                "fee_base_msat": "9999000",
-                "fee_rate_milli_msat": "969",
-                "disabled": false,
-                "max_htlc_msat": "20858726000",
-                "last_update": 1710771869,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c5528c628681aa17ab9e117aa3ee6f06c750dfb17df758ecabcd68f1567ad8c1",
-            "node2_pub": "02a81f90ae5574dc84bc3ae2db50ff995f32c02a90f64ed1b5c5d74e91bbe72d0f"
-        },
-        {
-            "channel_id": "806532460941672458",
-            "chan_point": "3fea14c84516b2503db4bfa197b3e7624f44d8db25b3b92c0285a65b89d782de:10",
-            "last_update": 1710854670,
-            "capacity": "8000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "10000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710854670,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 420,
-                "min_htlc": "1000",
-                "fee_base_msat": "9999000",
-                "fee_rate_milli_msat": "969",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710854669,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c5528c628681aa17ab9e117aa3ee6f06c750dfb17df758ecabcd68f1567ad8c1",
-            "node2_pub": "02f460ae6d3d3e104f8afe520ae0cff3d94c35c2ba8df66da89f3c8006a265b90a"
-        },
-        {
-            "channel_id": "810677619872890881",
-            "chan_point": "a57521f06850aa1ed6951109754ed7fed3bab5174c55b770bd1cbea38fded879:1",
-            "last_update": 1710855335,
-            "capacity": "10169420",
-            "node1_policy": {
                 "time_lock_delta": 100,
                 "min_htlc": "1000",
                 "fee_base_msat": "500",
                 "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "10067726000",
-                "last_update": 1710855335,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 420,
-                "min_htlc": "1000",
-                "fee_base_msat": "9999000",
-                "fee_rate_milli_msat": "969",
-                "disabled": false,
-                "max_htlc_msat": "10067726000",
-                "last_update": 1710811469,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c5528c628681aa17ab9e117aa3ee6f06c750dfb17df758ecabcd68f1567ad8c1",
-            "node2_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba"
-        },
-        {
-            "channel_id": "803639645902995457",
-            "chan_point": "8883741ab79fd11eeb32b1b89c8f66a9166098c784c87e45725e40a774ef5945:1",
-            "last_update": 1710779069,
-            "capacity": "6669420",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "400000000",
-                "last_update": 1710703755,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 420,
-                "min_htlc": "1000",
-                "fee_base_msat": "69420",
-                "fee_rate_milli_msat": "2569",
-                "disabled": false,
-                "max_htlc_msat": "6669420000",
-                "last_update": 1710779069,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c5528c628681aa17ab9e117aa3ee6f06c750dfb17df758ecabcd68f1567ad8c1",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "912294484525449217",
-            "chan_point": "b2c27d2e7e7382f50a7b257625df952855a2c0a27e792a1b5c2687647dabd922:1",
-            "last_update": 1710854492,
-            "capacity": "2069420",
-            "node1_policy": {
-                "time_lock_delta": 420,
-                "min_htlc": "1000",
-                "fee_base_msat": "9999000",
-                "fee_rate_milli_msat": "969",
-                "disabled": false,
-                "max_htlc_msat": "2048726000",
-                "last_update": 1710806069,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2048726000",
-                "last_update": 1710854492,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c5528c628681aa17ab9e117aa3ee6f06c750dfb17df758ecabcd68f1567ad8c1",
-            "node2_pub": "03f4553a2e6092fb7c03e7c4041451d9946e7326f6bf2c852278dacbaff798a4b3"
-        },
-        {
-            "channel_id": "851739981126762497",
-            "chan_point": "a10d1e87b630afb9a65ab2446428242d7093b370a8eb04bd63b30b41e6f58629:1",
-            "last_update": 1710830804,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "2500000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "250",
-                "disabled": false,
-                "max_htlc_msat": "67108864",
-                "last_update": 1710830804,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "10000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "98",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710809670,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02f460ae6d3d3e104f8afe520ae0cff3d94c35c2ba8df66da89f3c8006a265b90a",
-            "node2_pub": "02826f50035eca93c7ebfbad4f9621a8eb201f4e28f994db5b6b5af32a65efb6b9"
-        },
-        {
-            "channel_id": "872351426129297409",
-            "chan_point": "1e1b6c76f7d4aa8e14753adff8a5e26638b50645c4f050197555025c682466d6:1",
-            "last_update": 1710853535,
-            "capacity": "33000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "10000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "848",
-                "disabled": false,
-                "max_htlc_msat": "32670000000",
-                "last_update": 1710791160,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "66",
-                "disabled": false,
-                "max_htlc_msat": "32670000000",
-                "last_update": 1710853535,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02f460ae6d3d3e104f8afe520ae0cff3d94c35c2ba8df66da89f3c8006a265b90a",
-            "node2_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba"
-        },
-        {
-            "channel_id": "890618712284594176",
-            "chan_point": "e9612e54537118f81f40f85341da7ad07343e0be6bfe25904ef48dc0ae5c6af9:0",
-            "last_update": 1710788292,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "20",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1706666663,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
                 "disabled": true,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710788292,
+                "max_htlc_msat": "11880000000",
+                "last_update": 1710826535,
                 "custom_records": {}
             },
-            "custom_records": {},
-            "node1_pub": "03d8ef4620be554d89902bc9fde9498b67790f416833b84d76298e248e4fccef56",
-            "node2_pub": "033878501f9a4ce97dba9a6bba4e540eca46cb129a322eb98ea1749ed18ab67735"
+            "custom_records": {}
         },
         {
-            "channel_id": "890008483268722689",
-            "chan_point": "3d7354a71f1e121f48b18ad218f63d1262a3352941d1c78ff3df52347e5fb441:1",
-            "last_update": 1710844092,
-            "capacity": "596696",
+            "node1_pub": "02f4fc0975ac75696c3a06c91553256f9a39bcc8de93b091c0db3500847e3fc007",
+            "node2_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f",
+            "channel_id": "856191903629639683",
+            "chan_point": "03b43e1001e2a3659d3157ff1fa9ef0fac574f4c990db864c9afdee3a4905f23:3",
+            "last_update": 1710827582,
+            "capacity": "12000000",
             "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "11880000000",
+                "last_update": 1708936377,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "4000",
+                "disabled": true,
+                "max_htlc_msat": "11880000000",
+                "last_update": 1710827582,
+                "custom_records": {}
+            },
+            "custom_records": {}
+        },
+        {
+            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+            "node2_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f",
+            "channel_id": "861833497883574273",
+            "chan_point": "0482621aeb0de1762640b99dfc600326903a52d11c8dcdf02a5e5d2652732c8f:1",
+            "last_update": 1710843782,
+            "capacity": "20000000",
+            "node1_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "4000",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710843782,
+                "custom_records": {}
+            },
+            "node2_policy": {
                 "time_lock_delta": 144,
                 "min_htlc": "1",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "499",
                 "disabled": false,
-                "max_htlc_msat": "268513000",
-                "last_update": 1710255983,
+                "max_htlc_msat": "19800000000",
+                "last_update": 1710773696,
+                "custom_records": {}
+            },
+            "custom_records": {}
+        },
+        {
+            "node1_pub": "0217603b3450466d08265399ea6a00d2f258f5fbe0f935746dbe9c3dd979ce24f2",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+            "channel_id": "868275536468508673",
+            "chan_point": "8f39a77c466153c950748c07161214f0b87849b2072f33d576ac014b273576f3:1",
+            "last_update": 1710851120,
+            "capacity": "1500000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "250",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1500000000",
+                "last_update": 1710844566,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
+                "time_lock_delta": 144,
+                "min_htlc": "1",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
+                "fee_rate_milli_msat": "499",
                 "disabled": false,
-                "max_htlc_msat": "268513000",
-                "last_update": 1710844092,
+                "max_htlc_msat": "800000000",
+                "last_update": 1710851120,
                 "custom_records": {}
             },
-            "custom_records": {},
-            "node1_pub": "03d8ef4620be554d89902bc9fde9498b67790f416833b84d76298e248e4fccef56",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+            "custom_records": {}
         },
         {
-            "channel_id": "863224380019245057",
-            "chan_point": "e2333fc2241f5a643042f9c3cc63445bda954f364be7a2b9a10d8efe2ccf0ea2:1",
-            "last_update": 1710837335,
-            "capacity": "5500000",
+            "node1_pub": "02ed2ba8e0138de3155fd33ba025c9840f0a409b221321140b838ba49fc3275b3b",
+            "node2_pub": "0353ca731df02320a40b57d35c3b27a2bdaf62a47190481cf6f9d1335651cc4490",
+            "channel_id": "881279460444864513",
+            "chan_point": "fb3bcb3309588a29ecf7aa76251ec099d2f201e6723a3440ac4a504206f9e233:1",
+            "last_update": 1710855640,
+            "capacity": "2000000",
             "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "2500000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1200",
+                "time_lock_delta": 100,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "50",
                 "disabled": false,
-                "max_htlc_msat": "2147483648",
-                "last_update": 1710809204,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710821835,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "325",
+                "disabled": false,
+                "max_htlc_msat": "1500000000",
+                "last_update": 1710855640,
+                "custom_records": {}
+            },
+            "custom_records": {}
+        },
+        {
+            "node1_pub": "02b705ad9fff5b30e69dd3810d100372332c1a750db5a50edf7353c77ab486643e",
+            "node2_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba",
+            "channel_id": "891818279431438336",
+            "chan_point": "316bc4974bc4382554b80ba30eaaecf18c3f45f03fed41f99e9600d1c5dd3029:0",
+            "last_update": 1710800025,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "550",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710800025,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 100,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "3",
+                "fee_rate_milli_msat": "71",
                 "disabled": false,
-                "max_htlc_msat": "5445000000",
-                "last_update": 1710837335,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710769269,
                 "custom_records": {}
             },
-            "custom_records": {},
-            "node1_pub": "02826f50035eca93c7ebfbad4f9621a8eb201f4e28f994db5b6b5af32a65efb6b9",
-            "node2_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba"
+            "custom_records": {}
         },
         {
-            "channel_id": "891000242730369025",
-            "chan_point": "62fa5f64440a9834834556417619821bee9cce1fc9e178b438791e3cf958aced:1",
-            "last_update": 1710791204,
+            "node1_pub": "02b705ad9fff5b30e69dd3810d100372332c1a750db5a50edf7353c77ab486643e",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+            "channel_id": "908655100992880641",
+            "chan_point": "0acfd2470db4eb06268b3f22b4c45c0fdcc11d10b6519577662e54823a0f264e:1",
+            "last_update": 1710841427,
             "capacity": "10000000",
             "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "2500000",
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
                 "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1200",
+                "fee_rate_milli_msat": "150",
                 "disabled": false,
-                "max_htlc_msat": "4294967296",
-                "last_update": 1710791204,
+                "max_htlc_msat": "4500000000",
+                "last_update": 1710841427,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -1261,130 +1037,43 @@
                 "fee_rate_milli_msat": "499",
                 "disabled": false,
                 "max_htlc_msat": "4500000000",
-                "last_update": 1710388692,
+                "last_update": 1710835874,
                 "custom_records": {}
             },
-            "custom_records": {},
-            "node1_pub": "02826f50035eca93c7ebfbad4f9621a8eb201f4e28f994db5b6b5af32a65efb6b9",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+            "custom_records": {}
         },
         {
-            "channel_id": "875742319905538049",
-            "chan_point": "f4536026e5cde574cdae70158fd4a38071b3bb70283f7f607f32a6b6d95d9e31:1",
-            "last_update": 1710811414,
-            "capacity": "4000000",
+            "node1_pub": "022e9a32023ba0975a08076006a91ffab8872f5efe35319c094949d17b267dd14a",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+            "channel_id": "909624870216794113",
+            "chan_point": "e3fa81525f15b48f53c1d3ee0bf1bd3c490a690932d66d96113546c0e711ba4f:1",
+            "last_update": 1710844270,
+            "capacity": "10000000",
             "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "163",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710777184,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710811414,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02a81f90ae5574dc84bc3ae2db50ff995f32c02a90f64ed1b5c5d74e91bbe72d0f",
-            "node2_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba"
-        },
-        {
-            "channel_id": "822739262397939713",
-            "chan_point": "103adf6d1cd8cb046f9104170952b44ef1d6e4dd1115536b882980f8cd3d4bfd:1",
-            "last_update": 1710788735,
-            "capacity": "12540428",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "390",
-                "disabled": false,
-                "max_htlc_msat": "12415024000",
-                "last_update": 1706706263,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "500",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "12415024000",
-                "last_update": 1710788735,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "033878501f9a4ce97dba9a6bba4e540eca46cb129a322eb98ea1749ed18ab67735",
-            "node2_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba"
-        },
-        {
-            "channel_id": "912301081592332288",
-            "chan_point": "a5614f49b621627bbe1068d025b81a32bc3a443a70678bc210956dca178d151f:0",
-            "last_update": 1710853535,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "299",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710853535,
-                "custom_records": {}
-            },
-            "node2_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710802292,
+                "max_htlc_msat": "4500000000",
+                "last_update": 1710844270,
                 "custom_records": {}
             },
-            "custom_records": {},
-            "node1_pub": "03f4553a2e6092fb7c03e7c4041451d9946e7326f6bf2c852278dacbaff798a4b3",
-            "node2_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba"
-        },
-        {
-            "channel_id": "908613319477559296",
-            "chan_point": "cfb2f76ca8478a857b5c4520ba1d86c37234161530e36af96abc830fc3e31359:0",
-            "last_update": 1710839372,
-            "capacity": "5000000",
-            "node1_policy": {
+            "node2_policy": {
                 "time_lock_delta": 144,
                 "min_htlc": "1",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "499",
                 "disabled": false,
-                "max_htlc_msat": "10000000",
-                "last_update": 1710839372,
+                "max_htlc_msat": "4500000000",
+                "last_update": 1710488605,
                 "custom_records": {}
             },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2250000000",
-                "last_update": 1710800492,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03f4553a2e6092fb7c03e7c4041451d9946e7326f6bf2c852278dacbaff798a4b3",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+            "custom_records": {}
         },
         {
+            "node1_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
             "channel_id": "910688097976844288",
             "chan_point": "1842477544dba187a5eec5f94f99d1f84ea6b44f6e37fa941b777d657b60a198:0",
             "last_update": 1710756335,
@@ -1409,9 +1098,94 @@
                 "last_update": 1710329935,
                 "custom_records": {}
             },
-            "custom_records": {},
-            "node1_pub": "037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+            "custom_records": {}
+        },
+        {
+            "node1_pub": "022e9a32023ba0975a08076006a91ffab8872f5efe35319c094949d17b267dd14a",
+            "node2_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f",
+            "channel_id": "914020717692649473",
+            "chan_point": "e1b6ec692e4b38f31863ab65942577a27c85ab22bfcd9911d011d88dfee80c78:1",
+            "last_update": 1710775870,
+            "capacity": "2500000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "2475000000",
+                "last_update": 1710775870,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 200,
+                "min_htlc": "1000",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "2000",
+                "disabled": false,
+                "max_htlc_msat": "2475000000",
+                "last_update": 1710775382,
+                "custom_records": {}
+            },
+            "custom_records": {}
+        },
+        {
+            "node1_pub": "02b705ad9fff5b30e69dd3810d100372332c1a750db5a50edf7353c77ab486643e",
+            "node2_pub": "0353ca731df02320a40b57d35c3b27a2bdaf62a47190481cf6f9d1335651cc4490",
+            "channel_id": "915764543201214465",
+            "chan_point": "abb62e1e66e87d26899d003c309895356cd9fecead0f59faf890c66e4162fab7:1",
+            "last_update": 1710847412,
+            "capacity": "3000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "350",
+                "disabled": false,
+                "max_htlc_msat": "2970000000",
+                "last_update": 1710814426,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "890",
+                "disabled": false,
+                "max_htlc_msat": "1500000000",
+                "last_update": 1710847412,
+                "custom_records": {}
+            },
+            "custom_records": {}
+        },
+        {
+            "node1_pub": "02ed2ba8e0138de3155fd33ba025c9840f0a409b221321140b838ba49fc3275b3b",
+            "node2_pub": "027303a99a67e64858b9f5fc80943fc5288dabb6396b17dcb567afea2c9c39d54a",
+            "channel_id": "917898695256702977",
+            "chan_point": "5273d25d66d45bc8e5d2e2ecddfc6458d0c302fac53aad14cbc24609bebed2db:1",
+            "last_update": 1710838461,
+            "capacity": "500000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710838461,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "10",
+                "disabled": false,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710785651,
+                "custom_records": {}
+            },
+            "custom_records": {}
         }
     ]
 }

--- a/test/data/LN_100.json
+++ b/test/data/LN_100.json
@@ -4,12 +4,92 @@
     "graph": {},
     "nodes": [
         {
-            "last_update": 1710745155,
-            "alias": "039fe3a61b5ca53e7303",
+            "last_update": 1710607733,
+            "alias": "BlueWave",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "4keohmkplnat5hdjfjnyxjraxc7fxgtyrmk26zxyvscyuwdkqfkepwad.onion:9735"
+                    "addr": "bh32yyu7dgyodzq3wdunho5esew5qbvrd2flsynqzeyilnd7jnyeahqd.onion:9735"
+                }
+            ],
+            "color": "#d6de37",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "0242902a3a5aa34829db9def5b44939f9f459f4ee08e97cba18516c62ddf8ec9e6"
+        },
+        {
+            "last_update": 1702845433,
+            "alias": "03796678b7111abef10f",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "kgrxo24cm2ykhfazqer7bxzezcevrmir2du455o4mfbg3rpvqubpaqqd.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -69,90 +149,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "039fe3a61b5ca53e73035d29535f2335637c26fc16098f9c904df8b1d9659870ed"
-        },
-        {
-            "last_update": 1710661619,
-            "alias": "MerchantConnectHUB",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "13.48.127.153:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "oer3c7qbszh4addvims7tzb6cuczoppgef5g5r3e27ii2msbe7gws5ad.onion:9735"
-                }
-            ],
-            "color": "#f73718",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "55": {
                     "name": "keysend",
                     "is_required": false,
@@ -165,108 +161,18 @@
                 }
             },
             "custom_records": {},
-            "id": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a"
+            "pub_key": "03796678b7111abef10f3ff85b88f81f9cfe81cac7e3628a11af1679ed912757d5"
         },
         {
-            "last_update": 1710781815,
-            "alias": "Fopstronaut",
+            "last_update": 1709578090,
+            "alias": "REDWHISPER",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "46j5jejiwxbsangywayyrkgvdse35grgmbi5cn7wnpedcl22ejy6egid.onion:9735"
+                    "addr": "piwsugtc6hr3jukavptmv6tjrxt2wt2i2q35lvjx6lk25vwvi43zicqd.onion:9735"
                 }
             ],
-            "color": "#c35817",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0240b2b1f91d742327ebd34ea1129985ec98f9c08f7ab9a884a77ff3472897242e"
-        },
-        {
-            "last_update": 1710607875,
-            "alias": "FreeRoaming",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "7uwdcv7ks7ws64pxbllaof23zfg4gcqwusow5vjpiv2ct7zgzx2ltbyd.onion:9735"
-                }
-            ],
-            "color": "#027649",
+            "color": "#023bb9",
             "features": {
                 "1": {
                     "name": "data-loss-protect",
@@ -305,6 +211,11 @@
                 },
                 "17": {
                     "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
                     "is_required": false,
                     "is_known": true
                 },
@@ -340,654 +251,15 @@
                 }
             },
             "custom_records": {},
-            "id": "0276499dd9775f36cf95506c16e14ed6ec4cf230e8e5d341a441e1190d3f9e1e4f"
+            "pub_key": "023bb9937dea9707583e45aa6708af0c5d16d9ca3970f67ab76606f43b7457309d"
         },
         {
-            "last_update": 1710803106,
-            "alias": "Deenmo \u96fb\u6bcd",
+            "last_update": 1710772374,
+            "alias": "fr33node",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "eyr5o3rzgmfozqhkl7jfwiw2w4g34azax7h2djlnma2svt25w6kiz5qd.onion:9735"
-                }
-            ],
-            "color": "#ff777f",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "181": {
-                    "name": "simple-taproot-chans-x",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0223d7aa491e26a307b4203916b8d60ded8cfe832806b432d6cfc278e96374f9aa"
-        },
-        {
-            "last_update": 1710856667,
-            "alias": "zap.opentimestamps.org",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "51.158.54.115:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[2001:bc8:1201:71a:2e59:e5ff:fe42:52f4]:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "df6vnwqzdsywgqlv3krv27gytggca3xx5i2rx5xsg4undvmwnebyoaqd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "181": {
-                    "name": "simple-taproot-chans-x",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9"
-        },
-        {
-            "last_update": 1710714184,
-            "alias": "Mintter",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "23.20.24.146:9734"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d"
-        },
-        {
-            "last_update": 1710337046,
-            "alias": "Eternal Mole",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "zajf44jbpuaenwtjlih2x56agm2pfvms3hkqzghifu2phgtwnxb553yd.onion:9735"
-                }
-            ],
-            "color": "#ff2148",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02da4f536ea290aa280854d6165fa5a23151f072ed8ee285e8658db91a942db9fd"
-        },
-        {
-            "last_update": 1710777026,
-            "alias": "wyssblitz",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "85.195.227.160:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[2a02:168:6219:faac:bc:1:0:1]:9736"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "ozw5ef4kkornd45fztjjyrtf6eneqn2uxjoa3acefg67huvlth5pgaid.onion:9735"
-                }
-            ],
-            "color": "#ffd700",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2"
-        },
-        {
-            "last_update": 1710856655,
-            "alias": "8DegreesWO",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "123.243.56.82:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "qibbostfivjwvjynom3qv4ia27ppz2pkfnvu4pmqylq32ddjuskpiwad.onion:9735"
-                }
-            ],
-            "color": "#324851",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5"
-        },
-        {
-            "last_update": 1551797168,
-            "alias": "lndh4xx0r",
-            "addresses": [],
-            "color": "#68f442",
-            "features": {},
-            "custom_records": {},
-            "id": "027e5ef63402f1a74c1293f46a0bae52625745ff9184b277506d4645f99f22d629"
-        },
-        {
-            "last_update": 1710856657,
-            "alias": "The Wall",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "150.136.37.44:9735"
-                }
-            ],
-            "color": "#000000",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "729": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4"
-        },
-        {
-            "last_update": 1710757844,
-            "alias": "ComputoErgoSumZeroBaseFee",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "tofnbpwqhikarql65yxtalwgopoabmejmandzakkng3gn7vlyps724yd.onion:9735"
+                    "addr": "ubzmye2tytcqarycr3jsirl3ajxallddfpvorc4t2odao4y5yovdalad.onion:9735"
                 }
             ],
             "color": "#68f442",
@@ -1054,4789 +326,7 @@
                 }
             },
             "custom_records": {},
-            "id": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c"
-        },
-        {
-            "last_update": 1710754315,
-            "alias": "zlnd0",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "54.87.193.89:9735"
-                }
-            ],
-            "color": "#141414",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0251fff168b58b74e9b476af5a515b91fe0540a3681bc97fbb65379a807aea5f66"
-        },
-        {
-            "last_update": 1710726528,
-            "alias": "7th Mountain",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "6zpzxqd4jgjopx6doaqrvku6uz5khtbwswidqfryotseavdvr7hfeuyd.onion:9735"
-                }
-            ],
-            "color": "#d105ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "037e8b1af65a511e3baf38e45509fb1bfb8023a6e5e2555774998b9ce91a3c58b6"
-        },
-        {
-            "last_update": 1710282531,
-            "alias": "jrfoliveira-lnd-br",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "ekwpfzs3a3brnixfbfbj4bs5aq3r4u2esabauqs2aqmngzk5kiifuwyd.onion:9735"
-                }
-            ],
-            "color": "#236dc9",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03ab5a4b4f9883321da39bcac78f298c673f5d3f0d90cac8780d7f730fed8c2193"
-        },
-        {
-            "last_update": 1709149992,
-            "alias": "DeutscheBank|CLN",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "90.146.207.67:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[fe80::3bc7:c09f:5a3e:f7ab:9735]:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "bafx5t6dmxwm5ocwawt2o6yrdlyksuqt7c6liylopkok4y3rnytqghid.onion:9735"
-                }
-            ],
-            "color": "#0018a8",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "6": {
-                    "name": "gossip-queries",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "29": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "35": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "39": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "41": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "43": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "163": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                }
-            },
-            "custom_records": {},
-            "id": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09"
-        },
-        {
-            "last_update": 1710856956,
-            "alias": "adam.masterofpearls.net",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "103.126.161.212:9742"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "yun2c4togcga4kdvzudldhlohzr2jhluxm6l5txi6kzo5qjwbribjqyd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad"
-        },
-        {
-            "last_update": 1710802848,
-            "alias": "Freedom",
-            "addresses": [],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "036eb0617ee7a70277b2e48cfe98f0b82943409a81edf7fdbc2296995273033665"
-        },
-        {
-            "last_update": 1710785680,
-            "alias": "03bcf1f73199ed4445a8",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "dpdviwkmpgeje5c5o5rg2e6q673csnpq67d2szezfrd6gl56kdetf4qd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02"
-        },
-        {
-            "last_update": 1710852027,
-            "alias": "NERV",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "130.44.132.180:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "q6npaalvvlnxulczsxuwmdhjwlozvthrn543kxkpn7t6f7qvxjazd5qd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a"
-        },
-        {
-            "last_update": 1710613588,
-            "alias": "028d9e9348bb5594bc5c",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "rxce2vyulvcrskc3mxi2xp723evl7yrtowinx6ddjlyb5r4wlu3r2iad.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "028d9e9348bb5594bc5ccf195fa193fb3260287bb0529a65a74570fc2907c8cf36"
-        },
-        {
-            "last_update": 1710856578,
-            "alias": "LN-Fukaya Japan",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "133.18.236.236:9735"
-                }
-            ],
-            "color": "#f0fff0",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c"
-        },
-        {
-            "last_update": 1710856043,
-            "alias": "LNB\u03dfG [Hub-1]",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "213.174.156.66:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[2a02:b48:207:2:9735:9735:0:1]:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "qimt6abvc2iuexwrtl5tzyrygnu7mshjahvresve5hdli6nstdg7elyd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "181": {
-                    "name": "simple-taproot-chans-x",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "last_update": 1710824916,
-            "alias": "NewMoney",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "46.27.201.147:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "etwfiieipjmomcjlda4vc27fxjee5nfaac73ysp6ych54m5mtwihtead.onion:9735"
-                }
-            ],
-            "color": "#39ff14",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e"
-        },
-        {
-            "last_update": 1705171744,
-            "alias": "nodeacademy",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "efeeepycsti2yqlhfku3mdke76rak62q2jf675pqc35ksm6ncohwmqid.onion:9735"
-                }
-            ],
-            "color": "#ff0000",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02e48fa379deeef66dd8cc9c6e60581d5467eb13ed8bb93ad06ee8de064b0134b9"
-        },
-        {
-            "last_update": 1710636110,
-            "alias": "Nerdminer.store",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "3a7rhzcnikasbsudpbhyhynqgfsjato4v26wmuri25xobw7rql4nrmid.onion:9735"
-                }
-            ],
-            "color": "#f7931a",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02926a7ec4f47b624239aac1652228971ac812c6ff813efe9b5e772184cf3cdc31"
-        },
-        {
-            "last_update": 1710854445,
-            "alias": "chapmanjw \ud83d\udc27",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "fhxnffkcokchjh567m3dma3jpup7wi6dlxo6u2pmn7b6bmp6fzuvobyd.onion:9735"
-                }
-            ],
-            "color": "#6031c0",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa"
-        },
-        {
-            "last_update": 1710664963,
-            "alias": "Blitzknoten",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "fhdndjrermtvez7vr76z63plo7kwnsmwejh43a624uunwc6cnw5ousqd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03fc8b5c254d4764d145b98a7a823791ed1f37c9d965d8068468f9711c44a76cf5"
-        },
-        {
-            "last_update": 1710816747,
-            "alias": "CoinPayments",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "213.167.79.31:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1"
-        },
-        {
-            "last_update": 1710854098,
-            "alias": "NodeMcNodyface2000",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "46.101.71.189:9736"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "m5j5lkipfnrrmw75bp3ny47s2rtvqu3wut5r53fkcnu5j32vyx3hruyd.onion:9735"
-                }
-            ],
-            "color": "#ff00ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03d9231f97a1dccd822ffc58226e9c7f2bec9dac00df4c0ff6c73b3d3f6c6ef6ea"
-        },
-        {
-            "last_update": 1710856703,
-            "alias": "River Financial 1",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "34.68.41.206:9735"
-                }
-            ],
-            "color": "#f2a900",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a"
-        },
-        {
-            "last_update": 1710836139,
-            "alias": "Lite Roast",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "66cvqxwi2fjku2qphbkfiwvriq36fmjz2xszwcdpz476t7iev5vq6zqd.onion:9735"
-                }
-            ],
-            "color": "#ef820d",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9"
-        },
-        {
-            "last_update": 1710847603,
-            "alias": "ln1.BitcoLi.com",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "217.170.101.208:9736"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "l37fatn3xqp2msebagkxsyh3cbxswqfah5i5kzkrq22hgj7nku6dv5id.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "032cd1bac674b61e993c9c0afe8efe23e3b1eb30246719010f2cf0f1452ee21e2b"
-        },
-        {
-            "last_update": 1668163837,
-            "alias": "tardis",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "ihkzcyadixtgovl37oceqjhbbjae4diphvl3anut5t5gwlbglkd62cyd.onion:9736"
-                }
-            ],
-            "color": "#0283ce",
-            "features": {
-                "1": {
-                    "name": "data-loss-protect",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "21": {
-                    "name": "anchor-commitments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "35": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "39": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0283cee5a23b761503f4e1b38ed06c0559d1cfb3695a4ee23254f201f41bd52b3f"
-        },
-        {
-            "last_update": 1710854260,
-            "alias": "ElDorado18769",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "vxcmxpttq7p46nryvz2hvwb55x7fnhexxpqbu6xi6y7czhqrd6zkzlad.onion:9735"
-                }
-            ],
-            "color": "#ffd700",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0289411927ecaf49467c44093990b6f446a5d9b396fb6663b070c3f97e1b9359a6"
-        },
-        {
-            "last_update": 1692924529,
-            "alias": "NoHighFructose",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "u3gtdcd3yrzfnkmokgm5f5vcl6ekedk2f35ivydpy4c7tapfb3txjyid.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02cb080fa2386d00e74c90cb4a5a3fb8a16278c248adf851e6af3f67802fa6ab99"
-        },
-        {
-            "last_update": 1710837312,
-            "alias": "Yankee Hotel Foxtrot",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "91.236.230.11:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "favvhm4fbs3mbfjjvvfxyvtydf62jjmmkajwbac3bepzr27l3nbkclad.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03d6f80df785288de2fe5de19f24ba8a1db3d20647a88d0a903be9de3e7bb8fce1"
-        },
-        {
-            "last_update": 1710798523,
-            "alias": "Centella23",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "fd6bn67drecsqpjwmyutahtkccdczwqmbxiov3hlixulgj42wmqolqid.onion:9735"
-                }
-            ],
-            "color": "#ff3333",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03b14edc2c0645a69d641080ff968a8c75fa1247334da8b6fdc9c3e90ca6f99052"
-        },
-        {
-            "last_update": 1669358759,
-            "alias": "medea",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "midbdlknuz3nrtkzohgxyqpntyokblbzdzrswkjvptebdh3ogdpcuwyd.onion:9736"
-                }
-            ],
-            "color": "#600050",
-            "features": {
-                "1": {
-                    "name": "data-loss-protect",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02398b614028892474fc95ed64c48791f994975042d0bd7e9592d0ec4128bbace4"
-        },
-        {
-            "last_update": 1710786006,
-            "alias": "MajicMike",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "xojsx3rxlzyon3jbhpp6v3u6klca7y3yqy25izdzf4nj2fnwvi4icpyd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02464181ef50b59a26cde9aa37bd32ced1cb1923b4811165fb1e619b7507639083"
-        },
-        {
-            "last_update": 1710856591,
-            "alias": "okx",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "8.210.134.135:26658"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "last_update": 1710746375,
-            "alias": "Stay humble and stack sats",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "lcuuuilw2ltqard3p2bcxhzhcc3feqcqd3mwdngfvjpthyih2b22uzqd.onion:9735"
-                }
-            ],
-            "color": "#51e321",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02dcfd154ed7e84f19f73be69b6471e028c45db1a8f3d9bade7e0f2159ea12d492"
-        },
-        {
-            "last_update": 1710372546,
-            "alias": "kittyboy",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "170.75.174.88:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "46xw4pdqzw344yn4qk3sjmf6pak2uujtb2gbz3qpgwfia2txg6ohebyd.onion:9735"
-                }
-            ],
-            "color": "#4cbb17",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02063fec62479bdf7d43f046056303e48f5029108111ade42aef41c622a6245d52"
-        },
-        {
-            "last_update": 1710801494,
-            "alias": "allyourbankarebelongtous",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "68.183.118.179:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "tbpjgiwlk5bnmrog2lbxfzbzkyhuekktiwhr2qi7fe4374vs67qirlyd.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "035fed4182fbd0725264f8a0018cabb6b25514dd231291162ac8dd63afb278e9e8"
-        },
-        {
-            "last_update": 1710657383,
-            "alias": "alan\u2607soft",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "198.27.251.219:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[2001:5a8:40c7:f500:2601:7cdc:1a2d:661c]:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "yvof7h3hlvyzbd5idb3husw37mfxpvmkc56p2ljlkzhs66sqotsjfgyd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03aa776656f3d083baf8bc2c88f1555e62847adb52a2498a60d0d6a08d566fc256"
-        },
-        {
-            "last_update": 1710625730,
-            "alias": "5ElementsBoltz",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "fbwhu2c6rejsgfx7kejs5ud2xyykwvfuvesqxhqz46zpuroxkk5zxlqd.onion:9735"
-                }
-            ],
-            "color": "#93c47d",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03a0fbf509a4c1f14647934988c7b484da8ab6090e81d015c6746ecd1134a37207"
-        },
-        {
-            "last_update": 1710733257,
-            "alias": "centex",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "71.19.144.52:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "bga5yctvch2gphdaeho24vdkoidrilxy35qh7fqwtctmroh7dytwrzqd.onion:9735"
-                }
-            ],
-            "color": "#a8a8a3",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0210ef7d43c105753673563feb1e20fe344b844ab65aa710cb2288a257ec024c99"
-        },
-        {
-            "last_update": 1710646937,
-            "alias": "MoonDust",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "f6mjfz5px6e54onfdlb7nzatiigoxwuhs4scal3wdserovnveh2wuvyd.onion:9735"
-                }
-            ],
-            "color": "#99d6d3",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "026d1de80e59f3fe2b27aa3dc8012f4437165bf99971bd9b7d8afedb066f92d695"
-        },
-        {
-            "last_update": 1710856652,
-            "alias": "The Continental",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "93.95.229.250:9736"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "6mv24uxdtlhyzu5uioek46z3buriwwapwadyfy6wf4qmeflmmx56kiid.onion:9735"
-                }
-            ],
-            "color": "#800000",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "last_update": 1708957961,
-            "alias": "OnGlide",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "109.123.246.220:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[2a02:c206:2129:6277::1]:9735"
-                }
-            ],
-            "color": "#08873b",
-            "features": {
-                "1": {
-                    "name": "data-loss-protect",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03d64e760b4af3698e51eb7ed7d97fbbae41f8cd28c0bcb6851c21207922f6697d"
-        },
-        {
-            "last_update": 1710849539,
-            "alias": "PeterJFrancoIII",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "oyonslv2muhpngxl3yip3z7mt27auzlsx2luqydkxadludv2cva3thad.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972"
-        },
-        {
-            "last_update": 1709837050,
-            "alias": "Boltz|CLN",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "45.86.229.190:9736"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[2a10:1fc0:3::270:a9dc]:9736"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "oo5tkbbpgnqjopdjxepyfavx3yemtylgzul67s7zzzxfeeqpde6yr7yd.onion:9736"
-                }
-            ],
-            "color": "#ff9800",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "6": {
-                    "name": "gossip-queries",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018"
-        },
-        {
-            "last_update": 1710808140,
-            "alias": "thereisnoalternative",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "67i6uq57mskljlqhtnthciofkl7vyd367vsbfrsy7ha5h5cuoqpvksid.onion:9736"
-                }
-            ],
-            "color": "#028787",
-            "features": {
-                "1": {
-                    "name": "data-loss-protect",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02878765b772b842029f1808b768cc53ff6b88521c1fb3e4d409fda1f540f2122c"
-        },
-        {
-            "last_update": 1710856181,
-            "alias": "Prufa Fuerk - BTC Drag Queen",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "ahkmgbwfiurcj6xqd4n3iscecnoljkrufjhgy7et2zyu7rqqpsjmjzid.onion:9735"
-                }
-            ],
-            "color": "#ff7e33",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03e20ae8b749c3e5e8b96c66c98141177e7b75571b90cab80c9085af7c80bd3852"
-        },
-        {
-            "last_update": 1710835305,
-            "alias": "Orwel1984LN",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "fis5qyygan7bssw424zqzf6iynhm34wclvqzampjkaisfdproa76zxad.onion:9735"
-                }
-            ],
-            "color": "#37362b",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "026e10b080dc2ffba3966daeab5803a2d263788cef0750bff3001bda037e358d98"
-        },
-        {
-            "last_update": 1707896793,
-            "alias": "node2",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "vb3fjvfsidndxhia4fpkbazob4vjmegq6pzkhghnn7kfitfc7r37i6ad.onion:9735"
-                }
-            ],
-            "color": "#9fe2bf",
-            "features": {
-                "1": {
-                    "name": "data-loss-protect",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03e8b9a977fa3ae7acce74c25986c7240a921222e349729737df832a1b5ceb49df"
-        },
-        {
-            "last_update": 1710838956,
-            "alias": "Boltz",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "45.86.229.190:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "d7kak4gpnbamm3b4ufq54aatgm3alhx3jwmu6kyy2bgjaauinkipz3id.onion:9735"
-                }
-            ],
-            "color": "#ff9800",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "last_update": 1710844400,
-            "alias": "\u26a1satstacker\u26a1",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "74.91.123.238:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "rkvnpl7tqegx2khem3nv643e7cbhjgi7gyccg4i2favbumeflo7u3qid.onion:9735"
-                }
-            ],
-            "color": "#7851a9",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf"
-        },
-        {
-            "last_update": 1710771596,
-            "alias": "okcoin",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "47.243.25.4:26658"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "036b53093df5a932deac828cca6d663472dbc88322b05eec1d42b26ab9b16caa1c"
-        },
-        {
-            "last_update": 1710624233,
-            "alias": "GeldBoerse",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "6hh3xud4magn3c6pqqs6hem4ujxxnhcgpobakty2wtcf5fv2ltgosnqd.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004"
-        },
-        {
-            "last_update": 1709977298,
-            "alias": "ACINQ",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "3.33.236.230:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "of7husrflx7sforh3fw6yqlpwstee3wg5imvvmkp4bz6rbjxtg5nljad.onion:9735"
-                }
-            ],
-            "color": "#49daaa",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "29": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "39": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "last_update": 1710821651,
-            "alias": "OpenNode.com",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "18.222.70.85:9735"
-                }
-            ],
-            "color": "#000000",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "last_update": 1696866301,
-            "alias": "Mayonara",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "a36swbjelkpzzlq45b6rm6linuptkvd77soq6dfboqtrvz5xjls5g5ad.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03bd743abf0f94b6d208d1c3c47aa8e958d6ddd8aa4e8c910c6e1d6b8dd7413a93"
-        },
-        {
-            "last_update": 1710852494,
-            "alias": "Pakal",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "dterkiqrrorfaiie3ksojpyi3u4atiicei66j776pyxxus2htoubopyd.onion:9735"
-                }
-            ],
-            "color": "#33ff7c",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02c45389d58edf3c9dced6716791ed450ff632e74e962ac0d489047498f4e54a08"
-        },
-        {
-            "last_update": 1710766726,
-            "alias": "frontiblitz",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "vmw54zkpw273iutasc5xq6xqdwa4sbrrhjn4o2vhsdphietrnapgdgid.onion:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "80.135.69.168:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0216fcf031519e0924e5e4b64a731b207cccb85b13caebffd0f664a32a39bcd368"
-        },
-        {
-            "last_update": 1710852262,
-            "alias": "Clack Bank",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "xuajljlyr2ojnamraeet35qmo2ixvwusvs6flss7d5yojerbmolnneid.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660"
-        },
-        {
-            "last_update": 1710855194,
-            "alias": "Obi-Wan Cryptobi",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "a7datrripiey644ochuvanewzko6rf2x5p34e4r5lp2e2fxxix6rqtad.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8"
-        },
-        {
-            "last_update": 1710855939,
-            "alias": "lynchlight",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "27fhfzho7ao3wdxhlzttsuqgld7uypvcimgvuwt3kyuxj53lhgnsauyd.onion:9735"
-                }
-            ],
-            "color": "#68f442",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03740f82191202480ace717fcdf00f71a8b1eb9bdc2bb5e2106cd0ab5cb4d7a54e"
-        },
-        {
-            "last_update": 1710820471,
-            "alias": "southxchange.com",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "54.187.0.23:9735"
-                }
-            ],
-            "color": "#428bca",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
+            "pub_key": "02e45ec6486ad8d2b2dcfe3e994f89035f7f1975e800bfe56f030d910647601199"
         },
         {
             "last_update": 1710847816,
@@ -5925,18 +415,18 @@
                 }
             },
             "custom_records": {},
-            "id": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
+            "pub_key": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
         },
         {
-            "last_update": 1710666458,
-            "alias": "the-name-is-not-important",
+            "last_update": 1710855669,
+            "alias": "River Financial 2",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "vhicg76wyxy432m4esep5pchjqg3o5ijydrgsgb3pnhqbfhwlfjqk6ad.onion:9735"
+                    "addr": "34.136.230.235:9735"
                 }
             ],
-            "color": "#ff5000",
+            "color": "#ff9900",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -5998,11 +488,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "2023": {
                     "name": "script-enforced-lease",
                     "is_required": false,
@@ -6010,305 +495,15 @@
                 }
             },
             "custom_records": {},
-            "id": "032f3380e907937c704bef15f051d0747b942976e994a2e615ad3f5b8fb0aa6660"
+            "pub_key": "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5"
         },
         {
-            "last_update": 1710836136,
-            "alias": "deZentraliZe",
+            "last_update": 1707020283,
+            "alias": "027d5369f807773ed75d",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "vq4jg26bo3yisenvmrnmesdczuhxykvubo27s3wbgrawrma7sbsheqid.onion:9735"
-                }
-            ],
-            "color": "#35a224",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "last_update": 1588482652,
-            "alias": "ergos",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "xrgkr4cnnfs24hzz4pr5rj7ltne2jhwf7uxbgvvpzwrvkqbjctp776ad.onion:9735"
-                }
-            ],
-            "color": "#8865df",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "15": {
-                    "name": "payment-addr",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "032f2304b61a6e956c7e1d62d630fa163f9bcb91965dd79717b83e0023c7640305"
-        },
-        {
-            "last_update": 1710677279,
-            "alias": "SNIPER",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "3azcn4hsupz52sjyfwgf6rdd3tgc4ydo2ddamooy2rbzkvawy445tkid.onion:9735"
-                }
-            ],
-            "color": "#ff33f6",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02d7fd835234992a11895ab762fd58a0a5b9d4349560d9452273754bba38515fc1"
-        },
-        {
-            "last_update": 1710631652,
-            "alias": "Martian Bitcoin",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "af3uligphtel3en63b454niti7bozsf5t2hjeqfeuq7bxyhb2b3jl2yd.onion:9735"
-                }
-            ],
-            "color": "#ff0000",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03f20b295a728be64537bd7df1bf9092ed4bbf09b2c10f68c482d6fcb4f2232b28"
-        },
-        {
-            "last_update": 1710765882,
-            "alias": "CRYPTOSCOUT",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "pdnsor2bfqsl5brwtkqdrvuhsno7hbc23wzddie24niv2awizezwcnqd.onion:9735"
+                    "addr": "leb7bxhf3ppdfssy2bu4udc2cnhbehw5nhkkiumh76fhxel6bqtqmqqd.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -6368,6 +563,11 @@
                     "is_required": false,
                     "is_known": true
                 },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
                 "2023": {
                     "name": "script-enforced-lease",
                     "is_required": false,
@@ -6375,22 +575,22 @@
                 }
             },
             "custom_records": {},
-            "id": "02a1431534bfe333be9ff587f8f197b1b3d9ec05b58eb42e2a08f590fea6cc8866"
+            "pub_key": "027d5369f807773ed75dc87dd12c585210b72827263f4a1009f052e67c12ac92f5"
         },
         {
-            "last_update": 1710856652,
-            "alias": "Peeky",
+            "last_update": 1710847881,
+            "alias": "lnd1.relampago.cash",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "46.101.122.181:17759"
+                    "addr": "44.225.98.1:9735"
                 },
                 {
                     "network": "tcp",
-                    "addr": "jcilwp3el44flfrkzy6sgnxrojuvx2wl6b6uval542lnoevxlkcubaqd.onion:9735"
+                    "addr": "6hmm7rvxv6mu7sv5wetqfigjljrde2cd6kr474ncylbbfzdsczyvhlad.onion:9735"
                 }
             ],
-            "color": "#51766d",
+            "color": "#ffa47a",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -6464,26 +664,22 @@
                 }
             },
             "custom_records": {},
-            "id": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
+            "pub_key": "0338bbdb38184852f728ef833e9ca0d01e134e9490f5b3fd3219b3ad9eaa0fc49d"
         },
         {
-            "last_update": 1710696837,
-            "alias": "momentum",
+            "last_update": 1710623243,
+            "alias": "bitpi",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "3.123.70.97:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "33csfwgfzc7vifvnn2kodcal6vblzicrqdl66qfkql6averpfesvb3id.onion:9735"
+                    "addr": "iddfruwmorrrlr32akea422ajghfyicyohdd3n3a6mmiigd5x7druhyd.onion:9735"
                 }
             ],
-            "color": "#5234eb",
+            "color": "#68f442",
             "features": {
-                "1": {
+                "0": {
                     "name": "data-loss-protect",
-                    "is_required": false,
+                    "is_required": true,
                     "is_known": true
                 },
                 "5": {
@@ -6496,19 +692,14 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "8": {
+                "9": {
                     "name": "tlv-onion",
-                    "is_required": true,
+                    "is_required": false,
                     "is_known": true
                 },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
+                "12": {
                     "name": "static-remote-key",
-                    "is_required": false,
+                    "is_required": true,
                     "is_known": true
                 },
                 "14": {
@@ -6521,43 +712,93 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "19": {
-                    "name": "wumbo-channels",
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
                     "is_required": false,
                     "is_known": true
-                },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
                 },
                 "27": {
                     "name": "shutdown-any-segwit",
                     "is_required": false,
                     "is_known": true
                 },
-                "29": {
-                    "name": "unknown",
+                "31": {
+                    "name": "amp",
                     "is_required": false,
-                    "is_known": false
-                },
-                "39": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
+                    "is_known": true
                 },
                 "45": {
                     "name": "explicit-commitment-type",
                     "is_required": false,
                     "is_known": true
                 },
-                "47": {
-                    "name": "scid-alias",
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "033e8bc45cc79dabebd18507ba39b101c839240932174bff6ddf34631305881cc3"
+        },
+        {
+            "last_update": 1674198664,
+            "alias": "Bitcomoon.com",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "e3xx3u5oxvuo4bgix5cl2ngfeyvexoz7my3rktgrpmf6gq3sryi2orqd.onion:9735"
+                }
+            ],
+            "color": "#79e0ed",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
                     "is_required": false,
                     "is_known": true
                 },
-                "51": {
-                    "name": "zero-conf",
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
                     "is_required": false,
                     "is_known": true
                 },
@@ -6567,26 +808,171 @@
                     "is_known": true
                 }
             },
-            "custom_records": {
-                "1": "029a000a0001000001f4"
-            },
-            "id": "03ecbf446779069cdbc506e809a137df875b1f76b9560bd39f4d9b143b82fa7df0"
+            "custom_records": {},
+            "pub_key": "02bf145fe009fef1230f3f435b5e448db3470a1fdbff95d41cefa71b7d6f14fcda"
         },
         {
-            "last_update": 1710856346,
-            "alias": "LNB\u03dfG [Hub-2]",
+            "last_update": 1710586588,
+            "alias": "Bitrequest",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "46.229.165.154:9735"
+                    "addr": "wvhczhxeyuo5gsbc6ub5n66yxycvojyx26eunh76l3ta7ks7yjckbgqd.onion:9735"
+                }
+            ],
+            "color": "#0cc0ed",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
                 },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02b568dfb3cb52a0bde61b706f333a4eb4b77b0d38f0a9a591a338a05ae5130296"
+        },
+        {
+            "last_update": 1710773661,
+            "alias": "raspiblitz",
+            "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "[2a02:b48:207:2:9735:9735:0:2]:9735"
+                    "addr": "n75lmwb3ykmwvbqajzkdh6otc6ukasij4f556ub54ug4qvs22rb3rsyd.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
                 },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02c87bce43398e73f65df561b4e776306fc1e74657d67131d76866ba617a0e63c2"
+        },
+        {
+            "last_update": 1710825523,
+            "alias": "qubi1",
+            "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "xbi6bipfby6prt6wddufgv5mq4mx2ihxsy4u4hycd73qfgc3oslonuid.onion:9735"
+                    "addr": "mkejl5jnqe4ovaow57l47hi46xbjcxnf54jriiwvs5rsxcxxjbo5b4yd.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -6626,8 +1012,158 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "19": {
-                    "name": "wumbo-channels",
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02b196899ff33d892562c557a37f56a3702f14eba8aee8585625ed8cf4217f2ab3"
+        },
+        {
+            "last_update": 1710850518,
+            "alias": "Knoten",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "xetu2kpbvonq2urqpadclyzy76gwhdrkz6lgazz65j66leapw4bmpoad.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03c0223a47deb4abe67071ad16f66c5c8dc38bbd5bd117589f80ba1d51eb7ddb96"
+        },
+        {
+            "last_update": 1710568425,
+            "alias": "Viva Bitcoin",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "2ti2gy74nlyjsgcs42wemjwd3skmndbbv776ufldkngbzmpo7tbsntyd.onion:9735"
+                }
+            ],
+            "color": "#ffff00",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
                     "is_required": false,
                     "is_known": true
                 },
@@ -6656,11 +1192,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "181": {
-                    "name": "simple-taproot-chans-x",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "2023": {
                     "name": "script-enforced-lease",
                     "is_required": false,
@@ -6668,7 +1199,7 @@
                 }
             },
             "custom_records": {},
-            "id": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
+            "pub_key": "02aeb397b7212dc1de5252684f9a1f1957d8bcc9864193b538ce78f9558685d666"
         },
         {
             "last_update": 1710394153,
@@ -6738,90 +1269,15 @@
                 }
             },
             "custom_records": {},
-            "id": "031fab3f6a8ae8588668fbe4bf4cae14c3aaa4134330b1798b81e60aaf9662ff20"
+            "pub_key": "031fab3f6a8ae8588668fbe4bf4cae14c3aaa4134330b1798b81e60aaf9662ff20"
         },
         {
-            "last_update": 1710818914,
-            "alias": "CleanFastNode | Low Fee to Free",
+            "last_update": 1710769806,
+            "alias": "EcoNode",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "lambbfwlyyck5njevv24ahw2px4oygvicbhsffmvhndceg5uiwasavyd.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322"
-        },
-        {
-            "last_update": 1710727195,
-            "alias": "stramash",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "32shkobykr7xpqyvauqb3a2yrn3gek5tx72pk4oju2pkd5v26hqg7vqd.onion:9735"
+                    "addr": "kpa3fv64oxsgl7ymsmu27t5wwe4vpx47wer3tr7fk5ateeskmoh6hiqd.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -6893,18 +1349,18 @@
                 }
             },
             "custom_records": {},
-            "id": "03c539a7b630001d2f324a487b949b4c294e9de0e05bc7f9c6e85af841af263cc5"
+            "pub_key": "0202b5d54467d075893d46b6205067bbab2bcbc632513cd15661ad803d2dcb4ce3"
         },
         {
-            "last_update": 1710852868,
-            "alias": "rainy-day",
+            "last_update": 1707656697,
+            "alias": "02f5be5f3d54b66bf531",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "g7hkc3ic3p5tzoyi7tuuigrfjdvdirp4fgl34fswwopsckgvjcvfyoid.onion:9735"
+                    "addr": "vedvjiibjrbbaaegvjqvx4thfobbj7gs5scb5gtpvxyb3t423ao23sad.onion:9735"
                 }
             ],
-            "color": "#47375b",
+            "color": "#3399ff",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -6961,8 +1417,83 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "55": {
-                    "name": "keysend",
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02f5be5f3d54b66bf531b96f06327f59cd139f6e2c301cc0131a3f632025c2704c"
+        },
+        {
+            "last_update": 1710693115,
+            "alias": "lightning-roulette.com",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "34.65.32.189:9735"
+                }
+            ],
+            "color": "#11ff22",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
                     "is_required": false,
                     "is_known": true
                 },
@@ -6973,22 +1504,22 @@
                 }
             },
             "custom_records": {},
-            "id": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
+            "pub_key": "031678745383bd273b4c3dbefc8ffbf4847d85c2f62d3407c0c980430b3257c403"
         },
         {
-            "last_update": 1710509679,
-            "alias": "devzorLN\ud83d\udc38",
+            "last_update": 1662699597,
+            "alias": "BambergCityNode5",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "84.0.239.209:9735"
+                    "addr": "tfsmtkznl6spgnm5j3xxa6wmawvmi4ipgbvuazdngy6xqbigqdiojpid.onion:9735"
                 }
             ],
-            "color": "#037e27",
+            "color": "#cd6d5f",
             "features": {
-                "1": {
+                "0": {
                     "name": "data-loss-protect",
-                    "is_required": false,
+                    "is_required": true,
                     "is_known": true
                 },
                 "5": {
@@ -7001,19 +1532,14 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "8": {
+                "9": {
                     "name": "tlv-onion",
-                    "is_required": true,
+                    "is_required": false,
                     "is_known": true
                 },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
+                "12": {
                     "name": "static-remote-key",
-                    "is_required": false,
+                    "is_required": true,
                     "is_known": true
                 },
                 "14": {
@@ -7025,146 +1551,13 @@
                     "name": "multi-path-payments",
                     "is_required": false,
                     "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
                 }
             },
             "custom_records": {},
-            "id": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
+            "pub_key": "024a65932bdad1c4ef070289a6dd9f71b315e61d871b38c79339d0cc3d26e100e1"
         },
         {
-            "last_update": 1710748832,
-            "alias": "BCash_Is_Trash",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "174.169.193.33:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "216.212.37.161:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "[2601:18c:9002:3de5:219:d1ff:fe75:dc2f]:9735"
-                }
-            ],
-            "color": "#ffaa00",
-            "features": {
-                "1": {
-                    "name": "data-loss-protect",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "13": {
-                    "name": "static-remote-key",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "last_update": 1710392677,
+            "last_update": 1710392585,
             "alias": "",
             "addresses": [],
             "color": "#007f00",
@@ -7231,18 +1624,182 @@
                 }
             },
             "custom_records": {},
-            "id": "02a6674aecc34ab056ae493c67e26c623c5ee02f3b9f69d1b40797ec3f226ec147"
+            "pub_key": "024729f3d5f7794f4df09bfdb7ca23a4fbe6c38997cdd213c694a2cca1c27cbb17"
         },
         {
-            "last_update": 1710856283,
-            "alias": "ziostanko",
+            "last_update": 1710817951,
+            "alias": "bblocker21",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "6zqdd5omqffhj72k33snvzu6wwjvflgco7r3ilgjp5nf7nf2xeue3dqd.onion:9735"
+                    "addr": "l4nxfimtxjjerzewyb4ihp4jhiauw2madq3krdnqz4s3x52kmya76lyd.onion:9735"
                 }
             ],
-            "color": "#dd4db4",
+            "color": "#ffb233",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "025dfb3926e67a64b45a164865a737ecfc37071d11ac4846b0d59c4979c8bb08b8"
+        },
+        {
+            "last_update": 1710847967,
+            "alias": "Bitrefill",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "54.155.41.207:9735"
+                }
+            ],
+            "color": "#002b28",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac"
+        },
+        {
+            "last_update": 1710767460,
+            "alias": "lnd.cryptoassets.co.za",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "197.155.6.194:9735"
+                },
+                {
+                    "network": "tcp",
+                    "addr": "xiigglrrhl6gl55g6ndou5pkg7y7gxmln6bs6eov2w5od2xavdfukrqd.onion:9735"
+                }
+            ],
+            "color": "#000000",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -7316,31 +1873,1599 @@
                 }
             },
             "custom_records": {},
-            "id": "02679d067ec30e5bb4ad13e277d655e2f3779dda5979b615c8fdf1be0b096ae257"
+            "pub_key": "021227d4be948ab84613d5dbd47b6e148cfb811432d27eb92e80d28382b1b27d27"
         },
         {
-            "last_update": 1710668404,
-            "alias": "LookBusy6",
+            "last_update": 1710821651,
+            "alias": "OpenNode.com",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "37.120.156.178:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "inermuufpcas2syrfytfcdmni4a67jeqwr26mglvkvwiavlj23ymqoqd.onion:9735"
+                    "addr": "18.222.70.85:9735"
                 }
             ],
-            "color": "#02c61e",
+            "color": "#000000",
             "features": {
-                "1": {
+                "0": {
                     "name": "data-loss-protect",
-                    "is_required": false,
+                    "is_required": true,
                     "is_known": true
                 },
                 "5": {
                     "name": "upfront-shutdown-script",
                     "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
+        },
+        {
+            "last_update": 1710836095,
+            "alias": "021cb32426ed1a6be953",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "g2vldjytfdx4r2hdmgg3ccqrxczxgxl4e3w7rr3emvp4br4xcoo4void.onion:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "021cb32426ed1a6be9533801e7c56a70ffc1c360a3a31819c3ae0a72e141d78000"
+        },
+        {
+            "last_update": 1710776023,
+            "alias": "Fastlightning",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "tspdnxsdk77b6wdly6lujqr724hoq23buuez3roy6xo5ausv3riisbqd.onion:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03919a0a495cfd08779a3c23168827243cabe597e8ee5ea0c7827b6c407e260fe2"
+        },
+        {
+            "last_update": 1710845779,
+            "alias": "LightningPremium",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "5u3crvcbydktdcwsk5utapo5vvd7s2uzkn45u7kemusvgikwqydytjad.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02626318f968469fb1dcd0453536bbabaab8861be75d8cde7900e57aab1bd4f3ac"
+        },
+        {
+            "last_update": 1648917357,
+            "alias": "mynodebtc.cooper",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "bh4ooqtd3mngj4vk3m3gpqd3isaywi67ed5iochdg3lhexzikc56epad.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03d213f4115a55f0d0ab185434fcb6d3f119fdede11e901fe57f8b91d57ed316e6"
+        },
+        {
+            "last_update": 1710852615,
+            "alias": "Decentralized",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "sgcq35suws6ft63egprwsncj357yt355rsa3aqqpjjimma4nfjhzdyqd.onion:9735"
+                }
+            ],
+            "color": "#61f5b2",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "035fcbf3d34c71ffe7404c5660242f9289991021cc3d52098d0038f839552365a3"
+        },
+        {
+            "last_update": 1710551722,
+            "alias": "02abb5e57ff442770d9d",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "172.67.158.44:9735"
+                },
+                {
+                    "network": "tcp",
+                    "addr": "rjufmivql2si355mfczbg2wirc24rnjngpo5hsotmabiafuewojkbdqd.onion:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02abb5e57ff442770d9dc1d1ab66f45b015ac7aa033e4407051d060a471b71b08b"
+        },
+        {
+            "last_update": 1710852249,
+            "alias": "Bitrefill Routing",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "54.77.250.40:9735"
+                }
+            ],
+            "color": "#ff001c",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f"
+        },
+        {
+            "last_update": 1710811679,
+            "alias": "bleskomat",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "165.227.161.245:9735"
+                },
+                {
+                    "network": "tcp",
+                    "addr": "5aggdumr4x3qkx5ptshggvrdkgaxkpsklw4nwmnsa6diby6vwcvccyad.onion:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03440f4dd43f5e30ffa0fd37eb99e2c27241d71e4fc5b3ea1e9c04a289a51c7ae0"
+        },
+        {
+            "last_update": 1710852256,
+            "alias": "Liaoning",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "vdhhkanmkfr7x2mlkbo7lah6sh7mhwxqt7gv73m44pkfk4y537tg54yd.onion:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03eaf4f94ad680855a7818c2f156ae4a86482dea2f396320c336989ce5f49da880"
+        },
+        {
+            "last_update": 1710848892,
+            "alias": "shtyrlitz",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "aswabsuhftuqagrvxlhzc5la73wj5skg7shp4vjpwgialbcgkceby6qd.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "0328946a0693c2a4dd7e5afc2ce2e020c54e07d6693a293b4e1c1fd7e2d09a3eeb"
+        },
+        {
+            "last_update": 1710803334,
+            "alias": "FinanzielleFreiheit",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "valdvygv5w6bfnza4yfshqsvljhv7grgyq4wgpke2jwvugfretiqwcqd.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03ea17fd97ca7382a192dd4533c8e95ca946ef0827b14984e682af699bcaeb5a53"
+        },
+        {
+            "last_update": 1710805061,
+            "alias": "lndwr2.zaphq.io",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "34.74.114.254:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02535215135eb832df0f9858ff775bd4ae0b8911c59e2828ff7d03b535b333e149"
+        },
+        {
+            "last_update": 1710856675,
+            "alias": "Civilization Phaze IV",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "ko4qvn23p2txecujtt5nv67mb2ikzhbebh2hs4rgfvonfpk2tqhux4id.onion:9735"
+                }
+            ],
+            "color": "#ff8733",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "02841286ba5314ac9a4a29eb8d558b30fec348f22e22351ff8896288dede68e6a7"
+        },
+        {
+            "last_update": 1710771876,
+            "alias": "0209a06852f1257d70e5",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "94.130.220.96:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "0209a06852f1257d70e5cea44a0919871fa20859eb33a62445f774e9fe96247a75"
+        },
+        {
+            "last_update": 1710586096,
+            "alias": "PERLY",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "twtvqk7jiz3luzkt346q326u5owmo73lfn4yhhr5efskkr4autuf6vqd.onion:9735"
+                }
+            ],
+            "color": "#9245ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "033f481fe0e9344228b58e0297162bfa8d648d5043c12b6323df5eac61bd39094c"
+        },
+        {
+            "last_update": 1700638994,
+            "alias": "UmbrelMCL",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "rlubaw7sxcaqmostf3e4x7yollfo4x2tzfwxrj3ssvxqusdes2q6k6yd.onion:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "0321743efb2d44a9c1ff8194f03728e119bbf6cde88201b9ac8e6e48f96c99d597"
+        },
+        {
+            "last_update": 1710736174,
+            "alias": "Laika",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "tezwktlb2f3ah2tbla6emehwic4eelwyxhycfvzgzmc7n6jxz33ozead.onion:9735"
+                }
+            ],
+            "color": "#300fb0",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "55": {
+                    "name": "keysend",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "03b9de7a7d7e8a474b859a59e314cf2a143ae9c569ce78c46289b3ad16cb8c03f9"
+        },
+        {
+            "last_update": 1710803050,
+            "alias": "lndeu0.zaphq.io",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "35.196.134.164:9735"
+                }
+            ],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "0335e4265f783f37378e969c6a123557cf5d22cc97ec42ea3abff5dfaa64afea83"
+        },
+        {
+            "last_update": 1710790037,
+            "alias": "0294774ee02a9faa5a58",
+            "addresses": [],
+            "color": "#3399ff",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "0294774ee02a9faa5a5870061f7f4833686184ad14a0b163c49442516c9edac1db"
+        },
+        {
+            "last_update": 1709977298,
+            "alias": "ACINQ",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "3.33.236.230:9735"
+                },
+                {
+                    "network": "tcp",
+                    "addr": "of7husrflx7sforh3fw6yqlpwstee3wg5imvvmkp4bz6rbjxtg5nljad.onion:9735"
+                }
+            ],
+            "color": "#49daaa",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
                     "is_known": true
                 },
                 "7": {
@@ -7373,8 +3498,13 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "21": {
-                    "name": "anchor-commitments",
+                "19": {
+                    "name": "wumbo-channels",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
                     "is_required": false,
                     "is_known": true
                 },
@@ -7383,7 +3513,7 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "35": {
+                "29": {
                     "name": "unknown",
                     "is_required": false,
                     "is_known": false
@@ -7402,601 +3532,18 @@
                     "name": "scid-alias",
                     "is_required": false,
                     "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
                 }
             },
             "custom_records": {},
-            "id": "02c61e171140fc1aac5d3e0bcfefdc79ea954306dfa29265f02def849dc7e80419"
+            "pub_key": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
         },
         {
-            "last_update": 1710809830,
-            "alias": "bfx-lnd0",
+            "last_update": 1710849539,
+            "alias": "PeterJFrancoIII",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "34.65.85.39:9735"
-                }
-            ],
-            "color": "#16b157",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "last_update": 1710856043,
-            "alias": "Sunny Sarah \u2600\ufe0f",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "77.72.85.173:9735"
-                }
-            ],
-            "color": "#f2f27a",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "last_update": 1710856657,
-            "alias": "WalletOfSatoshi.com",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "170.75.163.209:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "last_update": 1710637072,
-            "alias": "02ec23ef38b0af053817",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "mqrs56gqq7lrj5vlgxg34bfmku2yzllkvjod4qbcqzkexbm6nbuc2nad.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "02ec23ef38b0af053817b793fc97d82acba48ec64895eb3f1cf2b1357123d35e15"
-        },
-        {
-            "last_update": 1710666858,
-            "alias": "\u26a1TheBebop\u26a1",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "104.62.145.108:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "fz5asocn3f7noqjrdbnijtgiwsjgfcwfhmwwm5wqpthrpzc222rmbaad.onion:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "19": {
-                    "name": "wumbo-channels",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "181": {
-                    "name": "simple-taproot-chans-x",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "last_update": 1710792834,
-            "alias": "1ML.com node ALPHA",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "23.237.77.11:9735"
-                }
-            ],
-            "color": "#3399ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "last_update": 1710652836,
-            "alias": "OnionRouting @ramses_btc [nodl]",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "dfn7tldhgct7xxtw6kjrp6ndjf5xqivaqdhj5djheeuhijeplrki4wid.onion:9735"
-                }
-            ],
-            "color": "#0000ff",
-            "features": {
-                "0": {
-                    "name": "data-loss-protect",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "5": {
-                    "name": "upfront-shutdown-script",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "7": {
-                    "name": "gossip-queries",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "9": {
-                    "name": "tlv-onion",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "12": {
-                    "name": "static-remote-key",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "14": {
-                    "name": "payment-addr",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "17": {
-                    "name": "multi-path-payments",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "23": {
-                    "name": "anchors-zero-fee-htlc-tx",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "27": {
-                    "name": "shutdown-any-segwit",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "31": {
-                    "name": "amp",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "45": {
-                    "name": "explicit-commitment-type",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "2023": {
-                    "name": "script-enforced-lease",
-                    "is_required": false,
-                    "is_known": true
-                }
-            },
-            "custom_records": {},
-            "id": "03949914687fadf3bca1abe088db2b9a5bc105194a36f230f7e54e90e88d2dc0ec"
-        },
-        {
-            "last_update": 1710839218,
-            "alias": "SatoshiSamourai",
-            "addresses": [
-                {
-                    "network": "tcp",
-                    "addr": "159.69.32.62:33411"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "hci6mmdhts53obizhwbqpcivnak7dtyoh6mj6ryxd742rcbi7lcc2zqd.onion:9735"
+                    "addr": "oyonslv2muhpngxl3yip3z7mt27auzlsx2luqydkxadludv2cva3thad.onion:9735"
                 }
             ],
             "color": "#3399ff",
@@ -8056,26 +3603,6 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "181": {
-                    "name": "simple-taproot-chans-x",
-                    "is_required": false,
-                    "is_known": true
-                },
                 "2023": {
                     "name": "script-enforced-lease",
                     "is_required": false,
@@ -8083,22 +3610,18 @@
                 }
             },
             "custom_records": {},
-            "id": "02b61154d89b98662f4c58e1005963e918da6a8fdb5adbea85ad22a20b8e7fc0ad"
+            "pub_key": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972"
         },
         {
-            "last_update": 1710082114,
-            "alias": "DarkMoney",
+            "last_update": 1710850693,
+            "alias": "Wallet Sat's",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "140.82.25.134:9735"
-                },
-                {
-                    "network": "tcp",
-                    "addr": "no7amceixoozrcyv3lr7nhyj7xdvjcqdsiuysyxsikccqheb6wi5nnyd.onion:1234"
+                    "addr": "4a2tjhiyz3rqgpfvragnk4uszv32dytzhapen46igyjlyzfpgix5zeqd.onion:9735"
                 }
             ],
-            "color": "#02f97f",
+            "color": "#3399ff",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -8110,20 +3633,15 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "6": {
+                "7": {
                     "name": "gossip-queries",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "8": {
-                    "name": "tlv-onion",
-                    "is_required": true,
-                    "is_known": true
-                },
-                "11": {
-                    "name": "unknown",
                     "is_required": false,
-                    "is_known": false
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
                 },
                 "12": {
                     "name": "static-remote-key",
@@ -8140,8 +3658,78 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "19": {
-                    "name": "wumbo-channels",
+                "23": {
+                    "name": "anchors-zero-fee-htlc-tx",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "27": {
+                    "name": "shutdown-any-segwit",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "31": {
+                    "name": "amp",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "45": {
+                    "name": "explicit-commitment-type",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "2023": {
+                    "name": "script-enforced-lease",
+                    "is_required": false,
+                    "is_known": true
+                }
+            },
+            "custom_records": {},
+            "pub_key": "039157862ec407b1aa2353d879279916e76c8d2fcc4ac10d3f225972c8e58fbc43"
+        },
+        {
+            "last_update": 1710617991,
+            "alias": "RUSHBNOSTOP",
+            "addresses": [
+                {
+                    "network": "tcp",
+                    "addr": "maeiws6uq6baeuim5q6mcavn3xpn4kkpaa5rv7uqhrs6wubhccnkn7ad.onion:9735"
+                }
+            ],
+            "color": "#68f442",
+            "features": {
+                "0": {
+                    "name": "data-loss-protect",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "5": {
+                    "name": "upfront-shutdown-script",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "7": {
+                    "name": "gossip-queries",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "9": {
+                    "name": "tlv-onion",
+                    "is_required": false,
+                    "is_known": true
+                },
+                "12": {
+                    "name": "static-remote-key",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "14": {
+                    "name": "payment-addr",
+                    "is_required": true,
+                    "is_known": true
+                },
+                "17": {
+                    "name": "multi-path-payments",
                     "is_required": false,
                     "is_known": true
                 },
@@ -8150,55 +3738,40 @@
                     "is_required": false,
                     "is_known": true
                 },
-                "25": {
-                    "name": "unknown",
-                    "is_required": false,
-                    "is_known": false
-                },
                 "27": {
                     "name": "shutdown-any-segwit",
                     "is_required": false,
                     "is_known": true
                 },
-                "29": {
-                    "name": "unknown",
+                "31": {
+                    "name": "amp",
                     "is_required": false,
-                    "is_known": false
+                    "is_known": true
                 },
                 "45": {
                     "name": "explicit-commitment-type",
                     "is_required": false,
                     "is_known": true
                 },
-                "47": {
-                    "name": "scid-alias",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "51": {
-                    "name": "zero-conf",
-                    "is_required": false,
-                    "is_known": true
-                },
-                "55": {
-                    "name": "keysend",
+                "2023": {
+                    "name": "script-enforced-lease",
                     "is_required": false,
                     "is_known": true
                 }
             },
             "custom_records": {},
-            "id": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
+            "pub_key": "03382704812aca55bf853b353ecd3edef7e16a9420d7beb7e7d6b6c7fe2082252a"
         },
         {
-            "last_update": 1707616919,
-            "alias": "SmoothBrain",
+            "last_update": 1710774982,
+            "alias": "sheesh",
             "addresses": [
                 {
                     "network": "tcp",
-                    "addr": "zhofujc6th5bbg5vzv3p3k3cs7goumffwug5hcrcixdjyoxs2c4rhvid.onion:9735"
+                    "addr": "esowgqg2jhjzofvgkwdnyrozdvowvx7ymo3jsdh7oxxc74y7ga4egyyd.onion:9735"
                 }
             ],
-            "color": "#3399ff",
+            "color": "#68f442",
             "features": {
                 "0": {
                     "name": "data-loss-protect",
@@ -8267,7 +3840,7 @@
                 }
             },
             "custom_records": {},
-            "id": "0346078e95939cd4213e5806b82682d1a2c4619430e060eb8d09015dcc98457751"
+            "pub_key": "035d681f3696fc5039d304c621f6f39ba6e0aa0ad482065417720d4f820f8dcb0e"
         },
         {
             "last_update": 1710855402,
@@ -8347,1531 +3920,81 @@
                 }
             },
             "custom_records": {},
-            "id": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
+            "pub_key": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
         }
     ],
     "edges": [
         {
-            "channel_id": "873143074441003009",
-            "chan_point": "dabb6006bb6ab57cf71f13ea52a3984ac48bf777cead8d1ac4cbf513c071ce4d:1",
-            "last_update": 1710805309,
-            "capacity": "500000",
+            "channel_id": "821685930207739904",
+            "chan_point": "b8d52e4be913496dd31204b80a6214d30934fd77cf18d33f1f4b6f2b17aabc0a:0",
+            "last_update": 1710852888,
+            "capacity": "130000",
             "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "20",
-                "disabled": false,
-                "max_htlc_msat": "420000000",
-                "last_update": 1710805239,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710805309,
+                "max_htlc_msat": "128700000",
+                "last_update": 1710852888,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "128700000",
+                "last_update": 1710852885,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "039fe3a61b5ca53e73035d29535f2335637c26fc16098f9c904df8b1d9659870ed",
-            "node2_pub": "02cb080fa2386d00e74c90cb4a5a3fb8a16278c248adf851e6af3f67802fa6ab99"
+            "node1_pub": "0242902a3a5aa34829db9def5b44939f9f459f4ee08e97cba18516c62ddf8ec9e6",
+            "node2_pub": "035d681f3696fc5039d304c621f6f39ba6e0aa0ad482065417720d4f820f8dcb0e"
         },
         {
-            "channel_id": "910740874596843521",
-            "chan_point": "2412b9ffb1c0a0b9a088f0084d65a78af32355033227b1b71cc2bfc83493ed7a:1",
-            "last_update": 1710819709,
-            "capacity": "175000",
+            "channel_id": "851482695379255296",
+            "chan_point": "57457180438919be15029ad7763d11eb46d33057fe9ab02ca001439b48350e97:0",
+            "last_update": 1710451930,
+            "capacity": "300000",
             "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "173250000",
-                "last_update": 1710203872,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": true,
-                "max_htlc_msat": "173250000",
-                "last_update": 1710819709,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "039fe3a61b5ca53e73035d29535f2335637c26fc16098f9c904df8b1d9659870ed",
-            "node2_pub": "0346078e95939cd4213e5806b82682d1a2c4619430e060eb8d09015dcc98457751"
-        },
-        {
-            "channel_id": "849500275827343360",
-            "chan_point": "a9e6928be328d51cc120372bc8f495fec7d6e1ade7d38600b8e3d9b91f9a102a:0",
-            "last_update": 1710842402,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "4900500000",
-                "last_update": 1710807325,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "97",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710842402,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4"
-        },
-        {
-            "channel_id": "735425944523833345",
-            "chan_point": "dda46b5cf89c76b45361bb50eba6186cb61ec3048f15d1aaaa7935fc812b9498:1",
-            "last_update": 1710718947,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "162",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710695680,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710718947,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "760954405415550976",
-            "chan_point": "e685f0e5fca503e5c68f81cbf3f8148e1119fe748ca8b34228715568c8891e87:0",
-            "last_update": 1710809829,
-            "capacity": "4432108",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "243",
-                "disabled": false,
-                "max_htlc_msat": "4387787000",
-                "last_update": 1710791080,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "4387787000",
-                "last_update": 1710809829,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "865833521219436546",
-            "chan_point": "1e2455ddaea18e3c6f8fa4c74cf77789482818c0daec2b05206410ef68d85c26:2",
-            "last_update": 1710817202,
-            "capacity": "14000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "259",
-                "disabled": false,
-                "max_htlc_msat": "13860000000",
-                "last_update": 1710817202,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "13860000000",
-                "last_update": 1710805989,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "876694496961363971",
-            "chan_point": "700f6502012e25148552885e7eca4f1e77cfe021370120043c9832bbe5fa6dee:3",
-            "last_update": 1710846880,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "570",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710846880,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "600",
-                "disabled": false,
-                "max_htlc_msat": "25000000",
-                "last_update": 1710821196,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "877195874248949761",
-            "chan_point": "a561dff6fec000676e60d7e16ff0b93713311627ceba610abc7d48fc439dd215:1",
-            "last_update": 1710803680,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "109",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710803680,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "149",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710799709,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "887985381862801409",
-            "chan_point": "7923aa76eb4e7b441cb4a48b5ba1cdaa94a08afdd4230b4822d830be6bdd0271:1",
-            "last_update": 1710805703,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "811",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710802802,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "950",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710805703,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02"
-        },
-        {
-            "channel_id": "888140413055401985",
-            "chan_point": "4b6bef6253b7b45ac3582b939e3ba30fa7846cada643480dbd1b876881ae2534:1",
-            "last_update": 1710806402,
-            "capacity": "2900000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "173",
-                "disabled": false,
-                "max_htlc_msat": "2871000000",
-                "last_update": 1710806402,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "2871000000",
-                "last_update": 1710806129,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e"
-        },
-        {
-            "channel_id": "890970556046114824",
-            "chan_point": "abb7dcbdf515266a788b6acfd636cf18b88bf847de190e9b966334ce6f3cc241:8",
-            "last_update": 1710850480,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "515",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710850480,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710806281,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "channel_id": "891176164674830343",
-            "chan_point": "f0237ecd26cb623415c0be9c81904faf6af7ad7220e5c94a8e769b6ce3d5fb6d:7",
-            "last_update": 1710806394,
-            "capacity": "33679897",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "230",
-                "disabled": false,
-                "max_htlc_msat": "33343099000",
-                "last_update": 1710783881,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "33343099000",
-                "last_update": 1710806394,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "891182761691643904",
-            "chan_point": "c62b6c4082ab9677815db8a66b896aad5dcf3fb66af7394ce3a39b0176e905f3:0",
-            "last_update": 1710850480,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "155",
-                "disabled": true,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710850480,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "20",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1708990724,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "03d64e760b4af3698e51eb7ed7d97fbbae41f8cd28c0bcb6851c21207922f6697d"
-        },
-        {
-            "channel_id": "893714936923619329",
-            "chan_point": "0e9912bcdd6fa9664c32ea2f3229d55066b68554acc4aaeb2f49c18bac13a938:1",
-            "last_update": 1710806156,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "94",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710799202,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "8",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710806156,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5"
-        },
-        {
-            "channel_id": "900623168514097153",
-            "chan_point": "0116c247f21d015176b0ea43a9b777c7e21be98c5ffbab11206a6a91d14ba65a:1",
-            "last_update": 1710806042,
-            "capacity": "12000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "53",
-                "disabled": false,
-                "max_htlc_msat": "11880000000",
-                "last_update": 1710792786,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "793",
-                "disabled": false,
-                "max_htlc_msat": "11880000000",
-                "last_update": 1710806042,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "915167508329791489",
-            "chan_point": "dcec22bdaca8aaa51e0454649530c4f01d6de96f8e1f661d4dc98ab48027423a:1",
-            "last_update": 1710804927,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "132",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710782080,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "72",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710804927,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660"
-        },
-        {
-            "channel_id": "915858001747574785",
-            "chan_point": "b1c671b83a794beefb8c6e7625a82aa4f85c2edc394870fd1ff271042109a5bd:1",
-            "last_update": 1710855802,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "107",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710794680,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "559",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710855802,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "023e09c43b215bd3dbf483bcb409da3322ea5ea3b046f74698b89ee9ea785dd30a",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "915169707373166594",
-            "chan_point": "55f18bda85271cabb8373ae36d129d0dafa7a72b2875ee0b2dc9c372e829c4ba:2",
-            "last_update": 1710801235,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "21",
-                "fee_rate_milli_msat": "48",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710795210,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "56",
-                "disabled": false,
                 "max_htlc_msat": "297000000",
-                "last_update": 1710801235,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0240b2b1f91d742327ebd34ea1129985ec98f9c08f7ab9a884a77ff3472897242e",
-            "node2_pub": "02063fec62479bdf7d43f046056303e48f5029108111ade42aef41c622a6245d52"
-        },
-        {
-            "channel_id": "892222899696893953",
-            "chan_point": "e4d9fbffea7bfb9ad0e475493ee7fe01b9a1f8f2b3ae6faf90c1663e1f5a4c31:1",
-            "last_update": 1710810235,
-            "capacity": "150000",
-            "node1_policy": {
-                "time_lock_delta": 60,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "12",
-                "disabled": false,
-                "max_htlc_msat": "44550000",
-                "last_update": 1710810235,
+                "last_update": 1710451930,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "12",
-                "disabled": false,
-                "max_htlc_msat": "148500000",
-                "last_update": 1710787146,
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "50",
+                "disabled": true,
+                "max_htlc_msat": "297000000",
+                "last_update": 1706955502,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "0240b2b1f91d742327ebd34ea1129985ec98f9c08f7ab9a884a77ff3472897242e",
-            "node2_pub": "02464181ef50b59a26cde9aa37bd32ced1cb1923b4811165fb1e619b7507639083"
+            "node1_pub": "0242902a3a5aa34829db9def5b44939f9f459f4ee08e97cba18516c62ddf8ec9e6",
+            "node2_pub": "027d5369f807773ed75dc87dd12c585210b72827263f4a1009f052e67c12ac92f5"
         },
         {
-            "channel_id": "895938149490425857",
-            "chan_point": "d673373e1a11ee3663a3307b1c0b274446218bea76ace5b7d7cc977e72a578ff:1",
-            "last_update": 1710838986,
+            "channel_id": "852238059856199681",
+            "chan_point": "48442adc84d9f96ea82a15d24eb5eed6ea66a8b633296a7a0f7cd0adebbf4685:1",
+            "last_update": 1710705189,
             "capacity": "500000",
             "node1_policy": {
-                "time_lock_delta": 60,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "148500000",
-                "last_update": 1710815635,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100",
+                "fee_rate_milli_msat": "1",
                 "disabled": false,
                 "max_htlc_msat": "495000000",
-                "last_update": 1710838986,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0240b2b1f91d742327ebd34ea1129985ec98f9c08f7ab9a884a77ff3472897242e",
-            "node2_pub": "03e20ae8b749c3e5e8b96c66c98141177e7b75571b90cab80c9085af7c80bd3852"
-        },
-        {
-            "channel_id": "902458253593149440",
-            "chan_point": "697acf0824c21d9e1a0407c3cac398c33d1b41f361a86a7fde1968d5143babe2:0",
-            "last_update": 1710804931,
-            "capacity": "75000",
-            "node1_policy": {
-                "time_lock_delta": 60,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "45",
-                "disabled": false,
-                "max_htlc_msat": "22275000",
-                "last_update": 1710779635,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "6",
-                "disabled": false,
-                "max_htlc_msat": "74250000",
-                "last_update": 1710804931,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0240b2b1f91d742327ebd34ea1129985ec98f9c08f7ab9a884a77ff3472897242e",
-            "node2_pub": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660"
-        },
-        {
-            "channel_id": "917002593370439680",
-            "chan_point": "8d97198d0bb162b8587f82f0894bd9060477ccab8eed42883c8e1632efb7efa4:0",
-            "last_update": 1710846904,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "24",
-                "disabled": false,
-                "max_htlc_msat": "891000000",
-                "last_update": 1710840835,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "999",
-                "fee_rate_milli_msat": "199",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710846904,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0240b2b1f91d742327ebd34ea1129985ec98f9c08f7ab9a884a77ff3472897242e",
-            "node2_pub": "0289411927ecaf49467c44093990b6f446a5d9b396fb6663b070c3f97e1b9359a6"
-        },
-        {
-            "channel_id": "888071143737786368",
-            "chan_point": "7aacf54a4dab6a51df4f8bea215643ba6f210d922ab105ef723c75568534d23a:0",
-            "last_update": 1710777401,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710404279,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710777401,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0276499dd9775f36cf95506c16e14ed6ec4cf230e8e5d341a441e1190d3f9e1e4f",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "894816647584612353",
-            "chan_point": "77897b9270780b94ce82de1fec17f4aba9247c0fc0a6e53ac7028376716444ed:1",
-            "last_update": 1710823575,
-            "capacity": "8000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710823575,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "8000000000",
-                "last_update": 1710777196,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0276499dd9775f36cf95506c16e14ed6ec4cf230e8e5d341a441e1190d3f9e1e4f",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "902541816357650432",
-            "chan_point": "9a2a39d638b7db23a14f3ae69400918bde63dbd06f1b7b1113500509559bc6a3:0",
-            "last_update": 1710777417,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1709138352,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710777417,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0276499dd9775f36cf95506c16e14ed6ec4cf230e8e5d341a441e1190d3f9e1e4f",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "911779913009135616",
-            "chan_point": "8b1f732e52c9895fc6fda35dd415fa19372ca34c9f55f095e2535351a5400716:0",
-            "last_update": 1710823575,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710823575,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 420,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "1000000000",
-                "last_update": 1710777412,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0276499dd9775f36cf95506c16e14ed6ec4cf230e8e5d341a441e1190d3f9e1e4f",
-            "node2_pub": "03b14edc2c0645a69d641080ff968a8c75fa1247334da8b6fdc9c3e90ca6f99052"
-        },
-        {
-            "channel_id": "840869109669625856",
-            "chan_point": "d655cf60cbfa9d73331520df7b1ae3c946f3916a567ac756ab905b928e37290f:0",
-            "last_update": 1710837344,
-            "capacity": "8344920",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "8344920000",
-                "last_update": 1710730303,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "780",
-                "disabled": false,
-                "max_htlc_msat": "8261471000",
-                "last_update": 1710837344,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0223d7aa491e26a307b4203916b8d60ded8cfe832806b432d6cfc278e96374f9aa",
-            "node2_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09"
-        },
-        {
-            "channel_id": "878373451249745921",
-            "chan_point": "e3e77ebf0473eb210c9af36adcc9c99e4956ba66cbde5846444767f7ba37d13b:1",
-            "last_update": 1710806796,
-            "capacity": "9000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "40",
-                "disabled": false,
-                "max_htlc_msat": "8910000000",
-                "last_update": 1710795103,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "160",
-                "disabled": false,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710806796,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0223d7aa491e26a307b4203916b8d60ded8cfe832806b432d6cfc278e96374f9aa",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "887931505799200770",
-            "chan_point": "f8524c131081965523c8ff656ea617ddb5a92b0ca7f0df1da2e730f1f0b00ea1:2",
-            "last_update": 1710831103,
-            "capacity": "2100000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "300",
-                "disabled": true,
-                "max_htlc_msat": "2079000000",
-                "last_update": 1710831103,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2079000000",
-                "last_update": 1705176514,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0223d7aa491e26a307b4203916b8d60ded8cfe832806b432d6cfc278e96374f9aa",
-            "node2_pub": "02e48fa379deeef66dd8cc9c6e60581d5467eb13ed8bb93ad06ee8de064b0134b9"
-        },
-        {
-            "channel_id": "889510404655153154",
-            "chan_point": "9b80320158a997aa7fbce2b926d6befce1e56411e18f23cdbfd6ff7f1d671e70:2",
-            "last_update": 1710776099,
-            "capacity": "9000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "339",
-                "disabled": false,
-                "max_htlc_msat": "8910000000",
-                "last_update": 1710775303,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "4365900000",
-                "last_update": 1710776099,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0223d7aa491e26a307b4203916b8d60ded8cfe832806b432d6cfc278e96374f9aa",
-            "node2_pub": "03d6f80df785288de2fe5de19f24ba8a1db3d20647a88d0a903be9de3e7bb8fce1"
-        },
-        {
-            "channel_id": "915776637806510081",
-            "chan_point": "8b8cc07fc47372cc013cd2707eb5d3e39adbcf713a1ec5b08068f7607c41d52c:1",
-            "last_update": 1710795103,
-            "capacity": "1987690",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "1207",
-                "disabled": false,
-                "max_htlc_msat": "1967814000",
-                "last_update": 1710795103,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1967814000",
-                "last_update": 1710781627,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0223d7aa491e26a307b4203916b8d60ded8cfe832806b432d6cfc278e96374f9aa",
-            "node2_pub": "037e8b1af65a511e3baf38e45509fb1bfb8023a6e5e2555774998b9ce91a3c58b6"
-        },
-        {
-            "channel_id": "878638433562591233",
-            "chan_point": "6a1b1a7bb1c14d61df82b0a5addf964171bb859ebd6e35467bcb1132ef01ceb7:1",
-            "last_update": 1710806941,
-            "capacity": "4230000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "4187700000",
-                "last_update": 1710794407,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "418770000",
-                "last_update": 1710806941,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "914768385717239808",
-            "chan_point": "984aeace2430e8bae3050d7eac5b540444d8a84f291cc5538eb1a702487476c7:0",
-            "last_update": 1710853854,
-            "capacity": "12501523",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "6312019080",
-                "last_update": 1710845119,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "943",
-                "fee_rate_milli_msat": "408",
-                "disabled": true,
-                "max_htlc_msat": "1237650000",
-                "last_update": 1710853854,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9",
-            "node2_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad"
-        },
-        {
-            "channel_id": "821952012015108097",
-            "chan_point": "7b4e3f43923eb954b92fdbf0d2fa7d6757392894ff1fd0a685ee48cc5407694b:1",
-            "last_update": 1710844741,
-            "capacity": "16672359",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "980",
-                "fee_rate_milli_msat": "298",
-                "disabled": false,
-                "max_htlc_msat": "2667235000",
-                "last_update": 1710844741,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "16505636000",
-                "last_update": 1710190455,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "846570077353803777",
-            "chan_point": "40767afaa2aa2c926ec21483f30d8ee06fe67f33a102e3468552eb3efd2ae9db:1",
-            "last_update": 1710849430,
-            "capacity": "5000453",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "950",
-                "fee_rate_milli_msat": "930",
-                "disabled": false,
-                "max_htlc_msat": "495044000",
-                "last_update": 1710814141,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4950449000",
-                "last_update": 1710849430,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "870668073774874625",
-            "chan_point": "0a38bcb2bc0be95287715061b29abbabd414a157178837d4064be30ddcd27c31:1",
-            "last_update": 1710836855,
-            "capacity": "1890890",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "864",
-                "fee_rate_milli_msat": "97",
-                "disabled": false,
-                "max_htlc_msat": "1871982000",
-                "last_update": 1710787141,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "1871982000",
-                "last_update": 1710836855,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9",
-            "node2_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9"
-        },
-        {
-            "channel_id": "895730341817417729",
-            "chan_point": "e97a83532203c8613e37647d5cd8fda9367dc3e12a03ccfaecdd4860b1915b7b:1",
-            "last_update": 1710803341,
-            "capacity": "1125187",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "991",
-                "fee_rate_milli_msat": "146",
-                "disabled": false,
-                "max_htlc_msat": "1113936000",
-                "last_update": 1710803341,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10",
-                "fee_rate_milli_msat": "196",
-                "disabled": false,
-                "max_htlc_msat": "1113936000",
-                "last_update": 1710785942,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9",
-            "node2_pub": "032cd1bac674b61e993c9c0afe8efe23e3b1eb30246719010f2cf0f1452ee21e2b"
-        },
-        {
-            "channel_id": "910346149899272193",
-            "chan_point": "365bb2040925c2f41ca8e85600c1e957a45c21c12ac1160c51bb175180a2c197:1",
-            "last_update": 1710785255,
-            "capacity": "3600930",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "3564921000",
-                "last_update": 1710781741,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "3564921000",
-                "last_update": 1710785255,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "030b5d1a2f2502eb14f7dfccd6de8d227cc533fe14214c80ecb5dd9bd6ef9dc8e9",
-            "node2_pub": "032f3380e907937c704bef15f051d0747b942976e994a2e615ad3f5b8fb0aa6660"
-        },
-        {
-            "channel_id": "809131706516897793",
-            "chan_point": "70ca9da4744b72ea143b198f76eceea958a443dda1894088b70c25895a43510a:1",
-            "last_update": 1710850983,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "9801000000",
-                "last_update": 1710776725,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "16",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710850983,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4"
-        },
-        {
-            "channel_id": "871392651990925314",
-            "chan_point": "f06bff21e1df7fd546fabde8be950c219b7700796ded647eb0fe3416d66ab255:2",
-            "last_update": 1710818584,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710817957,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710818584,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "821242827146919937",
-            "chan_point": "a0ce804de16626e0257407719ca57fcdde63c226d9b3deb75db32d1ce4adf259:1",
-            "last_update": 1710777184,
-            "capacity": "2509864",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "140",
-                "fee_rate_milli_msat": "225",
-                "disabled": false,
-                "max_htlc_msat": "2484766000",
-                "last_update": 1710641388,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "215",
-                "disabled": false,
-                "max_htlc_msat": "2509864000",
-                "last_update": 1710777184,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "0283cee5a23b761503f4e1b38ed06c0559d1cfb3695a4ee23254f201f41bd52b3f"
-        },
-        {
-            "channel_id": "817583652359569408",
-            "chan_point": "b66a8f3c7b6cd8613cb81431da299cb6c2fd350e367909266bd8085cd9a3079f:0",
-            "last_update": 1710849183,
-            "capacity": "6000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710757535,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "243",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710849183,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "817938794614095872",
-            "chan_point": "e3b506f1fcbd8b101a09582ee647be990a2f8ba34070635c25e7c017b6efb2a7:0",
-            "last_update": 1710844807,
-            "capacity": "7000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "6930000000",
-                "last_update": 1710844807,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "790",
-                "disabled": false,
-                "max_htlc_msat": "6930000000",
-                "last_update": 1710831183,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "870995728242049026",
-            "chan_point": "36b81313bb77e4f698bf57e105eebf2d25a4176e989a1644ca730efa52110972:2",
-            "last_update": 1710792030,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "3300",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710662559,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "46",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710792030,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "870995728242049025",
-            "chan_point": "36b81313bb77e4f698bf57e105eebf2d25a4176e989a1644ca730efa52110972:1",
-            "last_update": 1710856622,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "80",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710826584,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "378",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710856622,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad"
-        },
-        {
-            "channel_id": "799243798480945153",
-            "chan_point": "427846104523e371c86052671fd8512c79f2e9670c1c9496ccf3573a33bd7e87:1",
-            "last_update": 1710835030,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "791",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710802383,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710835030,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "808800753561698304",
-            "chan_point": "45852beb30e8892eb5bbf3a6c5a909f6e032b85790088de23e86be621618cf9a:0",
-            "last_update": 1710831679,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710780783,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "250",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710831679,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "03ecbf446779069cdbc506e809a137df875b1f76b9560bd39f4d9b143b82fa7df0"
-        },
-        {
-            "channel_id": "814898644921286656",
-            "chan_point": "590542a22b5bb19091adf2382dd3a38f82d96f8f7d0536cf89b7b816a9931a65:0",
-            "last_update": 1710852783,
-            "capacity": "17000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "784",
-                "disabled": false,
-                "max_htlc_msat": "16830000000",
-                "last_update": 1710852783,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16830000000",
-                "last_update": 1710786594,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "814912938681958400",
-            "chan_point": "d2ef50e2c909a58eb259860b1b61472342f7e4150bc8ed6d340c671ad34f0dde:0",
-            "last_update": 1710787983,
-            "capacity": "17000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "790",
-                "disabled": false,
-                "max_htlc_msat": "16830000000",
-                "last_update": 1710787983,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16830000000",
-                "last_update": 1710786481,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "channel_id": "870917662991581185",
-            "chan_point": "bd435a56ea66f2c7169141f7e91640198bf6b576ad6a617c89ab35ea008ddf76:1",
-            "last_update": 1710852783,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "642",
-                "disabled": false,
-                "max_htlc_msat": "4500000000",
-                "last_update": 1710852783,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "4500000000",
-                "last_update": 1710502431,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "870917662991581186",
-            "chan_point": "bd435a56ea66f2c7169141f7e91640198bf6b576ad6a617c89ab35ea008ddf76:2",
-            "last_update": 1710853254,
-            "capacity": "12000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "449",
-                "disabled": false,
-                "max_htlc_msat": "11880000000",
-                "last_update": 1710843783,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "11880000000",
-                "last_update": 1710853254,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "880121674776838145",
-            "chan_point": "cd201b078a551da05c6fdc7686ac29672f551ff51c47df6074f9badc17bc7b2a:1",
-            "last_update": 1710856655,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "63",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710822184,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "721",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710856655,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "889853452122324993",
-            "chan_point": "9435f2b0356f96949d84f44e569cc3c202dfa4eadcb236a5cebbf19021ba4050:1",
-            "last_update": 1710845821,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "108",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710845821,
+                "last_update": 1710617530,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -9880,56 +4003,27 @@
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "10",
                 "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710813189,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710705189,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "0334bbf89f5fc82c8aebbddc9f2b78f9528cd2fd916fbc091a8ce35aed57c1110d",
+            "node1_pub": "0242902a3a5aa34829db9def5b44939f9f459f4ee08e97cba18516c62ddf8ec9e6",
             "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
         },
         {
-            "channel_id": "911307122958139392",
-            "chan_point": "4679249fc2096cbfa2b52f627272f3358b14272392e1292c5011c472197e514d:0",
-            "last_update": 1710475350,
-            "capacity": "20000",
+            "channel_id": "892895800825741312",
+            "chan_point": "997c879c28e44b11493fffc1e3bdd41bfab8ebcb815a3b8b0c6d0f7baeabe86b:0",
+            "last_update": 1710607091,
+            "capacity": "50000",
             "node1_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": true,
-                "max_htlc_msat": "19800000",
-                "last_update": 1710475350,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "19800000",
-                "last_update": 1710203858,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02da4f536ea290aa280854d6165fa5a23151f072ed8ee285e8658db91a942db9fd",
-            "node2_pub": "0346078e95939cd4213e5806b82682d1a2c4619430e060eb8d09015dcc98457751"
-        },
-        {
-            "channel_id": "911375292734111744",
-            "chan_point": "9a52758816c54d975ad82f529b842eeb98400b24e76f27f2be990d5e474ba9e1:0",
-            "last_update": 1710840728,
-            "capacity": "200000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710444750,
+                "max_htlc_msat": "49500000",
+                "last_update": 1710607091,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -9938,4977 +4032,56 @@
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": true,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710840728,
+                "max_htlc_msat": "49500000",
+                "last_update": 1705276253,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "02da4f536ea290aa280854d6165fa5a23151f072ed8ee285e8658db91a942db9fd",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
+            "node1_pub": "03796678b7111abef10f3ff85b88f81f9cfe81cac7e3628a11af1679ed912757d5",
+            "node2_pub": "021cb32426ed1a6be9533801e7c56a70ffc1c360a3a31819c3ae0a72e141d78000"
         },
         {
-            "channel_id": "911445661564338177",
-            "chan_point": "25daedd93e82f933009c517fa830828e06f13dc692db38d8249cb098954d3035:1",
-            "last_update": 1710558366,
-            "capacity": "450000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "500",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "202500000",
-                "last_update": 1710414150,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": true,
-                "max_htlc_msat": "200000000",
-                "last_update": 1710558366,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02da4f536ea290aa280854d6165fa5a23151f072ed8ee285e8658db91a942db9fd",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "906760642476572673",
-            "chan_point": "5eb34c50d0be7e10116fcc5c538d3f914399a5497f49ea2193c05aaab4b13b60:1",
-            "last_update": 1710826559,
+            "channel_id": "892768257448935424",
+            "chan_point": "7b2351fe1f9dc287e376f481ae3e52cb39ad417cb8387087b91054e300ddc486:0",
+            "last_update": 1710639306,
             "capacity": "2000000",
             "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "666",
-                "fee_rate_milli_msat": "206",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710794296,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710826559,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "0216fcf031519e0924e5e4b64a731b207cccb85b13caebffd0f664a32a39bcd368"
-        },
-        {
-            "channel_id": "884230549666856961",
-            "chan_point": "8a4daff1aa3e01c961069dcb536902276c1b4f188086afc48d7206fecf073e86:1",
-            "last_update": 1710795242,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "793",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710795242,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "110000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710792805,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "882751706630717441",
-            "chan_point": "7450a6a9a1bc1f7b99f8443f005f3b5e4466844ebe8ad8173d4d7104926ed8b8:1",
-            "last_update": 1710808485,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710799066,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "120000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710808485,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c"
-        },
-        {
-            "channel_id": "874085355913216004",
-            "chan_point": "98060c5be41321c51fae2ba3c32293f67590c9f2d96d3ec25fc048c63ba66be5:4",
-            "last_update": 1710815214,
-            "capacity": "16000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710814354,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "14256000000",
-                "last_update": 1710815214,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "914725504737935361",
-            "chan_point": "762048a5cca2c3e8fa832df4b63d69dacd10d660c5dc585ec504eb3a8b6f8c33:1",
-            "last_update": 1710844618,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710794407,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "860",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710844618,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "876489987910139906",
-            "chan_point": "98241a18341b9d0f5711cfd1f1f291bade5cb07d92d63b6c847ebef920e531fe:2",
-            "last_update": 1710853848,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "5049000000",
-                "last_update": 1710824784,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "110000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": true,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710853848,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad"
-        },
-        {
-            "channel_id": "843854283763351557",
-            "chan_point": "604dd3a3ca03ee7622c7400824ea9b55ec8743b5aa721a943ebd8ce63a83d330:5",
-            "last_update": 1710795414,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "560",
-                "disabled": false,
-                "max_htlc_msat": "17820000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710793854,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "843969732347101191",
-            "chan_point": "f12cfdea431fa5f3e279d722a570e870475e3a3d6b177c3339a94ec4bb89cc89:7",
-            "last_update": 1710795431,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1800",
-                "disabled": false,
-                "max_htlc_msat": "14948498700",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710795431,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "845123120189997057",
-            "chan_point": "3e662f41aac21c2f5c44c4a5bebafbacb32eb4f22d5ca5ebec7f91de5ce2c438:1",
-            "last_update": 1710795414,
-            "capacity": "16000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1975",
-                "disabled": false,
-                "max_htlc_msat": "14256000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710793681,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "channel_id": "847237480926019584",
-            "chan_point": "7f857a3128b1bdbec1caea8639e08a278276d64e61085c24c1c2cc6cd6556d08:0",
-            "last_update": 1710795414,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "8910000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "9890000000",
-                "last_update": 1709802574,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "849396921885065218",
-            "chan_point": "f0177af04b030ee9a3e25b2a8aa4abfdbe1565026587eb45bd99a5c978346b44:2",
-            "last_update": 1710856184,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "4455000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "622",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710856184,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "891181662240702469",
-            "chan_point": "80867d2afa2a95be7d50339cc23666b30819c725ffeb9c419553ca7c02abe9c7:5",
-            "last_update": 1710795414,
-            "capacity": "13876101",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "120000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2080",
-                "disabled": false,
-                "max_htlc_msat": "13737340000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "13737340000",
-                "last_update": 1710793794,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "860914306180251648",
-            "chan_point": "ed8246c6eddd498751e0a2f0c5a4944c1c23f9478245c3729fa4a6686fecfc35:0",
-            "last_update": 1710795414,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "110000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "4455000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1762",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710794903,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02"
-        },
-        {
-            "channel_id": "886632982537699356",
-            "chan_point": "75f178a4f984736b1210e62a4bbc66c9e7aee62b340d3aef67d9da7fd4549a7e:28",
-            "last_update": 1710795414,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "120000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "510",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710795189,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "891223443594936321",
-            "chan_point": "19afa21125db02921477ec0c8b6fe5dd5db61dc76502ad440fc60af001b96684:1",
-            "last_update": 1710818418,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "440",
-                "disabled": false,
-                "max_htlc_msat": "2500000",
-                "last_update": 1710818418,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "906677079711744001",
-            "chan_point": "eb6d79a8b9c671d8d5bd5bd581b04ae974e9e84ca37a69a0a6c8b992398d8749:1",
-            "last_update": 1710795414,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "110000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1640",
-                "disabled": false,
-                "max_htlc_msat": "900000000",
-                "last_update": 1710795414,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "400000000",
-                "last_update": 1710783823,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02ad4afb6e50ae4635ec5ddf5a57c44d4cc4b376ac6580f78cda0454a86e5fa6c2",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "892033783627251715",
-            "chan_point": "bf601e16d85a744563b4015ad2e866f3dc5ca99304347fcbd9d9a85fc10a1f99:3",
-            "last_update": 1710852956,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710798808,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710852956,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c"
-        },
-        {
-            "channel_id": "900672646537740289",
-            "chan_point": "eaf460381e375744a46ff9a44ad5b79f62cac61093e37b3c9ffc91fe83cd04ad:1",
-            "last_update": 1710838442,
-            "capacity": "15417405",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "643",
-                "disabled": false,
-                "max_htlc_msat": "15263231000",
-                "last_update": 1710838442,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "5000000",
-                "fee_base_msat": "200",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "15263231000",
-                "last_update": 1710792785,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "771060016808132608",
-            "chan_point": "5f97f8bc00ede3b058a18786bab5ff1bfce4404378a14092bb549e5a59422f25:0",
-            "last_update": 1710798007,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710798007,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "12",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710797156,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "847367223422222337",
-            "chan_point": "79e185d51ea4fcc7bbd6097b5347953b5ac7d784d6114bb75e120a46badb2cd7:1",
-            "last_update": 1710853845,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "2019600000",
-                "last_update": 1710812251,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "48",
-                "disabled": true,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710853845,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad"
-        },
-        {
-            "channel_id": "777861595839201280",
-            "chan_point": "cb68eb58ac92a04826796d70a0f66936b4056c69a16943ddbe17cd50191d4aac:0",
-            "last_update": 1710799709,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710788156,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "490",
-                "fee_rate_milli_msat": "27",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710799709,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "782170581782364160",
-            "chan_point": "8e2747babaea4f5862d636ece0f85873c1ad41e8da8b3e4e10da64359c4946e5:0",
-            "last_update": 1710606356,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "600",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4000000000",
-                "last_update": 1710606356,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1707894782,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "03e8b9a977fa3ae7acce74c25986c7240a921222e349729737df832a1b5ceb49df"
-        },
-        {
-            "channel_id": "795794630361415682",
-            "chan_point": "6496d3736f9c9e8b8b1d6e9be60a183ba9e2b0f3d7e1d663b634cf105ba90580:2",
-            "last_update": 1710816956,
-            "capacity": "4537566",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "11",
-                "disabled": false,
-                "max_htlc_msat": "4537566000",
-                "last_update": 1710816956,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1",
-                "fee_rate_milli_msat": "853",
-                "disabled": false,
-                "max_htlc_msat": "4492191000",
-                "last_update": 1708896886,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "02c61e171140fc1aac5d3e0bcfefdc79ea954306dfa29265f02def849dc7e80419"
-        },
-        {
-            "channel_id": "817944292095492096",
-            "chan_point": "66fe1cefe13ca0f0250556ea4efadf82e15d329f5fd1e194fdfe26473ac475d0:0",
-            "last_update": 1710626156,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "90",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710626156,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "4940000000",
-                "last_update": 1710407375,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "825092217231507457",
-            "chan_point": "c23a61ef6f223075191f4fe63e41fb79aa0263f875ba41ba54abad6baa64de03:1",
-            "last_update": 1710856206,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710795356,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "773",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710856206,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "886172287273140225",
-            "chan_point": "81c3850d762990fc9bc02f045d3bf56d4b8e2099630167ac4d73c2916e744987:1",
-            "last_update": 1710852956,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "6",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710852956,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "28",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710846516,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "886632982537699350",
-            "chan_point": "75f178a4f984736b1210e62a4bbc66c9e7aee62b340d3aef67d9da7fd4549a7e:22",
-            "last_update": 1710829389,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "18",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710789956,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710829389,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "891176164674830341",
-            "chan_point": "f0237ecd26cb623415c0be9c81904faf6af7ad7220e5c94a8e769b6ce3d5fb6d:5",
-            "last_update": 1710797156,
-            "capacity": "18449825",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "608",
-                "disabled": false,
-                "max_htlc_msat": "18265327000",
-                "last_update": 1710797156,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "18265327000",
-                "last_update": 1710788394,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "901942582481321985",
-            "chan_point": "ca99ffc32cda35e405fb09a1ba4540f5793aa06e302c82365efc44ff9e9f5aa9:1",
-            "last_update": 1710845087,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "18",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710824156,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710845087,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02b21ca992bf95e3f324302265ad86cec24f36166fd7afca44efa0809aaa8b25c5",
-            "node2_pub": "03740f82191202480ace717fcdf00f71a8b1eb9bdc2bb5e2106cd0ab5cb4d7a54e"
-        },
-        {
-            "channel_id": "618510475044978689",
-            "chan_point": "27ed5f50c115c0f1cabcdbd25c093a8327bc3781d01170b9325ec1fffc4d4897:1",
-            "last_update": 1710833221,
-            "capacity": "77954",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": true,
-                "max_htlc_msat": "77175000",
-                "last_update": 1710833221,
-                "custom_records": {}
-            },
-            "node2_policy": null,
-            "custom_records": {},
-            "node1_pub": "027e5ef63402f1a74c1293f46a0bae52625745ff9184b277506d4645f99f22d629",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "818596302609448961",
-            "chan_point": "aa7d526f8393597823c1f74165faa3e70e4895bfbce52dded19d7ee7754d638d:1",
-            "last_update": 1710764361,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "19602000000",
-                "last_update": 1710642258,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710764361,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "036b53093df5a932deac828cca6d663472dbc88322b05eec1d42b26ab9b16caa1c"
-        },
-        {
-            "channel_id": "834121406772871169",
-            "chan_point": "2983bbcc6513a9ba0ddb99536a023ba39a827033a60e916a3978bd4e46eaf426:1",
-            "last_update": 1710846371,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "100000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710796525,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "12",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710846371,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "890969456403218436",
-            "chan_point": "8025463adb8a06cd4e6ca13dbd3bd7c3371d5b8aad6a12be4a9f397d114a7681:4",
-            "last_update": 1710853194,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710843325,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710853194,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "856856008640430081",
-            "chan_point": "508fd067957c832d369ff1117e1ffdc82b3450ecb896a0beb08ca3dbd1389cf3:1",
-            "last_update": 1710853925,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "4900500000",
-                "last_update": 1710853925,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "2524500000",
-                "last_update": 1710851784,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad"
-        },
-        {
-            "channel_id": "869442118326157317",
-            "chan_point": "21d47c8ec7b1b25baba89d3926a078c50cd8db450d80185abfe7dfdf6d2bd17d:5",
-            "last_update": 1710852808,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710776725,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710852808,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c"
-        },
-        {
-            "channel_id": "872967152657956865",
-            "chan_point": "e6e7793d18f4614b34ab531eab8c51edf94dfdec378b4b231c160d68187a6ed7:1",
-            "last_update": 1710853055,
-            "capacity": "6750750",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "6683243000",
-                "last_update": 1710776725,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "6683243000",
-                "last_update": 1710853055,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9"
-        },
-        {
-            "channel_id": "887911714563293185",
-            "chan_point": "2f6e136d4d24bb5104ffbc0817ddabc3d6896cd970c4d78db28b9bda2356d7c7:1",
-            "last_update": 1710851224,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710850525,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "840",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710851224,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02"
-        },
-        {
-            "channel_id": "892976065148354562",
-            "chan_point": "9d0754f50c89e2101622ef0c86a47961824fbb633e9929aacde1fbd84d30f342:2",
-            "last_update": 1710853081,
-            "capacity": "6000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710843325,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710853081,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "channel_id": "900373579538169859",
-            "chan_point": "ea5fa418dd2d268d8a8539622d790595af132e08577879b3bcdd1c46984c648d:3",
-            "last_update": 1710853200,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710850525,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "2000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "210",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710853200,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a"
-        },
-        {
-            "channel_id": "912280190891261953",
-            "chan_point": "77d60be06f921869690cc980e0845a20cb5467d0da0caad48742d36eaed5654c:1",
-            "last_update": 1710839725,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710839725,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710788820,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "912947594362421249",
-            "chan_point": "7d188984e5e96aa0a23288b99839b817629d29e9616e5ddeaa0ec63433064016:1",
-            "last_update": 1710853030,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710796525,
-                "custom_records": {}
-            },
-            "node2_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710853030,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "913749138333368321",
-            "chan_point": "33aa6cbaff0cd415455af72e22256beeba6c325b2d761f614dd842b42d0b0b77:1",
-            "last_update": 1710852148,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710814525,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710852148,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "913884378282262529",
-            "chan_point": "df582df01799b0124edcac35e34a4c34fd51e84df9223081c3d49b3cfb3bf093:1",
-            "last_update": 1710852325,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710852325,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710178449,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "913884378282262530",
-            "chan_point": "df582df01799b0124edcac35e34a4c34fd51e84df9223081c3d49b3cfb3bf093:2",
-            "last_update": 1710852007,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710807325,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710852007,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "918239543869833217",
-            "chan_point": "3c2e9069325e1b7b63e542a298077cbd1281fe5f9a466cc08c126d3eb2762a74:1",
-            "last_update": 1710852325,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710852325,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "150",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710846507,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "918318708659912707",
-            "chan_point": "e50c68559d6cb3e11523f44c9b7643ee9cc736232d825f8786935ee2083c3a42:3",
-            "last_update": 1710852325,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710852325,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "700",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710848071,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0203e5b16ebe87b089f22e18752f1f7a66a1bdf77879df8d1c9e8d912dbfb9beb4",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "693407008184991745",
-            "chan_point": "16feb61e417b88ec6dfcb7bdf5086df8742752437d08d8ae67d99425d7f1b60c:1",
-            "last_update": 1710810044,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710739803,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710810044,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "channel_id": "634461090198192128",
-            "chan_point": "1b153ae33e82e7a1e39b3b5b81a7d1098a83c64de718455abe3e711a473944a1:0",
-            "last_update": 1710814836,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710813644,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710814836,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "03949914687fadf3bca1abe088db2b9a5bc105194a36f230f7e54e90e88d2dc0ec"
-        },
-        {
-            "channel_id": "768970944798261248",
-            "chan_point": "3c44260dfda78ea7f57ac16afedf09a793124ee6885da5a09500c5bce10e1e28:0",
-            "last_update": 1710799709,
-            "capacity": "200000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710786644,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "490",
-                "fee_rate_milli_msat": "2755",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710799709,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "784400391410548736",
-            "chan_point": "693c90f2059c00b22cda8884faa5d2ed63985322648d6de199924def6e4448e7:0",
-            "last_update": 1710822644,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710822644,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710817807,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "786308044043059200",
-            "chan_point": "59ff4cc701e9fef9f340fdc056b0f28bc7074d46ecfb6ef7fdf00d72819f27e6:0",
-            "last_update": 1710842444,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710842444,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710842221,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "799824340611891201",
-            "chan_point": "6f814b81a1d936d6f92d450fee907e95d202e0f3b6e638182f1b38442d8a5976:1",
-            "last_update": 1710816794,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": true,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710693019,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710816794,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004"
-        },
-        {
-            "channel_id": "799825440052215808",
-            "chan_point": "69f286d092bc593c0f8eb70bb729a8ec72ebb7dae39054324363f560ed62d97a:0",
-            "last_update": 1710844884,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710844884,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710844883,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8"
-        },
-        {
-            "channel_id": "882751706562166785",
-            "chan_point": "2a89152ee98907401588891f97ce101fd12907d16405c8af5e7d3bbc486ed3f5:1",
-            "last_update": 1710798659,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710798659,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710637286,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02607c9c92b7fa405dd27d8114d5ba1e6c04bf8757bef18b3649bffa2691d7638c",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "792726993064493056",
-            "chan_point": "b3b1cfa6f4b7e11e36ac4a7d2f39085ccdf4535740aaa263ffb6d09aca80efa8:0",
-            "last_update": 1710695796,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "2500000000",
-                "last_update": 1710695796,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1709781601,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0251fff168b58b74e9b476af5a515b91fe0540a3681bc97fbb65379a807aea5f66",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "904879378123849729",
-            "chan_point": "efeb0be5eebeebb14d33a632175cb4f550525ca85a2a4fc61c8c986ef5d078d2:1",
-            "last_update": 1710782196,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "6900000000",
-                "last_update": 1710782196,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "9000000000",
-                "last_update": 1710536797,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0251fff168b58b74e9b476af5a515b91fe0540a3681bc97fbb65379a807aea5f66",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "891147577330302982",
-            "chan_point": "44267c22d8d42675c44f3292e0da57247570fcc6f049c5d81a6e4faeaf26dea7:6",
-            "last_update": 1710784794,
-            "capacity": "16130671",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "6900000000",
-                "last_update": 1710782196,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "15969365000",
-                "last_update": 1710784794,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0251fff168b58b74e9b476af5a515b91fe0540a3681bc97fbb65379a807aea5f66",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "891985405155409920",
-            "chan_point": "fb1779447452b5e90d05649547cada306c81e43886bfbcf00d641ad3228f901c:0",
-            "last_update": 1710783447,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "2500000000",
-                "last_update": 1710782196,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710783447,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0251fff168b58b74e9b476af5a515b91fe0540a3681bc97fbb65379a807aea5f66",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "906430788937777153",
-            "chan_point": "841493689f73098f373995e21b175e9f03089d61598a4c7619bd0268bd7a593a:1",
-            "last_update": 1710784854,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710782196,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710784854,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0251fff168b58b74e9b476af5a515b91fe0540a3681bc97fbb65379a807aea5f66",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "914055902124900353",
-            "chan_point": "cf040b5b220ea08d5b2cc974fb44065c8b107798a1422bbaa68d0c9d21f78aa0:1",
-            "last_update": 1710784538,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "6900000000",
-                "last_update": 1710782196,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710784538,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0251fff168b58b74e9b476af5a515b91fe0540a3681bc97fbb65379a807aea5f66",
-            "node2_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a"
-        },
-        {
-            "channel_id": "914928914386583552",
-            "chan_point": "15f6de8ddc05846e37dce7acb7a0e75aa49671f1b80ddf0f036359ac014707f0:0",
-            "last_update": 1710856504,
-            "capacity": "1500000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710834728,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710856504,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "037e8b1af65a511e3baf38e45509fb1bfb8023a6e5e2555774998b9ce91a3c58b6",
-            "node2_pub": "026e10b080dc2ffba3966daeab5803a2d263788cef0750bff3001bda037e358d98"
-        },
-        {
-            "channel_id": "910818939916582913",
-            "chan_point": "96fba2c16d7550289bc31b01a29e945ad11eb37aa80e531d5764972cf5a26f70:1",
-            "last_update": 1710756427,
-            "capacity": "2108840",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "948978000",
-                "last_update": 1710756427,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "948978000",
-                "last_update": 1710156582,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "037e8b1af65a511e3baf38e45509fb1bfb8023a6e5e2555774998b9ce91a3c58b6",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "880691221762408448",
-            "chan_point": "51016161dd4461b898aa699efdf658b385c55c8f5ea304a5b0e7a713a6efe8f9:0",
-            "last_update": 1710854364,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710854364,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10000",
-                "fee_rate_milli_msat": "10",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710854256,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ab5a4b4f9883321da39bcac78f298c673f5d3f0d90cac8780d7f730fed8c2193",
-            "node2_pub": "02a1431534bfe333be9ff587f8f197b1b3d9ec05b58eb42e2a08f590fea6cc8866"
-        },
-        {
-            "channel_id": "871232123334492161",
-            "chan_point": "443cc8cf7b8329fa76b7317186b775da00d6775dc46e5fea77185fee817c5017:1",
-            "last_update": 1710773229,
-            "capacity": "1500000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "15",
-                "disabled": false,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710765639,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710773229,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ab5a4b4f9883321da39bcac78f298c673f5d3f0d90cac8780d7f730fed8c2193",
-            "node2_pub": "02cb080fa2386d00e74c90cb4a5a3fb8a16278c248adf851e6af3f67802fa6ab99"
-        },
-        {
-            "channel_id": "886786914241085476",
-            "chan_point": "c34a46e8d7fd82170c9fc87cfcbc848c477a40799d638512bb60054aafd69cf3:36",
-            "last_update": 1710845516,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710845516,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710790630,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ab5a4b4f9883321da39bcac78f298c673f5d3f0d90cac8780d7f730fed8c2193",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "838382014339678209",
-            "chan_point": "ab4ac7a4205977b6e81a5ed470e82bdbc914528e6241b70dd951b29fb591806f:1",
-            "last_update": 1710583630,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710148326,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1000000000",
-                "last_update": 1710583630,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ab5a4b4f9883321da39bcac78f298c673f5d3f0d90cac8780d7f730fed8c2193",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "841004349543809031",
-            "chan_point": "b55216509c9c69a7b148d4bb4c5ebd2248b0b763b4883d7b42f12b826a5b970e:7",
-            "last_update": 1710823333,
-            "capacity": "931441",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "931441000",
-                "last_update": 1710786603,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2",
-                "disabled": false,
-                "max_htlc_msat": "922127000",
-                "last_update": 1710823333,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "channel_id": "884766011973632001",
-            "chan_point": "5a203316e4d7d79f65b38a1cfb667f25d7a5b98cfd8fe84465e43466e80a7923:1",
-            "last_update": 1710853952,
-            "capacity": "3406458",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "3406458000",
-                "last_update": 1710825151,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "514",
-                "disabled": false,
-                "max_htlc_msat": "3372394000",
-                "last_update": 1710853952,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "842164334255734789",
-            "chan_point": "5446bf1ed92f5b368bb2868cb438ea4226d98c4e7016965b7d3add652873a59c:5",
-            "last_update": 1710850206,
-            "capacity": "16464687",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "16464687000",
-                "last_update": 1710793535,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "657",
-                "disabled": false,
-                "max_htlc_msat": "16300041000",
-                "last_update": 1710850206,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "885679706110689280",
-            "chan_point": "ee08ee7f5dd6d2e5754714f59d6a1811728fb1ac11b32bd481794dc1cfc99d6e:0",
-            "last_update": 1710846508,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "46",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710846508,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "399",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710823334,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "890671488828571659",
-            "chan_point": "2348c64a627cd263ac2426db8d3022a8a15bc9e8ff1eed6e78d71a12dbb8f745:11",
-            "last_update": 1710856061,
-            "capacity": "7448636",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "7448636000",
-                "last_update": 1710788394,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5799",
-                "disabled": false,
-                "max_htlc_msat": "7374150000",
-                "last_update": 1710856061,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "884769310409359363",
-            "chan_point": "8d7771a68cdd340ff416c734f3a397524338ebbd8692e07e066c2a3308149039:3",
-            "last_update": 1710855309,
-            "capacity": "10465625",
-            "node1_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "763",
-                "disabled": false,
-                "max_htlc_msat": "10465625000",
-                "last_update": 1710855309,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "6",
-                "disabled": false,
-                "max_htlc_msat": "10360969000",
-                "last_update": 1710559282,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "890724265347121152",
-            "chan_point": "5d867f6e64b812dd0845153f6e144e710932b54a330775caf62251e6fe6f18d6:0",
-            "last_update": 1710823334,
-            "capacity": "13332843",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "13332843000",
-                "last_update": 1710788281,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "31265",
-                "disabled": false,
-                "max_htlc_msat": "13199515000",
-                "last_update": 1710823334,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "channel_id": "885154139383791616",
-            "chan_point": "3047d6a174b2c4d30341efb93dab1c9dfc1e6648a538147b1ec99264764ad06e:0",
-            "last_update": 1710823334,
-            "capacity": "13004976",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "13004976000",
-                "last_update": 1710795654,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1467",
-                "disabled": false,
-                "max_htlc_msat": "12874927000",
-                "last_update": 1710823334,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "886592300790186001",
-            "chan_point": "b118e2f5494e53302d817ef1132a207b01b08d0ee057cdf949c92f2ed87decf3:17",
-            "last_update": 1710816879,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
                 "disabled": false,
                 "max_htlc_msat": "2000000000",
-                "last_update": 1710732189,
+                "last_update": 1710607091,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 34,
                 "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "355",
+                "fee_base_msat": "5805",
+                "fee_rate_milli_msat": "6",
                 "disabled": false,
                 "max_htlc_msat": "1980000000",
-                "last_update": 1710816879,
+                "last_update": 1710639306,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
+            "node1_pub": "023bb9937dea9707583e45aa6708af0c5d16d9ca3970f67ab76606f43b7457309d",
+            "node2_pub": "021cb32426ed1a6be9533801e7c56a70ffc1c360a3a31819c3ae0a72e141d78000"
         },
         {
-            "channel_id": "890671488828571651",
-            "chan_point": "2348c64a627cd263ac2426db8d3022a8a15bc9e8ff1eed6e78d71a12dbb8f745:3",
-            "last_update": 1710850207,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "16777215000",
-                "last_update": 1710642109,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "462",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710850207,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "036b53093df5a932deac828cca6d663472dbc88322b05eec1d42b26ab9b16caa1c"
-        },
-        {
-            "channel_id": "890712170716200960",
-            "chan_point": "81c92f06daa3cafcbd75e43c134c2b85d67a7e151ba6126cc93a390c2562b743:0",
-            "last_update": 1710828451,
-            "capacity": "2320952",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "0",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "200000000",
-                "last_update": 1710828451,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1620",
-                "disabled": false,
-                "max_htlc_msat": "1044428000",
-                "last_update": 1710823334,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "885123353109856260",
-            "chan_point": "bb769fee80b64a20f4fe9a353a8abbcca92886429735883c6695f27ec9392dc9:4",
-            "last_update": 1710823334,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "61",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710823334,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "460",
-                "disabled": false,
-                "max_htlc_msat": "1600000000",
-                "last_update": 1710804996,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "885190423391830016",
-            "chan_point": "6bfad394aeac29487bf524269483aa27e3d19a260416c81ef9208b804565bc75:0",
-            "last_update": 1710850207,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "41",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710850207,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1921",
-                "disabled": false,
-                "max_htlc_msat": "16777215000",
-                "last_update": 1710803903,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02"
-        },
-        {
-            "channel_id": "890692379501592576",
-            "chan_point": "8096535b34d92a0311493fd3edeb4285250e135d82d91900a5faa436fad5e1a3:0",
-            "last_update": 1710850207,
-            "capacity": "3367879",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "141",
-                "disabled": false,
-                "max_htlc_msat": "3334201000",
-                "last_update": 1710850207,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "3367879000",
-                "last_update": 1710797255,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b9aacb265dc5ebde04b91b28f7c8bb6ba0af146e5f37426915742daf8f195a09",
-            "node2_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9"
-        },
-        {
-            "channel_id": "847069255619444742",
-            "chan_point": "4a45c2aae559d9f1624bd09d834b9806347cd7b77f3f9f4d46d9265b66007467:6",
-            "last_update": 1710853837,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": true,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710853837,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "1009800000",
-                "last_update": 1710826584,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "0210ef7d43c105753673563feb1e20fe344b844ab65aa710cb2288a257ec024c99"
-        },
-        {
-            "channel_id": "906305444600152064",
-            "chan_point": "0665b71abd8941ee5d914b1bb418a82e6aac7cfd1f770e471c18f4e25ce5410d:0",
-            "last_update": 1710853851,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "1093",
-                "disabled": true,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710853851,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "5000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710826584,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "918128493124452353",
-            "chan_point": "c8c0b4a272d09b56349b21aa983cc05292c85eb609016177909cec2aac63d132:1",
-            "last_update": 1710853901,
-            "capacity": "200000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "198000000000",
-                "last_update": 1710853901,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "100980000000",
-                "last_update": 1710829458,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "903685308548120576",
-            "chan_point": "44dc5a8930473f37e14e1d926afeb1ad7f1b2457e097d7678e80daef90eac85f:0",
-            "last_update": 1710853871,
-            "capacity": "200000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "100980000000",
-                "last_update": 1710826584,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "198000000000",
-                "last_update": 1710853871,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "847550841790070784",
-            "chan_point": "636b0b79a1a57c0571d40f4c58a613ed090783088995b22b907f81ede800d0c5:0",
-            "last_update": 1710837722,
-            "capacity": "15000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "80",
-                "disabled": true,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710837170,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710837722,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8"
-        },
-        {
-            "channel_id": "849145133569343489",
-            "chan_point": "121fff49478a804434074bb612dbcaebfb17a3e6a5aed0285174cbfc4730129f:1",
-            "last_update": 1710826584,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "80",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710826584,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "19790000000",
-                "last_update": 1710811968,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "850643767906795521",
-            "chan_point": "c77fc7743d1ae839d61ae01f563e36d0c2efed6af21287141a5f9def7b625357:1",
-            "last_update": 1710853828,
-            "capacity": "200000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "198000000000",
-                "last_update": 1710844584,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "900",
-                "disabled": true,
-                "max_htlc_msat": "198000000000",
-                "last_update": 1710853828,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "865042972264955905",
-            "chan_point": "5c017a51db7dc22eb52a1db9fd2470c8738ed20b819d1624cb1d3d8fea7fa9a1:1",
-            "last_update": 1710853870,
-            "capacity": "16000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "8078400000",
-                "last_update": 1710826584,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710853870,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1"
-        },
-        {
-            "channel_id": "865053967386869769",
-            "chan_point": "8f51beb2a7098a115f3e573a133e2258232d9bb16aeed3ad3b5e8e4ea3c8b103:9",
-            "last_update": 1710853858,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "80",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710812252,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2280",
-                "disabled": true,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710853858,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02"
-        },
-        {
-            "channel_id": "876520774203670529",
-            "chan_point": "d177c8cb199cb52447bbf801fef35016529c954cc8d1b0424b7cd0c5502e333d:1",
-            "last_update": 1710853844,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "5049000000",
-                "last_update": 1710812252,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "877",
-                "disabled": true,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710853844,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "881498263315152901",
-            "chan_point": "c9aca2250cf24b9a9e2912638e6612fd6c7c688a7c22d08f982ae7d329517168:5",
-            "last_update": 1710853845,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "10098000000",
-                "last_update": 1710837384,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "820",
-                "disabled": true,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710853845,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "891181662244962315",
-            "chan_point": "aaa33efa000286f755f397e0406c111ab785496d0dd453e423d31a0f9cfa8448:11",
-            "last_update": 1710853896,
-            "capacity": "279518538",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "2767233530",
-                "last_update": 1710826584,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": true,
-                "max_htlc_msat": "276723353000",
-                "last_update": 1710853896,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "891113492485767168",
-            "chan_point": "f390610af41dc814b464eccd9da6fc352d19a807606692cfb9833df69fe37956:0",
-            "last_update": 1710848185,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "2524500000",
-                "last_update": 1710848185,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1708123276,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "029efe15ef5f0fcc2fdd6b910405e78056b28c9b64e1feff5f13b8dce307e67cad",
-            "node2_pub": "03d64e760b4af3698e51eb7ed7d97fbbae41f8cd28c0bcb6851c21207922f6697d"
-        },
-        {
-            "channel_id": "912507789887012865",
-            "chan_point": "554769bad0c4319e3e359851a5e6f9870fac93156fa9817f4cf58c7ffe71e353:1",
-            "last_update": 1710809855,
-            "capacity": "4586041",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "2",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "4540181000",
-                "last_update": 1710788448,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": true,
-                "max_htlc_msat": "4540181000",
-                "last_update": 1710809855,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "036eb0617ee7a70277b2e48cfe98f0b82943409a81edf7fdbc2296995273033665",
-            "node2_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9"
-        },
-        {
-            "channel_id": "913143307368857601",
-            "chan_point": "46b2a80aff108c8c88818e9db3491cbf55ce2834e283674b9544063ebd5cf641:1",
-            "last_update": 1710775848,
-            "capacity": "9986705",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4494017000",
-                "last_update": 1710775848,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "4494017000",
-                "last_update": 1710429556,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "036eb0617ee7a70277b2e48cfe98f0b82943409a81edf7fdbc2296995273033665",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "887817156630216706",
-            "chan_point": "b5fbf147db53105008cd0232c6907b3fe3631c4b4318d9af9eb2c23bb0cfab87:2",
-            "last_update": 1710803903,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710773821,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "850",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710803903,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "888104129082228736",
-            "chan_point": "e6b60e6381d24396e8b927f1781dd3e939fddc55cbb18468be345868f5fe3fbe:0",
-            "last_update": 1710856103,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710816150,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710856103,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "766913758520082432",
-            "chan_point": "28240f7c92d664aaa0afc5bfcc5d6e84881ca92156bf3621d9ddd98b59261ddf:0",
-            "last_update": 1710801607,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710801607,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710800303,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "882861657635094533",
-            "chan_point": "fdd4302ba03fd52c4126427eb068d0cdbefdf0fd941ce12c53f6a1fc82ee01b2:5",
-            "last_update": 1710838103,
-            "capacity": "16777000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2",
-                "disabled": false,
-                "max_htlc_msat": "16609230000",
-                "last_update": 1710272041,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "290",
-                "disabled": false,
-                "max_htlc_msat": "16777000000",
-                "last_update": 1710838103,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "801882626311716864",
-            "chan_point": "27dbb81fe5aa4e6708d355315ad4e59e52f41efe979c0f9a3f2a930b2733cd7b:0",
-            "last_update": 1710820630,
-            "capacity": "16700000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "16533000000",
-                "last_update": 1710820630,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2800",
-                "disabled": false,
-                "max_htlc_msat": "16533000000",
-                "last_update": 1710820103,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "891147577331548167",
-            "chan_point": "88223c20dd386993a5371f9959365ce686a318bb1847bf85f557434918c155f9:7",
-            "last_update": 1710805703,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710788394,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1510",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710805703,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "890310849058308096",
-            "chan_point": "302ca5cfd6c299d04fae0dafd72cdac1c252b5940a40444a21a4c46bfa295673:0",
-            "last_update": 1710779281,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710779281,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1510",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710778703,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "channel_id": "882116188794912771",
-            "chan_point": "6b01eac9e084322af3150128de13c79437b256d94b86a78c54166a7f1596e182:3",
-            "last_update": 1710840654,
-            "capacity": "16777000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "16609230000",
-                "last_update": 1710840654,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "3200",
-                "disabled": false,
-                "max_htlc_msat": "16609230000",
-                "last_update": 1710838103,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "886759426467037194",
-            "chan_point": "5bc09590890f03e5e0a338c2352a2e3f87f30790814d056779b4881bea2cf68e:10",
-            "last_update": 1710793390,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710793390,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2050",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710789503,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "833192319416008705",
-            "chan_point": "c0eb614b520dfc7b06acff9abb36b58894f820e92b44187231f115ffdf90ab63:1",
-            "last_update": 1710778703,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710371133,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1750",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710778703,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "867045183061688321",
-            "chan_point": "e693836259d5755a842805de5cc5dc336f4e1246ea92462eb1270e49532da3a4:1",
-            "last_update": 1710715703,
-            "capacity": "3200000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "583",
-                "disabled": false,
-                "max_htlc_msat": "3200000000",
-                "last_update": 1710715703,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "80",
-                "disabled": false,
-                "max_htlc_msat": "3168000000",
-                "last_update": 1710301219,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bcf1f73199ed4445a8d6c033dd8cb550bb5205a16982ad2e13359e3318498c02",
-            "node2_pub": "03e8b9a977fa3ae7acce74c25986c7240a921222e349729737df832a1b5ceb49df"
-        },
-        {
-            "channel_id": "767788969758949377",
-            "chan_point": "7fb14a0ddce8ed717d52a90a3def834c8ffda42e53441fad640dedf268af2fc1:1",
-            "last_update": 1710831575,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710831575,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "2000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1080",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710795600,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "770599321434259457",
-            "chan_point": "6c848fe3d66f78b2e4b8c0796b257a2191a153d7e4eb2860ca78b133f0f4aeeb:1",
-            "last_update": 1710850347,
-            "capacity": "200000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710850347,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "2000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "210",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710781200,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "889552185993134082",
-            "chan_point": "ee3f1b4e3932bf09baef85846b8310adb60f9594a2d03a940a2d4b290f242516:2",
-            "last_update": 1710831614,
-            "capacity": "2111000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "2089890000",
-                "last_update": 1710831614,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "2000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1040",
-                "disabled": false,
-                "max_htlc_msat": "2089890000",
-                "last_update": 1710828000,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a",
-            "node2_pub": "026d1de80e59f3fe2b27aa3dc8012f4437165bf99971bd9b7d8afedb066f92d695"
-        },
-        {
-            "channel_id": "776331075584720897",
-            "chan_point": "e2d7977b3d01b530b343980038600af1ead3de09d0136403bd8fbdb51cb15052:1",
-            "last_update": 1710822600,
-            "capacity": "3000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "2000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710822600,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710434738,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a",
-            "node2_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf"
-        },
-        {
-            "channel_id": "777549334497067009",
-            "chan_point": "e1bada02582b89a96f150533784e3342416b078cebca00db93433de0e4822b7b:1",
-            "last_update": 1710842400,
-            "capacity": "1100000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "2000000",
-                "fee_base_msat": "1200",
-                "fee_rate_milli_msat": "605",
-                "disabled": false,
-                "max_htlc_msat": "1089000000",
-                "last_update": 1710842400,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": true,
-                "max_htlc_msat": "1089000000",
-                "last_update": 1710831568,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "891176164674764804",
-            "chan_point": "7bb32a8421519f5a2cc0132b38d43bb40c1f356dc59b127db2c28f8dab06b76c:4",
-            "last_update": 1710849594,
-            "capacity": "14197959",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "2000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1975",
-                "disabled": false,
-                "max_htlc_msat": "14055980000",
-                "last_update": 1710833400,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "14055980000",
-                "last_update": 1710849594,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028c589131fae8c7e2103326542d568373019b50a9eb376a139a330c8545efb79a",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "697408130948202497",
-            "chan_point": "2b86381aeeaecc5f328b7e0e8dd619c325faeaa1ed3392ed4beeb6b2252d0096:1",
-            "last_update": 1709925850,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "2000000000",
-                "last_update": 1709925850,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1708448218,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d9e9348bb5594bc5ccf195fa193fb3260287bb0529a65a74570fc2907c8cf36",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "698369104090628097",
-            "chan_point": "b06f6cd855b2e253b560293f4fa7724c5713d2cf62df9758cd3e8120a6e7deb8:1",
-            "last_update": 1709931250,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "2000000000",
-                "last_update": 1709931250,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "15",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1709245260,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d9e9348bb5594bc5ccf195fa193fb3260287bb0529a65a74570fc2907c8cf36",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "895995324144287745",
-            "chan_point": "4b8b65cf26354718d9fc7c222017dcb1011666bf2708a579cb9ca1776755e968:1",
-            "last_update": 1710824014,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710808189,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "200",
-                "disabled": true,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710824014,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d9e9348bb5594bc5ccf195fa193fb3260287bb0529a65a74570fc2907c8cf36",
-            "node2_pub": "03e20ae8b749c3e5e8b96c66c98141177e7b75571b90cab80c9085af7c80bd3852"
-        },
-        {
-            "channel_id": "891083805680795649",
-            "chan_point": "e6569df36648e11fd5f79d409cf4dea2f556e64447eb57eef9aff60b069d4a8a:1",
-            "last_update": 1710840208,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710840208,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710788394,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "624336787276169217",
-            "chan_point": "787aa85851dc5dc07ae190b794d41bb3f338eba842763f27bc3ca36a304f4eed:1",
-            "last_update": 1710840208,
-            "capacity": "800000",
-            "node1_policy": {
-                "time_lock_delta": 20,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "792000000",
-                "last_update": 1710840208,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "792000000",
-                "last_update": 1710786481,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5"
-        },
-        {
-            "channel_id": "834443563617746950",
-            "chan_point": "ef1f27205824cee35a1479e1c067320ed45754aec8d327fd33f0002217963466:6",
-            "last_update": 1710802630,
-            "capacity": "15000000",
-            "node1_policy": {
-                "time_lock_delta": 20,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "150",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710788008,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710802630,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "766215568571760640",
-            "chan_point": "c98bddd29953e3604da82c15142a8982eaac5d683ad831cf7f6b9ede0d543ef6:0",
-            "last_update": 1710831208,
-            "capacity": "20000",
-            "node1_policy": {
-                "time_lock_delta": 20,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "10",
-                "disabled": true,
-                "max_htlc_msat": "20000000",
-                "last_update": 1710831208,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "19427000",
-                "last_update": 1668106106,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "02398b614028892474fc95ed64c48791f994975042d0bd7e9592d0ec4128bbace4"
-        },
-        {
-            "channel_id": "852254552520261644",
-            "chan_point": "bbd654001c37c0913a7cf5110e91003f5eaf80efafab65c84027f2554cd0b121:12",
-            "last_update": 1710822208,
-            "capacity": "660000",
-            "node1_policy": {
-                "time_lock_delta": 20,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "653400000",
-                "last_update": 1710822208,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "653400000",
-                "last_update": 1710775236,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "03949914687fadf3bca1abe088db2b9a5bc105194a36f230f7e54e90e88d2dc0ec"
-        },
-        {
-            "channel_id": "871681823463505921",
-            "chan_point": "195cc8246336a50a279123bd7aa2f3ac8ef2c7dcf5309a9a2bd1e8f992a7f1bb:1",
-            "last_update": 1710853807,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710843808,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710853807,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "871702714138558469",
-            "chan_point": "b959b003d5d1cb426ef1fd8ce345104191cb57aa05b39250929fd1e5c9823161:5",
-            "last_update": 1710799949,
-            "capacity": "15000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710777208,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710799949,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "872614209320255507",
-            "chan_point": "d865c45c53b5e99c954deee8b14772bb0549d82e4298de126c1bc14d4bd5545a:19",
-            "last_update": 1710852808,
-            "capacity": "4400000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "4356000000",
-                "last_update": 1710852808,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "4356000000",
-                "last_update": 1710838621,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "872614209320255508",
-            "chan_point": "d865c45c53b5e99c954deee8b14772bb0549d82e4298de126c1bc14d4bd5545a:20",
-            "last_update": 1710752008,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710752008,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1709464547,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "874857213064708106",
-            "chan_point": "a3c16ff244b5ffae10b1997117820a0dc4c59ad29a28b4810f6fc634943a5991:10",
-            "last_update": 1710795208,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "100000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710795208,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 118,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1997",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710787359,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "874857213064708107",
-            "chan_point": "a3c16ff244b5ffae10b1997117820a0dc4c59ad29a28b4810f6fc634943a5991:11",
-            "last_update": 1710792794,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710792794,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "83",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710775044,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "892033783627251714",
-            "chan_point": "bf601e16d85a744563b4015ad2e866f3dc5ca99304347fcbd9d9a85fc10a1f99:2",
-            "last_update": 1710852747,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "1000",
-                "fee_base_msat": "900",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710831208,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710852747,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "020c92d71dfe47d49d322eed910064787973dff96c05a39d75a75d7e8f33aead4c",
-            "node2_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1"
-        },
-        {
-            "channel_id": "891086004748681220",
-            "chan_point": "dcf80c10558dcbc8aaafd325bff0b8c2e847e36ee3f77a729121eaaaf3e2c52d:4",
-            "last_update": 1710844203,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710844203,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710790081,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "channel_id": "882824274258034689",
-            "chan_point": "78e349ec2ca9dc60822ab9d755af8557ca273d9e5b9d192b43b083cf077c7cb9:1",
-            "last_update": 1710792787,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "1493",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710771444,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710792787,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "872443784965980161",
-            "chan_point": "9838f109ffd5875afa7ab83e656726c83b586a0b19060de5b42d43bd7f95ee09:1",
-            "last_update": 1710838621,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710838621,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710788281,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "898801277868834816",
-            "chan_point": "ca05a3f6d0c176149a1728f25c32c458e10253a58e4d8bcb6dd3560cd0e412c9:0",
-            "last_update": 1710856681,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "830",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710844271,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710856681,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "02679d067ec30e5bb4ad13e277d655e2f3779dda5979b615c8fdf1be0b096ae257"
-        },
-        {
-            "channel_id": "891176164675158018",
-            "chan_point": "6466c59736d408e10a11e2127710bd94b025f148f35a2db6ba4069b19af89a23:2",
-            "last_update": 1710842129,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "9900",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710842129,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710791881,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e"
-        },
-        {
-            "channel_id": "757384291199746048",
-            "chan_point": "53669ec939e58035111c8344ffb8cd03ee1c44a57ab62488672c84e241582e9a:0",
-            "last_update": 1710850381,
-            "capacity": "11007081",
-            "node1_policy": {
-                "time_lock_delta": 56,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1102",
-                "disabled": false,
-                "max_htlc_msat": "10897011000",
-                "last_update": 1710850381,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "10897011000",
-                "last_update": 1710817081,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "026d1de80e59f3fe2b27aa3dc8012f4437165bf99971bd9b7d8afedb066f92d695"
-        },
-        {
-            "channel_id": "890970556045983746",
-            "chan_point": "0346e8a51bc2e61160e02f2191c9dd3d5f15dca08d30a933b69fad8db8ccd37b:2",
-            "last_update": 1710788281,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 140,
-                "min_htlc": "1000",
-                "fee_base_msat": "2000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710755091,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710788281,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
-        },
-        {
-            "channel_id": "918058124356681728",
-            "chan_point": "a9b538ee337c8d19f37bbadf0429fb1c302db22f4bfb0e6af6f26a6fdfdc72d0:0",
-            "last_update": 1710793681,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710617844,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "500000000",
-                "last_update": 1710793681,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "02878765b772b842029f1808b768cc53ff6b88521c1fb3e4d409fda1f540f2122c"
-        },
-        {
-            "channel_id": "890521955192471556",
-            "chan_point": "7f10a4b436c27fb59e732a2db78a0da13b5b5ce418954dcc91c8190aefdf2340:4",
-            "last_update": 1710839407,
-            "capacity": "16000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710839407,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710788281,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "891147577331154950",
-            "chan_point": "fce08dc7251c524c38d5a9b0a8cdcea6d81d1fb1aca9464623aa69521002d1dc:6",
-            "last_update": 1710846513,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1112",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710846513,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710790081,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "891176164675223563",
-            "chan_point": "be9c2008ad15ab4dbfe34aab8f9829410f7a342479416d2715d1eba5feb08145:11",
-            "last_update": 1710831430,
-            "capacity": "333333333",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "330000000000",
-                "last_update": 1710831430,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "330000000000",
-                "last_update": 1710790081,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "908252679706640387",
-            "chan_point": "8adc603fdebfb9de7aa8422b653f1e4dc99f02f461c6ef5e2cb944d8a190da31:3",
-            "last_update": 1710842281,
-            "capacity": "400000000",
-            "node1_policy": {
-                "time_lock_delta": 18,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "396000000000",
-                "last_update": 1710795594,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 18,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "396000000000",
-                "last_update": 1710842281,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "890507661610319874",
-            "chan_point": "5ed0d6486be9fd4241fe4b7c44070cdfda10570c06857709f6501f6b30246e6d:2",
-            "last_update": 1710853776,
-            "capacity": "16000000",
-            "node1_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "994",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710853776,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "100000",
-                "fee_base_msat": "1",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710795481,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "637997119704858625",
-            "chan_point": "8feb0d917042be35695ed3d3dd789a9c16e3c5d0fb4d53e9f9845e5c7a38de77:1",
-            "last_update": 1710846510,
-            "capacity": "8164524",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "8082879000",
-                "last_update": 1710786481,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1",
-                "fee_base_msat": "490",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "8082879000",
-                "last_update": 1710846510,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "650917480759754753",
-            "chan_point": "49119135caa3ba8379cfbd5e6f153292ca1111733745fde0bc6dbe9f845051af:1",
-            "last_update": 1710786481,
-            "capacity": "8000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710786481,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710681636,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03949914687fadf3bca1abe088db2b9a5bc105194a36f230f7e54e90e88d2dc0ec"
-        },
-        {
-            "channel_id": "761877995223973888",
-            "chan_point": "71211fb929c5f02de455daee7729fe6f2fd6bc16fbb132849b2ad797ff5dfbb3:0",
-            "last_update": 1710850540,
-            "capacity": "7970456",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "7890752000",
-                "last_update": 1710849481,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "7890752000",
-                "last_update": 1710850540,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8"
-        },
-        {
-            "channel_id": "781024890669760513",
-            "chan_point": "745063f28c2a19f41c077807243f12f258cb475f15177a6d6893b0946d63407e:1",
-            "last_update": 1710779071,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710777481,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "415",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710779071,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03f20b295a728be64537bd7df1bf9092ed4bbf09b2c10f68c482d6fcb4f2232b28"
-        },
-        {
-            "channel_id": "815238394151174145",
-            "chan_point": "b88f3833c45336fa2a3e63806c836592b5f9897b29cc28702f51b1d07bf9319d:1",
-            "last_update": 1710856681,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710856681,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "5000",
-                "fee_rate_milli_msat": "1200",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710772694,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "035fed4182fbd0725264f8a0018cabb6b25514dd231291162ac8dd63afb278e9e8"
-        },
-        {
-            "channel_id": "831463887245082624",
-            "chan_point": "8fb0046ea3177a487e65f3281086c5912287d8981a4a3169a2b55db343cbcb41:0",
-            "last_update": 1710709774,
-            "capacity": "66658442",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "66658442000",
-                "last_update": 1710613681,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "4000",
-                "disabled": false,
-                "max_htlc_msat": "65981858000",
-                "last_update": 1710709774,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "886042544839786496",
-            "chan_point": "b6af2d57cb5227ffa47fd05c6202aaf5c2eee512088eefedc80f81047be40827:0",
-            "last_update": 1710836532,
-            "capacity": "200000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710836532,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710815843,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "channel_id": "891087104157220867",
-            "chan_point": "80656ab60c3125d0c2330841e0e579d52546aa3c51e5e38a0b900aba4bbb36eb:3",
-            "last_update": 1710829389,
-            "capacity": "22222222",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "22000000000",
-                "last_update": 1710790081,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "22000000000",
-                "last_update": 1710829389,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "891310305098596356",
-            "chan_point": "888876aa8768df1c36ab32aea53fee372a9d661c297f2c0f282378027e51466f:4",
-            "last_update": 1710842454,
-            "capacity": "400000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "396000000000",
-                "last_update": 1710838681,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "396000000000",
-                "last_update": 1710842454,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "890970556045983759",
-            "chan_point": "0346e8a51bc2e61160e02f2191c9dd3d5f15dca08d30a933b69fad8db8ccd37b:15",
-            "last_update": 1710802429,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710799081,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "999",
-                "disabled": false,
-                "max_htlc_msat": "400000000",
-                "last_update": 1710802429,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "891083805680664577",
-            "chan_point": "d834db8c96f8af9f03cd78c513a667eedc3a5a33bb350c5b92ff5f6325761bb8:1",
-            "last_update": 1710838347,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710790081,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710838347,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1"
-        },
-        {
-            "channel_id": "891147577329123339",
-            "chan_point": "7b163e01bb05bd0befe787d6d747f514eba41fd99ab14586e7edf9bbc64bcd52:11",
-            "last_update": 1710815796,
-            "capacity": "65400535",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "64746530000",
-                "last_update": 1710790081,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1330",
-                "disabled": false,
-                "max_htlc_msat": "64746530000",
-                "last_update": 1710815796,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "891181662240636932",
-            "chan_point": "fcaa2a1451d8881e93fc66a940a55f337ec9b51186066e6e7ffcd58e9e4ae869:4",
-            "last_update": 1710842255,
-            "capacity": "12817644",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "12689468000",
-                "last_update": 1710790081,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "12689468000",
-                "last_update": 1710842255,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "034ea80f8b148c750463546bd999bf7321a0e6dfc60aaf84bd0400a2e8d376c0d5",
-            "node2_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9"
-        },
-        {
-            "channel_id": "819299990012559360",
-            "chan_point": "14b70497fe165c16bf5babadfb21f11b4c6b142849ab8b16537f3620e653697b:0",
-            "last_update": 1710852929,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "666",
-                "fee_rate_milli_msat": "77",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710792496,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "9900",
-                "disabled": false,
-                "max_htlc_msat": "9000000000",
-                "last_update": 1710852929,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e",
-            "node2_pub": "0216fcf031519e0924e5e4b64a731b207cccb85b13caebffd0f664a32a39bcd368"
-        },
-        {
-            "channel_id": "872869296105455617",
-            "chan_point": "0dda5d00f0244719bf808e50497a014483992e45319aa074bfa086ed6c0c0ad5:1",
-            "last_update": 1710791633,
-            "capacity": "100000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10000",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "99000000",
-                "last_update": 1710791633,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "9900",
-                "disabled": false,
-                "max_htlc_msat": "95000000",
-                "last_update": 1710777329,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e",
-            "node2_pub": "02464181ef50b59a26cde9aa37bd32ced1cb1923b4811165fb1e619b7507639083"
-        },
-        {
-            "channel_id": "859713639326941185",
-            "chan_point": "3ea18ede724e185dbcc2a31f19c70adb972ddbe65b4a7b3b2c696ce49a6e9a06:1",
-            "last_update": 1710851129,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "9900",
-                "disabled": false,
-                "max_htlc_msat": "9000000000",
-                "last_update": 1710851129,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710792054,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "907461031312293889",
-            "chan_point": "17a9b5ba2b1b011222546a785945897294f7236c383b0a5b222aeab5f5d63de9:1",
-            "last_update": 1710820630,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "9900",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710791729,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710820630,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "914391253219868674",
-            "chan_point": "acf8a90a8ba334f408b13a1e581538c6fcc3d2398293a59b5fcad77f26769ca2:2",
-            "last_update": 1710849602,
-            "capacity": "3000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710849602,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710791590,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026c2683f3a85822cbb262baaed39d3985cbe3b8e9838135edef7cab7776a1df0e",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "875424561087774721",
-            "chan_point": "23285772c2b58382403eb095a929218a0c2658021bb7f3bc9407207f92df3bcb:1",
-            "last_update": 1710777930,
-            "capacity": "1300000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1287000000",
-                "last_update": 1710772948,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "1287000000",
-                "last_update": 1710777930,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02926a7ec4f47b624239aac1652228971ac812c6ff813efe9b5e772184cf3cdc31",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "880045808400203776",
-            "chan_point": "02d096ee28ee9697b30c5f035c68b25070d71e53c6228cb62f221da2f5940377:0",
-            "last_update": 1710798461,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "118",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710779805,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "9000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "700000000",
-                "last_update": 1710798461,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02926a7ec4f47b624239aac1652228971ac812c6ff813efe9b5e772184cf3cdc31",
-            "node2_pub": "02b61154d89b98662f4c58e1005963e918da6a8fdb5adbea85ad22a20b8e7fc0ad"
-        },
-        {
-            "channel_id": "890869400816975873",
-            "chan_point": "b250b1e03f62d37612d7901087862efaf93ce7e1ebcfea73972e2f903dc5ef0b:1",
-            "last_update": 1710856854,
-            "capacity": "5500000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "203",
-                "disabled": false,
-                "max_htlc_msat": "5445000000",
-                "last_update": 1710839130,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "5445000000",
-                "last_update": 1710856854,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02926a7ec4f47b624239aac1652228971ac812c6ff813efe9b5e772184cf3cdc31",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "893464248308137984",
-            "chan_point": "64fa7d079bf3996e3ccdd470f08af5cf8c3a6000382898aa8725717d55654edf:0",
-            "last_update": 1710849598,
-            "capacity": "2500000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "2475000000",
-                "last_update": 1710776130,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "288",
-                "disabled": false,
-                "max_htlc_msat": "2475000000",
-                "last_update": 1710849598,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02926a7ec4f47b624239aac1652228971ac812c6ff813efe9b5e772184cf3cdc31",
-            "node2_pub": "02ec23ef38b0af053817b793fc97d82acba48ec64895eb3f1cf2b1357123d35e15"
-        },
-        {
-            "channel_id": "915776637825908736",
-            "chan_point": "c1c184fded030338d3ac1fe258c5d5c60773865b26ea25d4a5241b09fd792dda:0",
-            "last_update": 1710797945,
-            "capacity": "291143",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "288232000",
-                "last_update": 1710777603,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "84",
-                "disabled": false,
-                "max_htlc_msat": "288232000",
-                "last_update": 1710797945,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "channel_id": "909981112139579393",
-            "chan_point": "44784998eab86ea58e3dc267eb91d3c4673c1a8af0b99634cef2a467668c4009:1",
-            "last_update": 1710824036,
+            "channel_id": "915246673262739457",
+            "chan_point": "4c2e260ea115e813a1255e12a1597e2577216d37d770c3e2328170fc28ffb153:1",
+            "last_update": 1710772374,
             "capacity": "100000",
             "node1_policy": {
                 "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "25",
+                "fee_rate_milli_msat": "1",
                 "disabled": false,
                 "max_htlc_msat": "99000000",
-                "last_update": 1710824036,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "94",
-                "disabled": false,
-                "max_htlc_msat": "99000000",
-                "last_update": 1710778145,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "02464181ef50b59a26cde9aa37bd32ced1cb1923b4811165fb1e619b7507639083"
-        },
-        {
-            "channel_id": "906118527774687232",
-            "chan_point": "17f6855949365016819787c8ff988fa5aa413b0be4782a015e97e80624f792c5:0",
-            "last_update": 1710796145,
-            "capacity": "200000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710754021,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "485",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710796145,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "910854124337037313",
-            "chan_point": "dc953288c0149c04210c2c44ae041873603f284401935248e254ccfa631e9e28:1",
-            "last_update": 1710849598,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "146",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710849598,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "198",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710797945,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "02ec23ef38b0af053817b793fc97d82acba48ec64895eb3f1cf2b1357123d35e15"
-        },
-        {
-            "channel_id": "916441842357436417",
-            "chan_point": "a09779347513780dde403004280979ae70ef944c9cdcd918dc13178c644bb2d3:1",
-            "last_update": 1710797946,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "1",
-                "last_update": 1710646566,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "632",
-                "disabled": false,
-                "max_htlc_msat": "225000000",
-                "last_update": 1710797946,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "911285132912361473",
-            "chan_point": "49a365941510a39499b55c809dfa92f368c06199e80ad50ae9a6bf9f48fef39e:1",
-            "last_update": 1710843838,
-            "capacity": "250000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "805",
-                "disabled": false,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710837265,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "539",
-                "disabled": true,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710843838,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "channel_id": "906432987942092800",
-            "chan_point": "4543ab7a72787917a8ce31a58f944d480ac5fb463dedcd568fbef4354c065eb5:0",
-            "last_update": 1710804925,
-            "capacity": "200000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "170",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710804925,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "207",
-                "disabled": false,
-                "max_htlc_msat": "198000000",
-                "last_update": 1710796145,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660"
-        },
-        {
-            "channel_id": "913194984464711681",
-            "chan_point": "c52f0dc6d23ec0e4377fa7ca993ee74d4901c44d42f7ff69d44ffb2f5488f0ea:1",
-            "last_update": 1710834571,
-            "capacity": "250000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "30",
-                "disabled": false,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710834571,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "205",
-                "disabled": false,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710797945,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d13d9fa06a4bd2cc22d47ee8f141aa11a54123bbd3f48a8e91095317289ed4aa",
-            "node2_pub": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972"
-        },
-        {
-            "channel_id": "880451528201666561",
-            "chan_point": "0a45e434bc7d88d948fb0d64ef064acb0e35236e48a590cfc700e9a8def0ca49:1",
-            "last_update": 1710856524,
-            "capacity": "400000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "396000000",
-                "last_update": 1710856524,
+                "last_update": 1710771876,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -14916,1855 +4089,28 @@
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "396000000",
-                "last_update": 1710856382,
+                "disabled": false,
+                "max_htlc_msat": "99000000",
+                "last_update": 1710772374,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "03fc8b5c254d4764d145b98a7a823791ed1f37c9d965d8068468f9711c44a76cf5",
-            "node2_pub": "02a1431534bfe333be9ff587f8f197b1b3d9ec05b58eb42e2a08f590fea6cc8866"
+            "node1_pub": "02e45ec6486ad8d2b2dcfe3e994f89035f7f1975e800bfe56f030d910647601199",
+            "node2_pub": "0209a06852f1257d70e5cea44a0919871fa20859eb33a62445f774e9fe96247a75"
         },
         {
-            "channel_id": "888968345274482693",
-            "chan_point": "51adf2c512a27e594430f4ab1db2e2bf51812adeeab7c030684aee4793136ac4:5",
+            "channel_id": "888979340321554436",
+            "chan_point": "0055cf02d8bbc7125784e8fee50605969c6cfe76fa24cea14e9ae66a6be4a7c8:4",
             "last_update": 1710793392,
             "capacity": "2000000",
             "node1_policy": {
                 "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
+                "fee_base_msat": "100",
                 "fee_rate_milli_msat": "10",
                 "disabled": false,
                 "max_htlc_msat": "1980000000",
-                "last_update": 1710793392,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710790926,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03fc8b5c254d4764d145b98a7a823791ed1f37c9d965d8068468f9711c44a76cf5",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "877750028176457729",
-            "chan_point": "9446e7e37d75d6cd606eb121fe4a7624a324730d7d5a1da694fcb6123d3cb188:1",
-            "last_update": 1710780869,
-            "capacity": "400000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "180000000",
-                "last_update": 1710780869,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "180000000",
-                "last_update": 1710756726,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03fc8b5c254d4764d145b98a7a823791ed1f37c9d965d8068468f9711c44a76cf5",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "880183247333294080",
-            "chan_point": "69cbac45e219262f63603880900208737ae80425a6d7de05b7dc3ec7743ba1a6:0",
-            "last_update": 1710810726,
-            "capacity": "250000",
-            "node1_policy": {
-                "time_lock_delta": 420,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710801988,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710810726,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03fc8b5c254d4764d145b98a7a823791ed1f37c9d965d8068468f9711c44a76cf5",
-            "node2_pub": "03b14edc2c0645a69d641080ff968a8c75fa1247334da8b6fdc9c3e90ca6f99052"
-        },
-        {
-            "channel_id": "821790383892725761",
-            "chan_point": "bf2794441ea3ac3c1cd62111ffa9b60eba56f7a9896453274b9c0d8330ef6895:1",
-            "last_update": 1710809441,
-            "capacity": "14000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "793",
-                "disabled": false,
-                "max_htlc_msat": "13860000000",
-                "last_update": 1710809441,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "13860000000",
-                "last_update": 1710792785,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "711049771679481856",
-            "chan_point": "59b74f2b919a912ba4ceea9421314a228147ae335806f679ca5051d85c9e2e78:0",
-            "last_update": 1710852747,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710835021,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710852747,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "788136531910983680",
-            "chan_point": "d156c40f8cefe188d87b78c2f0595f842e6209f8ce2b7b805306695d4fc0c115:0",
-            "last_update": 1710719547,
-            "capacity": "1730928",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "90",
-                "fee_rate_milli_msat": "90",
-                "disabled": false,
-                "max_htlc_msat": "1713619000",
-                "last_update": 1710711286,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1730928000",
-                "last_update": 1710719547,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "02c61e171140fc1aac5d3e0bcfefdc79ea954306dfa29265f02def849dc7e80419"
-        },
-        {
-            "channel_id": "817315371568988161",
-            "chan_point": "a9085ebd5e5a6a0bd3db46952a32caf541005732693111338125dfb4a6ef0592:1",
-            "last_update": 1710775347,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1708849333,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710775347,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "894031596313837569",
-            "chan_point": "35e12069808a2b201d54a33cc061ab599b8a97230971b6194687724a77bda1f1:1",
-            "last_update": 1710850947,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "146",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710846509,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710850947,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "837986190156496897",
-            "chan_point": "b523b1811fe0415da24c17ecfdcb724799d1f1247d0bee53db8ac355acfed4b1:1",
-            "last_update": 1710855276,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "599",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710855276,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "100000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710795147,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "818185085219766272",
-            "chan_point": "608894459b864bf320cf7c5099421f39fe536676fb0bc59201c8796896b19c29:0",
-            "last_update": 1710805947,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "16599443000",
-                "last_update": 1710407374,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16777215000",
-                "last_update": 1710805947,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "798729227012931584",
-            "chan_point": "22ab5002ec392c550ef0eb375fd8b63afabfc308879a4dac20a11e12675aa12a:0",
-            "last_update": 1710757347,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710170124,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710757347,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "836263255486300160",
-            "chan_point": "f193b03f6dce2ae6eb9f15ff80a3b9ea57b1eeff0d6002d408b070daa729ee38:0",
-            "last_update": 1710778947,
-            "capacity": "516136",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "510975000",
-                "last_update": 1710775429,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "510975000",
-                "last_update": 1710778947,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "03aa776656f3d083baf8bc2c88f1555e62847adb52a2498a60d0d6a08d566fc256"
-        },
-        {
-            "channel_id": "761097342026842113",
-            "chan_point": "d19c30652582d4f3700597340d6f913aeb72b8a9b3d0f34b8d3f5d28abfa631a:1",
-            "last_update": 1710837730,
-            "capacity": "3000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710837730,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "200",
-                "disabled": true,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710837722,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8"
-        },
-        {
-            "channel_id": "885503784086405122",
-            "chan_point": "942bae8170653d75c4dce866e25dd4f852bbb08ab0a87b0e322522332cf65ddf:2",
-            "last_update": 1710843747,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710843747,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "540",
-                "disabled": false,
-                "max_htlc_msat": "100000000",
-                "last_update": 1710818532,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "890653896537735169",
-            "chan_point": "485c67b3dd338114df1a6840f49c970bbd31f89245dd4c75310528acecffa50f:1",
-            "last_update": 1710799709,
-            "capacity": "8000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710787947,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "294",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710799709,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03afa7a8196dbca763ee6f9a34b634a7adc03f154e5d6979fe654db5606b5fb2b1",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "818028954598637569",
-            "chan_point": "2a061e74866099c3cf11d6aeaaa15be668a1fa8342b5607ba998392b04dd21f7:1",
-            "last_update": 1710842997,
-            "capacity": "11000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "10890000000",
-                "last_update": 1710772145,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "10890000000",
-                "last_update": 1710842997,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d9231f97a1dccd822ffc58226e9c7f2bec9dac00df4c0ff6c73b3d3f6c6ef6ea",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "818014660890198016",
-            "chan_point": "b3c6c3caca473939dbf2cf19d4ff1453c597ad0dc448c6a67c87ac47e9270e1d:0",
-            "last_update": 1710772147,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710772147,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710755376,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d9231f97a1dccd822ffc58226e9c7f2bec9dac00df4c0ff6c73b3d3f6c6ef6ea",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "887844644486447104",
-            "chan_point": "be9d438365cc0d134b1a35cca4d5fb073f16f6d35613cf751c40117581a0a376:0",
-            "last_update": 1710668359,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710668359,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710668359,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d9231f97a1dccd822ffc58226e9c7f2bec9dac00df4c0ff6c73b3d3f6c6ef6ea",
-            "node2_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf"
-        },
-        {
-            "channel_id": "907478623572656128",
-            "chan_point": "31ecc3e23c25f1983619873b83c8b009460e870a38d2c4eef4301729cc43a067:0",
-            "last_update": 1710792806,
-            "capacity": "35026599",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "1993",
-                "disabled": false,
-                "max_htlc_msat": "34676334000",
-                "last_update": 1710789444,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "5000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "34676334000",
-                "last_update": 1710792806,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "829098837694611457",
-            "chan_point": "4cdc504dba8dc4c2d0a17483715fcdb89547770c58392a691fb27144e7686d4a:1",
-            "last_update": 1710796348,
-            "capacity": "25000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "3000",
-                "disabled": false,
-                "max_htlc_msat": "24750000000",
-                "last_update": 1710796348,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "24750000000",
-                "last_update": 1710779138,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "915451182336770048",
-            "chan_point": "697ec252d84605f59e1987b13b0929de7ebfbf230d4d75d078a3c9a2edce238f:0",
-            "last_update": 1710806138,
-            "capacity": "25000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "24750000000",
-                "last_update": 1710789935,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "24750000000",
-                "last_update": 1710806138,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "852861482914086913",
-            "chan_point": "d42da8820c10beea7c6bc1ea3bf3f9ac42223e6727ba29c64dcf81df87b82a62:1",
-            "last_update": 1710825938,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710790807,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710825938,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a"
-        },
-        {
-            "channel_id": "917453393102307329",
-            "chan_point": "1875636e2df37679ba723222127c135a8af74d2fbb1d8cb038350603a359ea02:1",
-            "last_update": 1710824138,
-            "capacity": "16770000",
-            "node1_policy": {
-                "time_lock_delta": 72,
-                "min_htlc": "1",
-                "fee_base_msat": "2147483647",
-                "fee_rate_milli_msat": "2147483647",
-                "disabled": false,
-                "max_htlc_msat": "15093000000",
-                "last_update": 1710804837,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1677000000",
-                "last_update": 1710824138,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "02a6674aecc34ab056ae493c67e26c623c5ee02f3b9f69d1b40797ec3f226ec147"
-        },
-        {
-            "channel_id": "845966445535559680",
-            "chan_point": "ad83002e6a8933eebde18b1d129f1fb0cba9c9bd873135c28eda2cf93f525421:0",
-            "last_update": 1710635138,
-            "capacity": "40000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "40000000000",
-                "last_update": 1710635138,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "39590000000",
-                "last_update": 1710407375,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "878331669738618881",
-            "chan_point": "409328e536ab034bed408892c14f1c8c33c5a61864a11b218b0320cfcdfbc2b2:1",
-            "last_update": 1710838854,
-            "capacity": "200000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "198000000000",
-                "last_update": 1710838538,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "198000000000",
-                "last_update": 1710838854,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "914191142131531777",
-            "chan_point": "8c07ef56e91346a13e436f6889b7642b5ce6dcc3bdcccfe34b997efe0ee8b42e:1",
-            "last_update": 1710826409,
-            "capacity": "200000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "750",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710783157,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "999",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710826409,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "918207657982099457",
-            "chan_point": "24673c4c36261496ca8a455f172e46221d2bb2645bc9a9ff70281da68645d76d:1",
-            "last_update": 1710790036,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "750",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710789938,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710790036,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "918318708659912711",
-            "chan_point": "e50c68559d6cb3e11523f44c9b7643ee9cc736232d825f8786935ee2083c3a42:7",
-            "last_update": 1710848089,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710843938,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1900",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710848089,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "913871184242343937",
-            "chan_point": "f32e32a8e0ca48cb78e854ee8e83e8a1f892b2c7cc2b1a324dee855f0a732f1e:1",
-            "last_update": 1710792804,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "693",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710785844,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710792804,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "809914558767300609",
-            "chan_point": "d341010ca51ea59eba783e365e6271377d4c496ef7b96dadc7afd262ff393db2:1",
-            "last_update": 1710836855,
-            "capacity": "6500000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "6800",
-                "disabled": false,
-                "max_htlc_msat": "6435000000",
-                "last_update": 1709464504,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "6500000000",
-                "last_update": 1710836855,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "886759426467037221",
-            "chan_point": "5bc09590890f03e5e0a338c2352a2e3f87f30790814d056779b4881bea2cf68e:37",
-            "last_update": 1710793390,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710793390,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710790055,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "891331195755954177",
-            "chan_point": "7708b44825c00c4378e4376d46e4902595245aea2f993c5fb3b9e159f8fb51e7:1",
-            "last_update": 1710850933,
-            "capacity": "8000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710850933,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "450",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710847655,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ceeaec6cb017d1ea8ad04a5dfb3facb24a28399d24624ecce8f319973de361d9",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "913682068132331521",
-            "chan_point": "41d4a78da3fb713349fa6aa6ebec3c46ee7560988c9ddb5ea7d44a7d7ea97ae3:1",
-            "last_update": 1710811143,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "21",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "148500000",
-                "last_update": 1710795207,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10",
-                "fee_rate_milli_msat": "6",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710811143,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032cd1bac674b61e993c9c0afe8efe23e3b1eb30246719010f2cf0f1452ee21e2b",
-            "node2_pub": "02063fec62479bdf7d43f046056303e48f5029108111ade42aef41c622a6245d52"
-        },
-        {
-            "channel_id": "917869008391700481",
-            "chan_point": "e5b986d2dced1c3512b6a955b8c56a6d9a0ce84d8042baf8f7274b7483228d71:1",
-            "last_update": 1710834967,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "10",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "900000000",
-                "last_update": 1710834967,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710680573,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032cd1bac674b61e993c9c0afe8efe23e3b1eb30246719010f2cf0f1452ee21e2b",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "915143319166648321",
-            "chan_point": "3eae6c506a35b76f94780e7e705f9ea7f5338d414abe7cef45e3a54c22a95051:1",
-            "last_update": 1710827181,
-            "capacity": "1050000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "21",
-                "fee_rate_milli_msat": "43",
-                "disabled": false,
-                "max_htlc_msat": "1039500000",
-                "last_update": 1710795209,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "999",
-                "fee_rate_milli_msat": "199",
-                "disabled": false,
-                "max_htlc_msat": "1039500000",
-                "last_update": 1710827181,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0289411927ecaf49467c44093990b6f446a5d9b396fb6663b070c3f97e1b9359a6",
-            "node2_pub": "02063fec62479bdf7d43f046056303e48f5029108111ade42aef41c622a6245d52"
-        },
-        {
-            "channel_id": "766115513050660865",
-            "chan_point": "f24dae3678758902c178fc137d96d9556c8cce83b1671efd022e8de888978a8d:1",
-            "last_update": 1710842394,
-            "capacity": "1501000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "999",
-                "fee_rate_milli_msat": "199",
-                "disabled": false,
-                "max_htlc_msat": "1485990000",
-                "last_update": 1710605781,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "1485990000",
-                "last_update": 1710842394,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0289411927ecaf49467c44093990b6f446a5d9b396fb6663b070c3f97e1b9359a6",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "829806923117428737",
-            "chan_point": "2e7fa25c911daf1b0924215f77fe416aab275bcb140870a685990c2b2fa9616f:1",
-            "last_update": 1709731151,
-            "capacity": "3020000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "999",
-                "fee_rate_milli_msat": "199",
-                "disabled": false,
-                "max_htlc_msat": "3020000000",
-                "last_update": 1709632103,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "2989800000",
-                "last_update": 1709731151,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0289411927ecaf49467c44093990b6f446a5d9b396fb6663b070c3f97e1b9359a6",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "783929800410464259",
-            "chan_point": "4a975ba785e3c97d7416ad5971b1d40c7f819d8f749542494f1b52f93c0b6569:3",
-            "last_update": 1710776099,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710775535,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "24",
-                "disabled": false,
-                "max_htlc_msat": "2425500000",
-                "last_update": 1710776099,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d6f80df785288de2fe5de19f24ba8a1db3d20647a88d0a903be9de3e7bb8fce1",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "891989803281547265",
-            "chan_point": "0db781587b9650fc9e8648c93e3ad6e3d976f5ffc668ef60757c9a304ce977fd:1",
-            "last_update": 1710846512,
-            "capacity": "6000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "68",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710846512,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "129",
-                "disabled": false,
-                "max_htlc_msat": "2910600000",
-                "last_update": 1710756227,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d6f80df785288de2fe5de19f24ba8a1db3d20647a88d0a903be9de3e7bb8fce1",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "831361632605372418",
-            "chan_point": "e19542b6d7fc4c04bbc5128dd24529248247794d2f3ff4588399231f7e36d27f:2",
-            "last_update": 1710851454,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710851454,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "549",
-                "disabled": false,
-                "max_htlc_msat": "9702000000",
-                "last_update": 1710776099,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d6f80df785288de2fe5de19f24ba8a1db3d20647a88d0a903be9de3e7bb8fce1",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "828487509119860737",
-            "chan_point": "5fbc1f8863f5165e4479ca2056cd02c80cb7bf522cbc1dc676bcbbaa533d3b0e:1",
-            "last_update": 1710776099,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "4940000000",
-                "last_update": 1709802575,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "2425500000",
-                "last_update": 1710776099,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d6f80df785288de2fe5de19f24ba8a1db3d20647a88d0a903be9de3e7bb8fce1",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "780864362081746944",
-            "chan_point": "14273c7e6adc7308de60ff6698f440e1ff1c265140533fc3e087f6e2c031cdf0:0",
-            "last_update": 1710723429,
-            "capacity": "4130900",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "4089591000",
-                "last_update": 1667405919,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": true,
-                "max_htlc_msat": "4130900000",
-                "last_update": 1710723429,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02398b614028892474fc95ed64c48791f994975042d0bd7e9592d0ec4128bbace4",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "799054682375913472",
-            "chan_point": "3a85aad5ee2b6461922e7f9d5b621215a4bf1bcbd19f85fd3c2ab34dd4a2c145:0",
-            "last_update": 1710822335,
-            "capacity": "2593783",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "2567846000",
-                "last_update": 1668106106,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": true,
-                "max_htlc_msat": "2593783000",
-                "last_update": 1710822335,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02398b614028892474fc95ed64c48791f994975042d0bd7e9592d0ec4128bbace4",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "872458078657249281",
-            "chan_point": "42580092549395572b9d3b2fcb62588e954f5f5a9311c623c364d6d57e5321c7:1",
-            "last_update": 1710777654,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "2000",
-                "fee_rate_milli_msat": "401",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710752034,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710777654,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02464181ef50b59a26cde9aa37bd32ced1cb1923b4811165fb1e619b7507639083",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "880142565486821376",
-            "chan_point": "989e373af8f16e0ab44e2edf5e982737bff1970649f8ba8b67defb3804ffa0ca:0",
-            "last_update": 1710856584,
-            "capacity": "100000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "99000000",
-                "last_update": 1710856546,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "2000",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "99000000",
-                "last_update": 1710856584,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02464181ef50b59a26cde9aa37bd32ced1cb1923b4811165fb1e619b7507639083",
-            "node2_pub": "02a1431534bfe333be9ff587f8f197b1b3d9ec05b58eb42e2a08f590fea6cc8866"
-        },
-        {
-            "channel_id": "898715515783217153",
-            "chan_point": "7f08c1fedcdb73c4e732a0c1755c4a34d36883c23f57661f7956ba50da8e9100:1",
-            "last_update": 1710822234,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "10000",
-                "fee_rate_milli_msat": "102",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710822234,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710778348,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02464181ef50b59a26cde9aa37bd32ced1cb1923b4811165fb1e619b7507639083",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "854676776705392641",
-            "chan_point": "06e528c3aa685480e724342fe99a4c7950d0dd1950f80c99853b817344690cfb:1",
-            "last_update": 1710792785,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "3493",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710780444,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710792785,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "793725349583781889",
-            "chan_point": "14419f88d1b6c06e913b17334e9109e3e2f07e871d5d5c8dc638c116b3c16149:1",
-            "last_update": 1710853807,
-            "capacity": "30000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "29700000000",
-                "last_update": 1710836821,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "29700000000",
-                "last_update": 1710853807,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "903912907290509313",
-            "chan_point": "93265732f55845259f928e32d55a2dc344a71362fab9b3e9bfab63ee574a2319:1",
-            "last_update": 1710817959,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "3000",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710817959,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710776407,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "916707924072923137",
-            "chan_point": "86e7129aca2561994f3326cd70afb4ee44a9e8f235da68a80b6bc9cc84719140:1",
-            "last_update": 1710856541,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710794833,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710856541,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "026e10b080dc2ffba3966daeab5803a2d263788cef0750bff3001bda037e358d98"
-        },
-        {
-            "channel_id": "747631623111573505",
-            "chan_point": "d7b7158e53bd8f2ef22c487f5b79438dcf1e016b3fb85e27bac6268057577daa:1",
-            "last_update": 1710783607,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710783607,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710779229,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "781730777281789953",
-            "chan_point": "03ff40e8cc580ddd2c8e0f2bc2ac27583c8da9e1bf4adb7a7f3cfbfdd980e96d:1",
-            "last_update": 1710837761,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": true,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710837761,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710837722,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8"
-        },
-        {
-            "channel_id": "831463887242854401",
-            "chan_point": "d2ef8805303f9d342a745d4265b59ae9d03a179c44c7f72ecccc9d9f073b6a7b:1",
-            "last_update": 1710839407,
-            "capacity": "287994864",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "285114916000",
-                "last_update": 1710839407,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "285114916000",
-                "last_update": 1710786594,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "837719008782712833",
-            "chan_point": "78de4403197e8fee1c321cf443db66baa2a837fe056532f9f911c3251ceff574:1",
-            "last_update": 1710779071,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710776407,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "660",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710779071,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "03f20b295a728be64537bd7df1bf9092ed4bbf09b2c10f68c482d6fcb4f2232b28"
-        },
-        {
-            "channel_id": "849827930352517126",
-            "chan_point": "6dbdd06bc5b667d95341d1617d96b1f8b8c3560a71b3f36056e0e598fbb1ad02:6",
-            "last_update": 1710837607,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "16777215000",
-                "last_update": 1710837607,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "330000",
-                "fee_rate_milli_msat": "6800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710270791,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "917940476634267648",
-            "chan_point": "cb70204d26e24a808a297e28627fa6ba7b27a2b3f6acdc76d4d04e15593f0eea:0",
-            "last_update": 1710817807,
-            "capacity": "240000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710817807,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "999",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710557373,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "865090251294572545",
-            "chan_point": "3332b258dc310c4a58d5acbfcc6df50b1b42faf4e52757d9e1171b6a3e74e83e:1",
-            "last_update": 1710795032,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710794407,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1748",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710795032,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "884911147414388737",
-            "chan_point": "7e3c7d7d89989d4a9b5b9e0300431c91552d8141659f1cc6f980862bc3123196:1",
-            "last_update": 1710789007,
-            "capacity": "25000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "25000000000",
-                "last_update": 1710789007,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "24750000000",
-                "last_update": 1709837151,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018"
-        },
-        {
-            "channel_id": "891486227051118596",
-            "chan_point": "49e729aaddb933b263dc58e65f39ce9353f74cba67993056bf734b5a4cc99970:4",
-            "last_update": 1710843007,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710843007,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1820",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710817832,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd"
-        },
-        {
-            "channel_id": "910848626758057985",
-            "chan_point": "0def05ce13756e9cb7e148766c14db9125b7c2d29552dfc6bf2c53893d185a85:1",
-            "last_update": 1710846864,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710841207,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "1000000000",
-                "last_update": 1710846864,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0294ac3e099def03c12a37e30fe5364b1223fd60069869142ef96580c8439c2e0a",
-            "node2_pub": "02dcfd154ed7e84f19f73be69b6471e028c45db1a8f3d9bade7e0f2159ea12d492"
-        },
-        {
-            "channel_id": "867857722077216768",
-            "chan_point": "3ec26e56b0372502b1bea330ed4641c7ded3dc0775cffa12e9c9c198970ab55a:0",
-            "last_update": 1710756863,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "10",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "500000000",
-                "last_update": 1710756863,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710408068,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02dcfd154ed7e84f19f73be69b6471e028c45db1a8f3d9bade7e0f2159ea12d492",
-            "node2_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf"
-        },
-        {
-            "channel_id": "867889607965868033",
-            "chan_point": "4ed623b06cf489f9c5d56986f3b5804d8e35bd564cd12f889c47aa5fd92967fb:1",
-            "last_update": 1710846863,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "2000",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "900000000",
-                "last_update": 1710846863,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "400000000",
-                "last_update": 1710779432,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02dcfd154ed7e84f19f73be69b6471e028c45db1a8f3d9bade7e0f2159ea12d492",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "878343764437172224",
-            "chan_point": "14a981a4445fabc053771ce4b12c0cefe98b50de57e22729256a856263d7e021:0",
-            "last_update": 1710846863,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "10",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "1000000000",
-                "last_update": 1710846863,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710840654,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02dcfd154ed7e84f19f73be69b6471e028c45db1a8f3d9bade7e0f2159ea12d492",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "887757782897721347",
-            "chan_point": "8ae029111d3e44a0ef02a19caa5ba36b41fa78f30e1eb76293822180760611f6:3",
-            "last_update": 1710793392,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "500000000",
-                "last_update": 1710791064,
+                "last_update": 1710790557,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -16778,2531 +4124,8 @@
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "02dcfd154ed7e84f19f73be69b6471e028c45db1a8f3d9bade7e0f2159ea12d492",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "911120206074150913",
-            "chan_point": "6dd484cdf2a4c86e7da5e2e784c54a510064dd0c353e9bd0165485b006ffa077:1",
-            "last_update": 1710841832,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "500000000",
-                "last_update": 1710794663,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710841832,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02dcfd154ed7e84f19f73be69b6471e028c45db1a8f3d9bade7e0f2159ea12d492",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "854406296714674177",
-            "chan_point": "10fa10686b8bedb911e9196c3f936f0b5f2c1eee27cf89cd48621b51e10f73f7:1",
-            "last_update": 1710795209,
-            "capacity": "2500000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "21",
-                "fee_rate_milli_msat": "112",
-                "disabled": false,
-                "max_htlc_msat": "185625000",
-                "last_update": 1710795209,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "2475000000",
-                "last_update": 1710784078,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02063fec62479bdf7d43f046056303e48f5029108111ade42aef41c622a6245d52",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "876736278491561985",
-            "chan_point": "d8e55e19e98e230997e2352dfdc14bc266eb8e7df5c1d40526344c9c92671970:1",
-            "last_update": 1710855465,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710855465,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "5000",
-                "fee_rate_milli_msat": "90",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710772695,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "035fed4182fbd0725264f8a0018cabb6b25514dd231291162ac8dd63afb278e9e8",
-            "node2_pub": "0210ef7d43c105753673563feb1e20fe344b844ab65aa710cb2288a257ec024c99"
-        },
-        {
-            "channel_id": "862864839739768833",
-            "chan_point": "d7352c3603c86cd687dac0cd64fd60e9ac86b9d5d636a29cedc90a9d4b750ad5:1",
-            "last_update": 1710856850,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "721",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710856850,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "5000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710796094,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "035fed4182fbd0725264f8a0018cabb6b25514dd231291162ac8dd63afb278e9e8",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "792137654775119873",
-            "chan_point": "1a500b8a06cf493e82810f322d74648140ea4b695b7d8ad59ee017539d4e5fd1:1",
-            "last_update": 1710837494,
-            "capacity": "8000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710837054,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "5000",
-                "fee_rate_milli_msat": "150",
-                "disabled": false,
-                "max_htlc_msat": "7920000000",
-                "last_update": 1710837494,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "035fed4182fbd0725264f8a0018cabb6b25514dd231291162ac8dd63afb278e9e8",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "791326215171801089",
-            "chan_point": "90742bc6284af8e8ab5c092223882c1fd642dc502dd5f46d232f0de8b0027126:1",
-            "last_update": 1710855494,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "5000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710855494,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1708217359,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "035fed4182fbd0725264f8a0018cabb6b25514dd231291162ac8dd63afb278e9e8",
-            "node2_pub": "03e8b9a977fa3ae7acce74c25986c7240a921222e349729737df832a1b5ceb49df"
-        },
-        {
-            "channel_id": "886619788490833923",
-            "chan_point": "fe88ddff03886631613cfb2bf0f80849f8074bb2f4269c05de8abcc110741e65:3",
-            "last_update": 1710791589,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "5000",
-                "fee_rate_milli_msat": "225",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710790694,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710791589,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "035fed4182fbd0725264f8a0018cabb6b25514dd231291162ac8dd63afb278e9e8",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "875780802788851713",
-            "chan_point": "c905b203a557d41d1470da8fdd22c944edd5b971d65e1fe44591098c26e96c09:1",
-            "last_update": 1710811061,
-            "capacity": "1449122",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "9000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "1400000000",
-                "last_update": 1710811061,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "100000",
-                "disabled": false,
-                "max_htlc_msat": "1434631000",
-                "last_update": 1710779805,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03aa776656f3d083baf8bc2c88f1555e62847adb52a2498a60d0d6a08d566fc256",
-            "node2_pub": "02b61154d89b98662f4c58e1005963e918da6a8fdb5adbea85ad22a20b8e7fc0ad"
-        },
-        {
-            "channel_id": "836161000881717249",
-            "chan_point": "cea89443c0b7fb2edff1c42636e1138fd3f397de820346a7b662b3f8fdcb8cc9:1",
-            "last_update": 1710788029,
-            "capacity": "139488",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "250",
-                "disabled": false,
-                "max_htlc_msat": "138094000",
-                "last_update": 1710615283,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "139488000",
-                "last_update": 1710788029,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03aa776656f3d083baf8bc2c88f1555e62847adb52a2498a60d0d6a08d566fc256",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "801858437115543553",
-            "chan_point": "6df772d9802bd88777da94e8925da8f82732a73d0a4b7f8b9b6f5d53e84e4d3d:1",
-            "last_update": 1710838854,
-            "capacity": "1980100",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1960299000",
-                "last_update": 1710838854,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1960299000",
-                "last_update": 1710838429,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03aa776656f3d083baf8bc2c88f1555e62847adb52a2498a60d0d6a08d566fc256",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "835850938628308993",
-            "chan_point": "35aba867a8252bfc4759b2ef59074b068e0ebdb3c5e717a978bc1eb82d1c0284:1",
-            "last_update": 1710797506,
-            "capacity": "1463273",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710797506,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1463273000",
-                "last_update": 1710584629,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03aa776656f3d083baf8bc2c88f1555e62847adb52a2498a60d0d6a08d566fc256",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "789616474622590976",
-            "chan_point": "06f7db2f888a6a306812dde1d8d9de100fec0460765b3b805be295a69e538b0e:0",
-            "last_update": 1710797896,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "666",
-                "fee_rate_milli_msat": "71",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710797896,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710776875,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03a0fbf509a4c1f14647934988c7b484da8ab6090e81d015c6746ecd1134a37207",
-            "node2_pub": "0216fcf031519e0924e5e4b64a731b207cccb85b13caebffd0f664a32a39bcd368"
-        },
-        {
-            "channel_id": "888965046692806657",
-            "chan_point": "5af133ca55338c251f2f1f0633ca9d88a91513c7f30fff7018f14d2b40561157:1",
-            "last_update": 1710804189,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710804189,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710789475,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03a0fbf509a4c1f14647934988c7b484da8ab6090e81d015c6746ecd1134a37207",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "855466226006294529",
-            "chan_point": "0422e64d504b47aa739210589fdd807b662d49f1842a01f7740fe2c8cf8c3d0d:1",
-            "last_update": 1710797865,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710797865,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710164610,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0210ef7d43c105753673563feb1e20fe344b844ab65aa710cb2288a257ec024c99",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "891338892317229056",
-            "chan_point": "f47a9a4fc0f928832b7a1f8c68474a34a101d60d31e346d1e31e5eca3350ae39:0",
-            "last_update": 1710824865,
-            "capacity": "3000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": true,
-                "max_htlc_msat": "1500000000",
-                "last_update": 1710824865,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1708655260,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0210ef7d43c105753673563feb1e20fe344b844ab65aa710cb2288a257ec024c99",
-            "node2_pub": "03d64e760b4af3698e51eb7ed7d97fbbae41f8cd28c0bcb6851c21207922f6697d"
-        },
-        {
-            "channel_id": "765244699794800640",
-            "chan_point": "07587cefe0e70c0abe00bb2d953ebfd7f0867384389bd89f20ebf4eeee6226ba:0",
-            "last_update": 1710851454,
-            "capacity": "999000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "38",
-                "disabled": false,
-                "max_htlc_msat": "989010000",
-                "last_update": 1710681795,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "989010000",
-                "last_update": 1710851454,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026d1de80e59f3fe2b27aa3dc8012f4437165bf99971bd9b7d8afedb066f92d695",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "889552185993134083",
-            "chan_point": "ee3f1b4e3932bf09baef85846b8310adb60f9594a2d03a940a2d4b290f242516:3",
-            "last_update": 1710806982,
-            "capacity": "2177000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "59",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "2155230000",
-                "last_update": 1710806982,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "194",
-                "disabled": false,
-                "max_htlc_msat": "2155230000",
-                "last_update": 1710806982,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026d1de80e59f3fe2b27aa3dc8012f4437165bf99971bd9b7d8afedb066f92d695",
-            "node2_pub": "02ec23ef38b0af053817b793fc97d82acba48ec64895eb3f1cf2b1357123d35e15"
-        },
-        {
-            "channel_id": "900871658300571650",
-            "chan_point": "1bc46515753b7bc954c29857f9e2f8e378f9f2d7339f82f2678b451fabcc0422:2",
-            "last_update": 1710853596,
-            "capacity": "250000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710779403,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "50000000",
-                "last_update": 1710853596,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "channel_id": "878807758419656707",
-            "chan_point": "d172f4971d0eb98aec4ae058f1f45dd6ec11478aad6638172db18dd5d1b419c1:3",
-            "last_update": 1710792910,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "143",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710780444,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710792910,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "845879584162381825",
-            "chan_point": "232bda28374e21bf5e4881c05282b3bd94f66768862addcc31273e730dd1fbd7:1",
-            "last_update": 1710838621,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710838621,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "660",
-                "disabled": false,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710789122,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "900554998942924802",
-            "chan_point": "4a00921c950f3ec9b0ecc8a99ec25691e0f483e44d6d60f3144eaa225857d675:2",
-            "last_update": 1710829484,
-            "capacity": "25000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "24750000000",
-                "last_update": 1710814359,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "24750000000",
-                "last_update": 1710829484,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "908540751781888001",
-            "chan_point": "e3c5cbcb3dc5ee436ad18bc95b626cc6345c7d6b62037cd5147eced22c160f79:1",
-            "last_update": 1710843935,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710843935,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "540",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710821198,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "913926159750135812",
-            "chan_point": "ed6c60db9c08edf50df8c7bbc20ecce66e5723a731c57d7c7ce6939b8d3622ac:4",
-            "last_update": 1710817935,
-            "capacity": "30000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "29700000000",
-                "last_update": 1709837124,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "420",
-                "disabled": false,
-                "max_htlc_msat": "29700000000",
-                "last_update": 1710817935,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018"
-        },
-        {
-            "channel_id": "904553922787540994",
-            "chan_point": "06feff37e11559918f633469bf5b1d576ce9dbf38bb1a2c0fe29aee35b948ba1:2",
-            "last_update": 1710818434,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "40",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710082063,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "120",
-                "disabled": false,
-                "max_htlc_msat": "2500000",
-                "last_update": 1710818434,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "877676360866725892",
-            "chan_point": "76532275ebe9fbc723b20b836274959634e239d8ec700d412d014af1f901352d:4",
-            "last_update": 1710833796,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710806233,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1750",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710833796,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "890970556045918228",
-            "chan_point": "af2f60d891fa565c55c001dadc5b5b646036deccf66672a7794d15537db2d9a5:20",
-            "last_update": 1710850980,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710788394,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1225",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710850980,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "907475325008412673",
-            "chan_point": "799d70a2f5967cfec80d152c8947d091f1fcac0e7b715716a0925a92e1cf55a5:1",
-            "last_update": 1710856646,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 118,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1997",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710856646,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "140",
-                "disabled": false,
-                "max_htlc_msat": "1600000000",
-                "last_update": 1710803526,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "900554998942924803",
-            "chan_point": "4a00921c950f3ec9b0ecc8a99ec25691e0f483e44d6d60f3144eaa225857d675:3",
-            "last_update": 1710838854,
-            "capacity": "30000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "29700000000",
-                "last_update": 1710838854,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "660",
-                "disabled": false,
-                "max_htlc_msat": "1600000000",
-                "last_update": 1710803526,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "890037070565081089",
-            "chan_point": "7d968a07e332f4c43ec0b0149b74cdd6b43399e218715b7d3b44b7d2c22e53ea:1",
-            "last_update": 1710795190,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710795190,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "590",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710774722,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "918318708659912708",
-            "chan_point": "e50c68559d6cb3e11523f44c9b7643ee9cc736232d825f8786935ee2083c3a42:4",
-            "last_update": 1710813645,
-            "capacity": "30000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "29700000000",
-                "last_update": 1710756317,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "990",
-                "disabled": true,
-                "max_htlc_msat": "29700000000",
-                "last_update": 1710813645,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "036b53093df5a932deac828cca6d663472dbc88322b05eec1d42b26ab9b16caa1c"
-        },
-        {
-            "channel_id": "887854539999805443",
-            "chan_point": "2fd18d50c53a050494a128a645e267c36d382c17348ae9145432d3708859879c:3",
-            "last_update": 1710669996,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1709819848,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1300",
-                "disabled": false,
-                "max_htlc_msat": "1600000000",
-                "last_update": 1710669996,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c157946cc1cd376b929e36006e645fae490b1b1d4156b40db804e01b4bda48cd",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "891000242742820864",
-            "chan_point": "1c52f1f289a1b4cfaef82d59a2026affbdbd4db3ac9ad3f4c31c135274b4d16c:0",
-            "last_update": 1710795190,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": true,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710795190,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1708178341,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03d64e760b4af3698e51eb7ed7d97fbbae41f8cd28c0bcb6851c21207922f6697d",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "909409365923528704",
-            "chan_point": "49c82cd31c182241da61477db0606bf68d7687a2a0289d4441a2de896e4bd4eb:0",
-            "last_update": 1710849598,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "134",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710849598,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "30",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710834571,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972",
-            "node2_pub": "02ec23ef38b0af053817b793fc97d82acba48ec64895eb3f1cf2b1357123d35e15"
-        },
-        {
-            "channel_id": "910855223803248641",
-            "chan_point": "c1adc171b8699af20665cb0c9032f907aed3bf5828e80503f91b185bdf974335:1",
-            "last_update": 1710839556,
-            "capacity": "250000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "20",
-                "disabled": true,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710839556,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "30",
-                "disabled": true,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710839543,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "channel_id": "909352191396347905",
-            "chan_point": "1716c34b425cf0c9f844217531860a7743dfbf04ec5e3d8e1a576aaeca90c2f4:1",
-            "last_update": 1710834571,
-            "capacity": "150000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "206",
-                "disabled": false,
-                "max_htlc_msat": "148500000",
-                "last_update": 1710804928,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "30",
-                "disabled": false,
-                "max_htlc_msat": "148500000",
-                "last_update": 1710834571,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972",
-            "node2_pub": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660"
-        },
-        {
-            "channel_id": "884888057714835456",
-            "chan_point": "286ba21b4077b860b2756bb24c292e3b089c299ceea8fa01357b192c4892fe79:0",
-            "last_update": 1710235974,
-            "capacity": "25000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "11250000000",
-                "last_update": 1709837175,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "0",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "11250000000",
-                "last_update": 1710235974,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "885290478974468096",
-            "chan_point": "87366b7d602edb5837a722830913e9baf2628389aa6e1f33871d8147fca44f2a:0",
-            "last_update": 1710719830,
-            "capacity": "12500000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "12375000000",
-                "last_update": 1709837125,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "12500000000",
-                "last_update": 1710719830,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "891147577331548169",
-            "chan_point": "88223c20dd386993a5371f9959365ce686a318bb1847bf85f557434918c155f9:9",
-            "last_update": 1710617394,
-            "capacity": "61184973",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "60573124000",
-                "last_update": 1709837149,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "61184973000",
-                "last_update": 1710617394,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "912608944734928897",
-            "chan_point": "100b9ad75688499c202b24b736e029102cb6ce6ff7aa3b987644ee5190123f40:1",
-            "last_update": 1710785255,
-            "capacity": "5879527",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "5820732000",
-                "last_update": 1709773395,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "5879527000",
-                "last_update": 1710785255,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018",
-            "node2_pub": "032f3380e907937c704bef15f051d0747b942976e994a2e615ad3f5b8fb0aa6660"
-        },
-        {
-            "channel_id": "914460522418733065",
-            "chan_point": "164a121989ce3a449fd6a1d9fb477cadc36aaba0a31ecae3fd308399dce819b1:9",
-            "last_update": 1710856334,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1709906712,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710856334,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "901177322433085440",
-            "chan_point": "aab2143a50246731538ef4ebabbd1c2b8ae1da45dfd6dea990f154ebce3add24:0",
-            "last_update": 1710766897,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "225000000",
-                "last_update": 1710332622,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "0",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "10000000",
-                "last_update": 1710766897,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02878765b772b842029f1808b768cc53ff6b88521c1fb3e4d409fda1f540f2122c",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "895913960251129857",
-            "chan_point": "9127c51dc74a4cf96e711f5d40ca74361985d4d978eee702d174752f93cc1117:1",
-            "last_update": 1710856932,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "200",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710856932,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "176",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710838968,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03e20ae8b749c3e5e8b96c66c98141177e7b75571b90cab80c9085af7c80bd3852",
-            "node2_pub": "03740f82191202480ace717fcdf00f71a8b1eb9bdc2bb5e2106cd0ab5cb4d7a54e"
-        },
-        {
-            "channel_id": "893071722631593985",
-            "chan_point": "707ee4ebf6663c4a400ec17733264a9f6679f326b4ff517d5cecf6aa24164999:1",
-            "last_update": 1710838959,
-            "capacity": "1300000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "585000000",
-                "last_update": 1710727292,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "585000000",
-                "last_update": 1710838959,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03e20ae8b749c3e5e8b96c66c98141177e7b75571b90cab80c9085af7c80bd3852",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "898202043960197120",
-            "chan_point": "6a3d905ff8b039fd885069272dadc2a5b4414b58dada7aa3cf05e234fc4fc637:0",
-            "last_update": 1710774756,
-            "capacity": "1500000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "180",
-                "disabled": true,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710774756,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "176",
-                "disabled": true,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710774753,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03e20ae8b749c3e5e8b96c66c98141177e7b75571b90cab80c9085af7c80bd3852",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "channel_id": "914823361272348673",
-            "chan_point": "d317bce0c6a80bcb4e92dda2687239bc249727132e67b410af33e6df0c51165a:1",
-            "last_update": 1710856527,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710856527,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710780433,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026e10b080dc2ffba3966daeab5803a2d263788cef0750bff3001bda037e358d98",
-            "node2_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2"
-        },
-        {
-            "channel_id": "917030081169195009",
-            "chan_point": "408b92eaed4c09a5948882c2cf44fde071e8ef0137881cf5503a801a916faaa5:1",
-            "last_update": 1710856591,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710836445,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "25",
-                "disabled": true,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710856591,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026e10b080dc2ffba3966daeab5803a2d263788cef0750bff3001bda037e358d98",
-            "node2_pub": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322"
-        },
-        {
-            "channel_id": "888583516138504198",
-            "chan_point": "1f839136ac8684a59229c746a93e0aede80469dfd573b30c733b4f469390fd77:6",
-            "last_update": 1710793392,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "2000000000",
-                "last_update": 1710793392,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710528749,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03e8b9a977fa3ae7acce74c25986c7240a921222e349729737df832a1b5ceb49df",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "777886884546412545",
-            "chan_point": "04f90fc9f219c0251ac50c77d58bcbc526620bd1bc99118dce9d73884ff88d52:1",
-            "last_update": 1710799709,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1707894553,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "10",
-                "fee_rate_milli_msat": "14",
-                "disabled": false,
-                "max_htlc_msat": "2000000000",
-                "last_update": 1710799709,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03e8b9a977fa3ae7acce74c25986c7240a921222e349729737df832a1b5ceb49df",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "914459422986010625",
-            "chan_point": "1ba3fa355efd4d1c6d2cd19e8fa7b3ceadc12e0d4eaef6be4f6468fc834e5275:1",
-            "last_update": 1710798148,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "666",
-                "fee_rate_milli_msat": "67",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710797896,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710798148,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "0216fcf031519e0924e5e4b64a731b207cccb85b13caebffd0f664a32a39bcd368"
-        },
-        {
-            "channel_id": "759118221011845122",
-            "chan_point": "9442f5f7b4ecf8fe2c771131c7a9e746068772b87fc7bce7a6639f88cc9ec57c:2",
-            "last_update": 1710805347,
-            "capacity": "880161",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "880161000",
-                "last_update": 1710805347,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1964",
-                "fee_rate_milli_msat": "893",
-                "disabled": false,
-                "max_htlc_msat": "871360000",
-                "last_update": 1710711286,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "02c61e171140fc1aac5d3e0bcfefdc79ea954306dfa29265f02def849dc7e80419"
-        },
-        {
-            "channel_id": "760782881632944129",
-            "chan_point": "d8db0b44f4b48b451e3b0bde8c6eb6a4af829d34fccf55ee99bd690dfdbb6b3f:1",
-            "last_update": 1710848547,
-            "capacity": "2160000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2138400000",
-                "last_update": 1710848547,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "200",
-                "disabled": false,
-                "max_htlc_msat": "2138400000",
-                "last_update": 1710675413,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8"
-        },
-        {
-            "channel_id": "763386525186457600",
-            "chan_point": "6ecc2f5d0b222765e74cf1c6f1e27b3d5a6d449f2a410fe527863c72b7223fa4:0",
-            "last_update": 1710820433,
-            "capacity": "750000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "742500000",
-                "last_update": 1710819747,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "99",
-                "disabled": false,
-                "max_htlc_msat": "742500000",
-                "last_update": 1710820433,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004"
-        },
-        {
-            "channel_id": "841252839125483520",
-            "chan_point": "a0e71b6d00fffa5e76ef4d978ac510552ad9cd3df629abcddc8b5cfef895b125:0",
-            "last_update": 1710814350,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16777215000",
-                "last_update": 1710814350,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "40",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710117924,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "874673594643185670",
-            "chan_point": "395bfd28de332b83abb59ba0e470672382f1497e163fd596c538128307011543:6",
-            "last_update": 1710814989,
-            "capacity": "15000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710794564,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710814989,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "885657715774717952",
-            "chan_point": "dd9f14f77009101158c61ccce534ca874111679293f0d805ba1638d7d8bedd7d:0",
-            "last_update": 1710794569,
-            "capacity": "6000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710794569,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710791273,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
-        },
-        {
-            "channel_id": "887404839749419009",
-            "chan_point": "1c9fb05e680deddf738565130304c8d14fe1e44a72b308dee3f49f67a06ef622:1",
-            "last_update": 1710850347,
-            "capacity": "2500000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2475000000",
-                "last_update": 1710850347,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2475000000",
-                "last_update": 1709825515,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf"
-        },
-        {
-            "channel_id": "890970556045918209",
-            "chan_point": "af2f60d891fa565c55c001dadc5b5b646036deccf66672a7794d15537db2d9a5:1",
-            "last_update": 1710794570,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2000",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710794570,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710777594,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "892812237888815105",
-            "chan_point": "e0f0351f69d4ee89fc6241ea30f9fa601d1f86cff9e0b7baa095a9c9acad1787:1",
-            "last_update": 1710814658,
-            "capacity": "3000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710814358,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710814658,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322"
-        },
-        {
-            "channel_id": "899728166177341440",
-            "chan_point": "bd1ee502c7f031ffa3c41310a8ecef5fdd48c3c908b51d2ec73e97fed4514b17:0",
-            "last_update": 1710780150,
-            "capacity": "1500000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710780150,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "7000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710777671,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "02679d067ec30e5bb4ad13e277d655e2f3779dda5979b615c8fdf1be0b096ae257"
-        },
-        {
-            "channel_id": "910688097982808065",
-            "chan_point": "bb516ed4c15ffb282f61bf2fdaae9e388c369b9e87bcc5031193a627480bfffb:1",
-            "last_update": 1710855749,
-            "capacity": "30000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "4000",
-                "disabled": false,
-                "max_htlc_msat": "13500000000",
-                "last_update": 1710855749,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "999",
-                "disabled": false,
-                "max_htlc_msat": "13500000000",
-                "last_update": 1710688399,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "914274704892428293",
-            "chan_point": "dce437c9fc9edc78f741023a4d7691e130bca3566f1287012f1548d59f0f0991:5",
-            "last_update": 1710855930,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710814364,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "1000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "480",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710855930,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "892812237888815106",
-            "chan_point": "e0f0351f69d4ee89fc6241ea30f9fa601d1f86cff9e0b7baa095a9c9acad1787:2",
-            "last_update": 1710830858,
-            "capacity": "3000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710830858,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "2970000000",
-                "last_update": 1710657896,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf",
-            "node2_pub": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322"
-        },
-        {
-            "channel_id": "753139076771020800",
-            "chan_point": "1fe6d658d4ce492f3c7b98f61e47a89731b1f6772576ab12755b21c587a98e43:0",
-            "last_update": 1710820629,
-            "capacity": "8041640",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "7961224000",
-                "last_update": 1710820629,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "7961224000",
-                "last_update": 1709264880,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "887725897158885379",
-            "chan_point": "ebdba1f9d2a671c43a5a7a2d15b0871bcb9d8c8dbd90f739f990c604220b5e5b:3",
-            "last_update": 1710705190,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710705190,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710529962,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "905855744471203840",
-            "chan_point": "956fcec70445f16bf4d00bac78f24f3c27a45fbd900902657c916db0b2b765b5:0",
-            "last_update": 1710822636,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710822492,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710822636,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "038baffac55a282ae73e0627146a12a345f7beccb90dec07280e8b970a072849cf",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "channel_id": "840389722611122176",
-            "chan_point": "ea0ef25200606f5492052285955cdf20a075ca24ee800bde2c1ef33f0b898793:0",
-            "last_update": 1710737509,
-            "capacity": "16770000",
-            "node1_policy": {
-                "time_lock_delta": 72,
-                "min_htlc": "1",
-                "fee_base_msat": "2147483647",
-                "fee_rate_milli_msat": "2147483647",
-                "disabled": false,
-                "max_htlc_msat": "15093000000",
-                "last_update": 1710534432,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1677000000",
-                "last_update": 1710737509,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "036b53093df5a932deac828cca6d663472dbc88322b05eec1d42b26ab9b16caa1c",
-            "node2_pub": "02a6674aecc34ab056ae493c67e26c623c5ee02f3b9f69d1b40797ec3f226ec147"
-        },
-        {
-            "channel_id": "917568841806315521",
-            "chan_point": "e2aa45cafa819d6c8b800ecb43e4f396c1432592437cd28043a50558c3fa77dc:1",
-            "last_update": 1710705762,
-            "capacity": "16770000",
-            "node1_policy": {
-                "time_lock_delta": 72,
-                "min_htlc": "1",
-                "fee_base_msat": "2147483647",
-                "fee_rate_milli_msat": "2147483647",
-                "disabled": false,
-                "max_htlc_msat": "15093000000",
-                "last_update": 1710702323,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "1677000000",
-                "last_update": 1710705762,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "036b53093df5a932deac828cca6d663472dbc88322b05eec1d42b26ab9b16caa1c",
-            "node2_pub": "031fab3f6a8ae8588668fbe4bf4cae14c3aaa4134330b1798b81e60aaf9662ff20"
-        },
-        {
-            "channel_id": "891606073670172672",
-            "chan_point": "8d6969c0eaa0b30c82881ea9d7ad6a78d106e0a45f7b35c4c4d26b2b1a30411f:0",
-            "last_update": 1710788613,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710757309,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": true,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710788613,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "036b53093df5a932deac828cca6d663472dbc88322b05eec1d42b26ab9b16caa1c",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "763377729145667584",
-            "chan_point": "24bb4d197633e46a16c991bfccfaabe62e7d26fd887ee432271c1131b8d002a6:0",
-            "last_update": 1710820629,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "22",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710816739,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1710820629,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "834013654600253441",
-            "chan_point": "b2bec3d92ce448cf2f148300b47f498b91216b37df11fe0479632b6bd90ad55a:1",
-            "last_update": 1710820854,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 288,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "288",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710820433,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710820854,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "870764830809194497",
-            "chan_point": "d7f729cccc97631887603f016483c9a505273bce8b76b6b9e2d572e5d36d1ff0:1",
-            "last_update": 1710820433,
-            "capacity": "15000000",
-            "node1_policy": {
-                "time_lock_delta": 288,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "95",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710820433,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "161",
-                "disabled": false,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710819509,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "891181662244962307",
-            "chan_point": "aaa33efa000286f755f397e0406c111ab785496d0dd453e423d31a0f9cfa8448:3",
-            "last_update": 1710820794,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 288,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "33",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710820433,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710820794,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "906387907942612992",
-            "chan_point": "2592fcc1b383da2967c1b540dd245cb374d9bd8e283f933e18f0e51d958ad618:0",
-            "last_update": 1710820433,
-            "capacity": "8070000",
-            "node1_policy": {
-                "time_lock_delta": 180,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "21",
-                "disabled": false,
-                "max_htlc_msat": "3631500000",
-                "last_update": 1710820433,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "3631500000",
-                "last_update": 1710536071,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032f46d1e9a0c0db99cf788ddfd86d815be6e9d752af37f4cef5a13a5276af7004",
-            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
-        },
-        {
-            "channel_id": "829151614148083713",
-            "chan_point": "85b801accd68923e1650e3aab2c37d52d66bc7e31c62146be64b0e6364cb89bc:1",
-            "last_update": 1710757044,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "2693",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710757044,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710705110,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
-        },
-        {
-            "channel_id": "892812237888815107",
-            "chan_point": "e0f0351f69d4ee89fc6241ea30f9fa601d1f86cff9e0b7baa095a9c9acad1787:3",
-            "last_update": 1710818258,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "455",
-                "disabled": false,
-                "max_htlc_msat": "1800000000",
-                "last_update": 1710818258,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "1800000000",
-                "last_update": 1710816149,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322"
-        },
-        {
-            "channel_id": "917416009602236416",
-            "chan_point": "10f782b804347657cdb925866a7b9616f15dd8fd203b3de709245ecc808939a7:0",
-            "last_update": 1710785691,
-            "capacity": "99995000",
-            "node1_policy": {
-                "time_lock_delta": 140,
-                "min_htlc": "100",
-                "fee_base_msat": "2000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710785691,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710265468,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
-        },
-        {
-            "channel_id": "894843035960147968",
-            "chan_point": "cfcfe8f1dc8cf0f20a6292facfc00d7e820e89cff3de64bd057801fc3ec3fc8d:0",
-            "last_update": 1710757535,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710757535,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710312917,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
-        },
-        {
-            "channel_id": "879984235832803328",
-            "chan_point": "3677e1903d27d75610e6d866d6f23581780ec1154bd57c5148ecb385600ad53c:0",
-            "last_update": 1710850284,
-            "capacity": "400000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "180000000",
-                "last_update": 1710850284,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "180000000",
-                "last_update": 1710452732,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "02a1431534bfe333be9ff587f8f197b1b3d9ec05b58eb42e2a08f590fea6cc8866"
-        },
-        {
-            "channel_id": "908677091317514240",
-            "chan_point": "60ea6bc0bf78c321439693d86d80a3b9eb9208f358941ab5595624e926d7b86e:0",
-            "last_update": 1710853799,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710772034,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "999",
-                "disabled": false,
-                "max_htlc_msat": "1",
-                "last_update": 1710853799,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "908083354985693185",
-            "chan_point": "a8a0e01a433aa39bf3577469c982d74150ec39e14b441ee2aef7e7cb17408d40:1",
-            "last_update": 1710853944,
-            "capacity": "38000000",
-            "node1_policy": {
-                "time_lock_delta": 118,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1118",
-                "disabled": false,
-                "max_htlc_msat": "17100000000",
-                "last_update": 1710853944,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "100000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "17100000000",
-                "last_update": 1710835927,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "916338488352964608",
-            "chan_point": "4d0be2d98f261a3856dc53275711041441f11f517f0badf8731a3e926dac9de6:0",
-            "last_update": 1710786654,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710786654,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "699",
-                "disabled": false,
-                "max_htlc_msat": "20000000000",
-                "last_update": 1710779520,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "779061163002822657",
-            "chan_point": "f36a9e4aec796211afe127bb5133412df8a106f08aedf78095425b9b9281f7ae:1",
-            "last_update": 1710777271,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710267826,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "5000000000",
-                "last_update": 1710777271,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "03f20b295a728be64537bd7df1bf9092ed4bbf09b2c10f68c482d6fcb4f2232b28"
-        },
-        {
-            "channel_id": "886328417811628032",
-            "chan_point": "f058f77fa01b18f1b644391d1477f5286b5a11092d1f3fef0c3a8c3094df66fd:0",
-            "last_update": 1710780175,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "499",
-                "disabled": false,
-                "max_htlc_msat": "450000000",
-                "last_update": 1710780175,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "500",
-                "disabled": true,
-                "max_htlc_msat": "450000000",
-                "last_update": 1710755066,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "channel_id": "772480585848061953",
-            "chan_point": "ba90c6dab9a8c1566510af082dfaa0f9fc9b52f08f3bf154a1b804006ff62389:1",
-            "last_update": 1710852935,
-            "capacity": "89000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "88110000000",
-                "last_update": 1710836821,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "88110000000",
-                "last_update": 1710852935,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "840399618144075777",
-            "chan_point": "88f3930841f4cfe312129458113be3184d8716523115605fd922263aed69c624:1",
-            "last_update": 1710824135,
-            "capacity": "16770000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "1677000000",
-                "last_update": 1710824135,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 72,
-                "min_htlc": "1000",
-                "fee_base_msat": "2147483647",
-                "fee_rate_milli_msat": "2147483647",
-                "disabled": false,
-                "max_htlc_msat": "15093000000",
-                "last_update": 1710804837,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
-            "node2_pub": "02a6674aecc34ab056ae493c67e26c623c5ee02f3b9f69d1b40797ec3f226ec147"
-        },
-        {
-            "channel_id": "841717932551831552",
-            "chan_point": "eba0eb446c6bafe0d4fdc414337e92ea9c931ec75a7b921934fc9f2c19ded65b:0",
-            "last_update": 1710806135,
-            "capacity": "25000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "25000000000",
-                "last_update": 1710806135,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "24740000000",
-                "last_update": 1710106178,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "876533968392880129",
-            "chan_point": "eb3e07beff823a92b648b64bf32c12c18ed2eb6ab9594018aad873934eb97f82:1",
-            "last_update": 1710856059,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "100000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710795335,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "622",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710856059,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
+            "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
+            "node2_pub": "025dfb3926e67a64b45a164865a737ecfc37071d11ac4846b0d59c4979c8bb08b8"
         },
         {
             "channel_id": "886619788490833928",
@@ -19330,225 +4153,22 @@
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
+            "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
+            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
         },
         {
-            "channel_id": "918425361248288768",
-            "chan_point": "036f4a9be00df25cc8abfcdeeae828e0fbc7d82c92109e907aaf9837501680f7:0",
-            "last_update": 1710829005,
-            "capacity": "16770000",
+            "channel_id": "914391253219868685",
+            "chan_point": "acf8a90a8ba334f408b13a1e581538c6fcc3d2398293a59b5fcad77f26769ca2:13",
+            "last_update": 1710813189,
+            "capacity": "3000000",
             "node1_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 200,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": true,
-                "max_htlc_msat": "1677000000",
-                "last_update": 1710829005,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 72,
-                "min_htlc": "1000",
-                "fee_base_msat": "2147483647",
-                "fee_rate_milli_msat": "2147483647",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "2000",
                 "disabled": false,
-                "max_htlc_msat": "15093000000",
-                "last_update": 1710816411,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
-            "node2_pub": "031fab3f6a8ae8588668fbe4bf4cae14c3aaa4134330b1798b81e60aaf9662ff20"
-        },
-        {
-            "channel_id": "836085134494859265",
-            "chan_point": "520d4004b04a087cf4caebcc964807b5a25125d80ea2dbae37d0945772926250:1",
-            "last_update": 1710752454,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710752454,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "14",
-                "fee_rate_milli_msat": "473",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1696764162,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bd743abf0f94b6d208d1c3c47aa8e958d6ddd8aa4e8c910c6e1d6b8dd7413a93",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "887725897158885403",
-            "chan_point": "ebdba1f9d2a671c43a5a7a2d15b0871bcb9d8c8dbd90f739f990c604220b5e5b:27",
-            "last_update": 1710793392,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": true,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710793392,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "11",
-                "fee_rate_milli_msat": "64",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1696866301,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bd743abf0f94b6d208d1c3c47aa8e958d6ddd8aa4e8c910c6e1d6b8dd7413a93",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "872244773410242561",
-            "chan_point": "a8327095d11bb27001a01eb937ca67aaf65b83c40608740ac71520472a63856c:1",
-            "last_update": 1710804928,
-            "capacity": "1500000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "2",
-                "fee_rate_milli_msat": "21",
-                "disabled": false,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1696764162,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "2",
-                "disabled": true,
-                "max_htlc_msat": "1485000000",
-                "last_update": 1710804928,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03bd743abf0f94b6d208d1c3c47aa8e958d6ddd8aa4e8c910c6e1d6b8dd7413a93",
-            "node2_pub": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660"
-        },
-        {
-            "channel_id": "850015946893754368",
-            "chan_point": "a3891956a13d316353320900ce18ba1a3587f234e9114c4747cfe440ebdc1f8e:0",
-            "last_update": 1710837567,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "799",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710837567,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710820854,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02c45389d58edf3c9dced6716791ed450ff632e74e962ac0d489047498f4e54a08",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "890349331943456774",
-            "chan_point": "6d7baf1326d0cbde0530047238797bacb3b4a5c4fcb17576db3e0449dfb02bf4:6",
-            "last_update": 1710822190,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "239",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710790767,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710822190,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02c45389d58edf3c9dced6716791ed450ff632e74e962ac0d489047498f4e54a08",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "896008518285262849",
-            "chan_point": "c51e20bcabff1ad7c8a106724e5fdddc8a8b5663e0f78b51bbb566c0e2dba889:1",
-            "last_update": 1710856242,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "100000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "18",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710829878,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "559",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710856242,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02c45389d58edf3c9dced6716791ed450ff632e74e962ac0d489047498f4e54a08",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "914438532120117249",
-            "chan_point": "2e40ae74268d237080c2d3a9aca1a02674ad1702ef324f01c6e19143db3cba43:1",
-            "last_update": 1710799031,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "666",
-                "fee_rate_milli_msat": "1448",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710797896,
+                "max_htlc_msat": "2970000000",
+                "last_update": 1710789782,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -19557,607 +4177,27 @@
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710799031,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0216fcf031519e0924e5e4b64a731b207cccb85b13caebffd0f664a32a39bcd368",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "886811103491129368",
-            "chan_point": "e6e65cc949066dc849d8130f81bf8bfc9a52109c432318322053660ebe9deb1d:24",
-            "last_update": 1710804927,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710804189,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "107",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710804927,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "887562069920120832",
-            "chan_point": "8be39724b43ccbaf8fd265d56de9f937a917bd46244cd6fac3d1f1665128a125:0",
-            "last_update": 1710836908,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710836905,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710836908,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c5bfa5cab7e52e7cebc45fd1b86ea30ad518648651314563452b78b822333660",
-            "node2_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d"
-        },
-        {
-            "channel_id": "758610246763806720",
-            "chan_point": "b794af2543f913b3d55aa88e423c55754e56724c4e79f86d314fae42fe22fb7e:0",
-            "last_update": 1710849421,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710849421,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710675407,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "752654192138387456",
-            "chan_point": "2c74e2e392a24a544e4757d6ac14ecb9819af2347c61e1af69a5be6ccc3f2a8c:0",
-            "last_update": 1710837722,
-            "capacity": "1000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "50",
-                "disabled": false,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710835507,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710837722,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8",
-            "node2_pub": "02d7fd835234992a11895ab762fd58a0a5b9d4349560d9452273754bba38515fc1"
-        },
-        {
-            "channel_id": "831830024513650689",
-            "chan_point": "8ca58dc64ce982e8c0be06a8db71955c249257f1a390bad34111090ebf23dd5a:1",
-            "last_update": 1710850540,
-            "capacity": "11000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "10890000000",
-                "last_update": 1710675463,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "10890000000",
-                "last_update": 1710850540,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "761191900053700608",
-            "chan_point": "008ea1890bf2ab7394db0535869b1e4b5421ed88138b60055437cfa6e9d3d371:0",
-            "last_update": 1710837722,
-            "capacity": "500000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": true,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710835476,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "200",
-                "disabled": true,
-                "max_htlc_msat": "495000000",
-                "last_update": 1710837722,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "778522402337456128",
-            "chan_point": "fae096ee98e52b416bbc2335a747478431e7c286a41fb1641ec8eb282bd396f9:0",
-            "last_update": 1710837748,
-            "capacity": "15000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": true,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710837748,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "300",
-                "disabled": true,
-                "max_htlc_msat": "14850000000",
-                "last_update": 1710837722,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "886592300790185989",
-            "chan_point": "b118e2f5494e53302d817ef1132a207b01b08d0ee057cdf949c92f2ed87decf3:5",
-            "last_update": 1710850540,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710849189,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710850540,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c445275ee7d79ee5778ca2ac81b7c4d84aed7ee04629e8d8f35434b3c21e2da8",
-            "node2_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1"
-        },
-        {
-            "channel_id": "896036006065078273",
-            "chan_point": "6a8ba353e5346f0e804d393b86df79eec1c4ac56f33050e8261c7e4778c4184e:1",
-            "last_update": 1710845087,
-            "capacity": "2700000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "2673000000",
-                "last_update": 1710754021,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "2673000000",
-                "last_update": 1710845087,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03740f82191202480ace717fcdf00f71a8b1eb9bdc2bb5e2106cd0ab5cb4d7a54e",
-            "node2_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877"
-        },
-        {
-            "channel_id": "820734852769710081",
-            "chan_point": "531e5e90662b898ba3609ff1007fdbb6cd46c4d2fc1b77e1e84064baea8fa473:1",
-            "last_update": 1710837887,
-            "capacity": "6000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710750908,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "600",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710837887,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03740f82191202480ace717fcdf00f71a8b1eb9bdc2bb5e2106cd0ab5cb4d7a54e",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "603548320812826625",
-            "chan_point": "343676caad69a406feaa95c6385b93c91464f1931db7fd67ede6758156b34d46:1",
-            "last_update": 1710799709,
-            "capacity": "387705",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "383828000",
-                "last_update": 1710788221,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "490",
-                "fee_rate_milli_msat": "903",
-                "disabled": false,
-                "max_htlc_msat": "383828000",
-                "last_update": 1710799709,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "782331110584549377",
-            "chan_point": "bf2255817b69dc1ab29b89ad9dc4c076a306466d8061364695fc371ab23e501e:1",
-            "last_update": 1710720579,
-            "capacity": "18000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "17820000000",
-                "last_update": 1710720579,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "17820000000",
-                "last_update": 1710720579,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "679999563296407552",
-            "chan_point": "f5eaf2024b68fee991316f4b7dc735c086c8818df8eedacf113900bda3ccd6ef:0",
-            "last_update": 1710835021,
-            "capacity": "127218",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": true,
-                "max_htlc_msat": "125946000",
-                "last_update": 1710835021,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "125946000",
-                "last_update": 1588497052,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877",
-            "node2_pub": "032f2304b61a6e956c7e1d62d630fa163f9bcb91965dd79717b83e0023c7640305"
-        },
-        {
-            "channel_id": "890970556046049291",
-            "chan_point": "18f9e8f228d824a96ee6d6f0f6825677e49b4da0e6659bfc987d263db4319a50:11",
-            "last_update": 1710838621,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710838621,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710788394,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "777130420582875137",
-            "chan_point": "d7e1adde1d7ed154b5dda353615784c521493c9b2a89fb8bb7770eb36a20906e:1",
-            "last_update": 1710853157,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": true,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710853005,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "20",
-                "disabled": true,
-                "max_htlc_msat": "4000000000",
-                "last_update": 1710853157,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877",
-            "node2_pub": "03c539a7b630001d2f324a487b949b4c294e9de0e05bc7f9c6e85af841af263cc5"
-        },
-        {
-            "channel_id": "788021083301347329",
-            "chan_point": "e6091f883d1d82fd2a37c529dc06b2b363adec346ee790f35b4f6e0cb7585b78:1",
-            "last_update": 1710806221,
-            "capacity": "1111889",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "1111889000",
-                "last_update": 1710806221,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "207",
-                "fee_rate_milli_msat": "45",
-                "disabled": false,
-                "max_htlc_msat": "1100771000",
-                "last_update": 1710711286,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877",
-            "node2_pub": "02c61e171140fc1aac5d3e0bcfefdc79ea954306dfa29265f02def849dc7e80419"
-        },
-        {
-            "channel_id": "858296368964435969",
-            "chan_point": "03ef5a257f7ad3a0011702c4d0118d9bc50ee4e8cefd4f72d9e4bdc8511f8cca:1",
-            "last_update": 1710855921,
-            "capacity": "6000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "100",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710795421,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "809",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710855921,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0260fab633066ed7b1d9b9b8a0fac87e1579d1709e874d28a0d171a1f5c43bb877",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "893688548681449475",
-            "chan_point": "4091af261973b7c72aab80ec1d67dea0cb8707e1773632fe2abdfb70340a550f:3",
-            "last_update": 1710792785,
-            "capacity": "20000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "1193",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710789444,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "19800000000",
-                "last_update": 1710792785,
+                "max_htlc_msat": "2970000000",
+                "last_update": 1710813189,
                 "custom_records": {}
             },
             "custom_records": {},
             "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
-            "node2_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c"
+            "node2_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f"
         },
         {
-            "channel_id": "889855651147612161",
-            "chan_point": "7ce4049dacc96cbed13afd0664d05d6d4f68ec7b6d1bd6181fe03736af188fea:1",
-            "last_update": 1710838389,
+            "channel_id": "886786914241085444",
+            "chan_point": "c34a46e8d7fd82170c9fc87cfcbc848c477a40799d638512bb60054aafd69cf3:4",
+            "last_update": 1710830106,
             "capacity": "2000000",
             "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1",
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
                 "fee_base_msat": "0",
-                "fee_rate_milli_msat": "6800",
+                "fee_rate_milli_msat": "159",
                 "disabled": false,
                 "max_htlc_msat": "1980000000",
-                "last_update": 1710528539,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "2000000000",
-                "last_update": 1710838389,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "886669266406801434",
-            "chan_point": "a33b675ecfa23cfe02ed1522e63c89959ad4df509c61aea8f886a8bb6b5f3d8c:26",
-            "last_update": 1710705190,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710528895,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "2000000000",
-                "last_update": 1710705190,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "886759426467037191",
-            "chan_point": "5bc09590890f03e5e0a338c2352a2e3f87f30790814d056779b4881bea2cf68e:7",
-            "last_update": 1710846516,
-            "capacity": "2000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "110",
-                "disabled": false,
-                "max_htlc_msat": "1980000000",
-                "last_update": 1710846516,
+                "last_update": 1710828768,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -20167,26 +4207,26 @@
                 "fee_rate_milli_msat": "10",
                 "disabled": false,
                 "max_htlc_msat": "1980000000",
-                "last_update": 1710793390,
+                "last_update": 1710830106,
                 "custom_records": {}
             },
             "custom_records": {},
             "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
-            "node2_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be"
+            "node2_pub": "03382704812aca55bf853b353ecd3edef7e16a9420d7beb7e7d6b6c7fe2082252a"
         },
         {
-            "channel_id": "889855651147612179",
-            "chan_point": "7ce4049dacc96cbed13afd0664d05d6d4f68ec7b6d1bd6181fe03736af188fea:19",
+            "channel_id": "890068956432236548",
+            "chan_point": "ffbc1367d23f03fc1b3551faf2832e16668ee135fc780e22e46b72fb025c05a1:4",
             "last_update": 1710795190,
             "capacity": "2000000",
             "node1_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
+                "fee_rate_milli_msat": "1",
                 "disabled": false,
                 "max_htlc_msat": "1980000000",
-                "last_update": 1710790194,
+                "last_update": 1710790263,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -20201,41 +4241,99 @@
             },
             "custom_records": {},
             "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
+            "node2_pub": "0338bbdb38184852f728ef833e9ca0d01e134e9490f5b3fd3219b3ad9eaa0fc49d"
         },
         {
-            "channel_id": "837253915350269953",
-            "chan_point": "848f320938b8999ae3e5024c313d43bb5a9572cc143ef2edb58bce51093bbd67:1",
-            "last_update": 1710856876,
-            "capacity": "10000000",
+            "channel_id": "889913925275484176",
+            "chan_point": "48cd67b0995fb7e49876f4e18fba74bbde68bf3c713b6cc5ceb93c4f3272f4ee:16",
+            "last_update": 1710829389,
+            "capacity": "2000000",
             "node1_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "721",
+                "time_lock_delta": 80,
+                "min_htlc": "10000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "90",
                 "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710856876,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710789499,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 40,
-                "min_htlc": "100000",
+                "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "10",
                 "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710795189,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710829389,
                 "custom_records": {}
             },
             "custom_records": {},
             "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
+            "node2_pub": "03440f4dd43f5e30ffa0fd37eb99e2c27241d71e4fc5b3ea1e9c04a289a51c7ae0"
         },
         {
-            "channel_id": "886592300790185996",
-            "chan_point": "b118e2f5494e53302d817ef1132a207b01b08d0ee057cdf949c92f2ed87decf3:12",
-            "last_update": 1710799709,
+            "channel_id": "888987036985851905",
+            "chan_point": "094ff6c4b2ee8473bf7839d6d48c389576209ef4c581abb7abcab755bd20a4b8:1",
+            "last_update": 1710791182,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710791182,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "10",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710775389,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
+            "node2_pub": "035d681f3696fc5039d304c621f6f39ba6e0aa0ad482065417720d4f820f8dcb0e"
+        },
+        {
+            "channel_id": "886894666356949005",
+            "chan_point": "638f26ea27dfba927dfb3897f9fe9489d604f12b8b7721eb4f76fe09896f9f01:13",
+            "last_update": 1710841936,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710841936,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "10",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710793390,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
+            "node2_pub": "035fcbf3d34c71ffe7404c5660242f9289991021cc3d52098d0038f839552365a3"
+        },
+        {
+            "channel_id": "889855651147612169",
+            "chan_point": "7ce4049dacc96cbed13afd0664d05d6d4f68ec7b6d1bd6181fe03736af188fea:9",
+            "last_update": 1710813189,
             "capacity": "2000000",
             "node1_policy": {
                 "time_lock_delta": 40,
@@ -20244,181 +4342,123 @@
                 "fee_rate_milli_msat": "10",
                 "disabled": false,
                 "max_htlc_msat": "1980000000",
-                "last_update": 1710787990,
+                "last_update": 1710813189,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 100,
+                "time_lock_delta": 222,
                 "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "728",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "2000",
                 "disabled": false,
                 "max_htlc_msat": "1980000000",
-                "last_update": 1710799709,
+                "last_update": 1710790753,
                 "custom_records": {}
             },
             "custom_records": {},
             "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
+            "node2_pub": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac"
         },
         {
-            "channel_id": "892978264219451392",
-            "chan_point": "47b808a868836a7e09f60e23e29ac3421b85a5c066ace11802208eb70b2acffc:0",
-            "last_update": 1710851454,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710785255,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710851454,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "032f3380e907937c704bef15f051d0747b942976e994a2e615ad3f5b8fb0aa6660",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "886200874445373440",
-            "chan_point": "3481c1ba68a40c4f10b0430f389df50c295e9237430926e6f95ce535113a8c22:0",
-            "last_update": 1710829703,
-            "capacity": "250000",
+            "channel_id": "890068956432236557",
+            "chan_point": "ffbc1367d23f03fc1b3551faf2832e16668ee135fc780e22e46b72fb025c05a1:13",
+            "last_update": 1710793392,
+            "capacity": "2000000",
             "node1_policy": {
                 "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710829703,
+                "fee_rate_milli_msat": "10",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710793392,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "247500000",
-                "last_update": 1710829656,
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710789318,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
+            "node1_pub": "0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1",
+            "node2_pub": "03c0223a47deb4abe67071ad16f66c5c8dc38bbd5bd117589f80ba1d51eb7ddb96"
         },
         {
-            "channel_id": "888538436415324161",
-            "chan_point": "0a8ec0cd1822ea9be1ac09a4186f3bb8b6d871b1b7e74d45814bf6056a445165:1",
-            "last_update": 1710838596,
-            "capacity": "1000000",
+            "channel_id": "918488033557348353",
+            "chan_point": "3c57def65d9db037ef262b94448e0b19413365d50874dadf6c8706704ef2a6a0:1",
+            "last_update": 1710855657,
+            "capacity": "16770000",
             "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "3",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710838540,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "100",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710838596,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03b279522ced2ccd9d2c7d1fc500d24f567129fc12b9495a076e30a2e861fffb1d",
-            "node2_pub": "02ec23ef38b0af053817b793fc97d82acba48ec64895eb3f1cf2b1357123d35e15"
-        },
-        {
-            "channel_id": "677981959494041600",
-            "chan_point": "7807b3a696921a8a78b9b7fe2655d9b26da77f15c7214d3093186597264c8fbb:0",
-            "last_update": 1710604803,
-            "capacity": "20000",
-            "node1_policy": {
-                "time_lock_delta": 40,
+                "time_lock_delta": 72,
                 "min_htlc": "1",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": true,
-                "max_htlc_msat": "19800000",
-                "last_update": 1710604803,
+                "fee_base_msat": "2147483647",
+                "fee_rate_milli_msat": "2147483647",
+                "disabled": false,
+                "max_htlc_msat": "15093000000",
+                "last_update": 1710855657,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 40,
+                "time_lock_delta": 80,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "500",
                 "disabled": false,
-                "max_htlc_msat": "19800000",
-                "last_update": 1588470052,
+                "max_htlc_msat": "1677000000",
+                "last_update": 1710855493,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "032f2304b61a6e956c7e1d62d630fa163f9bcb91965dd79717b83e0023c7640305",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
+            "node1_pub": "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5",
+            "node2_pub": "024729f3d5f7794f4df09bfdb7ca23a4fbe6c38997cdd213c694a2cca1c27cbb17"
         },
         {
-            "channel_id": "780786296706498561",
-            "chan_point": "9726b7653e6c32397b464d5796a5064bf0a2efd29b923eb886bcd6398b7e0648:1",
-            "last_update": 1710853037,
-            "capacity": "1000000",
+            "channel_id": "913633689575358465",
+            "chan_point": "f4ba21d0d25d0d064fab44160da431b099ffa8f7fe5a7d1289a4ed3d2ce3c60b:1",
+            "last_update": 1710822543,
+            "capacity": "25000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1000",
+                "disabled": false,
+                "max_htlc_msat": "24750000000",
+                "last_update": 1710789935,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "500",
+                "disabled": false,
+                "max_htlc_msat": "24750000000",
+                "last_update": 1710822543,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5",
+            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
+        },
+        {
+            "channel_id": "914491308634472449",
+            "chan_point": "a0e58782bcff1c828a74744932f8ab32bafc27b275001372c2e62b5955387602:1",
+            "last_update": 1710790143,
+            "capacity": "100000000",
             "node1_policy": {
                 "time_lock_delta": 40,
                 "min_htlc": "1000",
                 "fee_base_msat": "0",
-                "fee_rate_milli_msat": "50",
-                "disabled": true,
-                "max_htlc_msat": "990000000",
-                "last_update": 1710853011,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "20",
-                "disabled": true,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710853037,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02d7fd835234992a11895ab762fd58a0a5b9d4349560d9452273754bba38515fc1",
-            "node2_pub": "03c539a7b630001d2f324a487b949b4c294e9de0e05bc7f9c6e85af841af263cc5"
-        },
-        {
-            "channel_id": "893206962632130561",
-            "chan_point": "fbef5d3f674ea2c2805e87ccc9e69c2e29a2683eec9b05511f8c9761a794fd98:1",
-            "last_update": 1710826203,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
+                "fee_rate_milli_msat": "0",
                 "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710826203,
+                "max_htlc_msat": "99000000000",
+                "last_update": 1710790037,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -20427,419 +4467,622 @@
                 "fee_base_msat": "0",
                 "fee_rate_milli_msat": "0",
                 "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710779071,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03f20b295a728be64537bd7df1bf9092ed4bbf09b2c10f68c482d6fcb4f2232b28",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "channel_id": "781195315046383617",
-            "chan_point": "12878d2a6cd3eb6113f912040024d878d4a4f53af0dd80673fa0c26b764ac191:1",
-            "last_update": 1710779230,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710779230,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1050",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710779071,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03f20b295a728be64537bd7df1bf9092ed4bbf09b2c10f68c482d6fcb4f2232b28",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "829895983516155905",
-            "chan_point": "58f40c67a68d1b505edd55be735b8015ae0d2a129fbef205f56539dda5fefb63:1",
-            "last_update": 1710813242,
-            "capacity": "100000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "2493",
-                "disabled": false,
                 "max_htlc_msat": "99000000000",
-                "last_update": 1710813242,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "99000000000",
-                "last_update": 1710792812,
+                "last_update": 1710790143,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
+            "node1_pub": "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5",
+            "node2_pub": "0294774ee02a9faa5a5870061f7f4833686184ad14a0b163c49442516c9edac1db"
         },
         {
-            "channel_id": "888338325045772289",
-            "chan_point": "4c2bbd413ea61c25fcb3e0de441fa0a6bf3edfcdc7afc3e5af810f281e18180c:1",
-            "last_update": 1710791357,
-            "capacity": "16777215",
+            "channel_id": "918488033557217280",
+            "chan_point": "9fd21e0a421924545e30b891812695791696c676367094ffe2467460eff56c36:0",
+            "last_update": 1710855500,
+            "capacity": "16770000",
             "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "793",
-                "disabled": false,
-                "max_htlc_msat": "16777215000",
-                "last_update": 1710663974,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 144,
+                "time_lock_delta": 72,
                 "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "2",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710791357,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c",
-            "node2_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f"
-        },
-        {
-            "channel_id": "891181662243454987",
-            "chan_point": "7795ebd8c0872e7f2569af9016d6bb8102a366f7692a39ae3221aef897e0fb2b:11",
-            "last_update": 1710852842,
-            "capacity": "333333333",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "1143",
-                "disabled": false,
-                "max_htlc_msat": "330000000000",
-                "last_update": 1710852842,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "5000000",
-                "fee_base_msat": "1",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "330000000000",
-                "last_update": 1710792791,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c",
-            "node2_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7"
-        },
-        {
-            "channel_id": "894927698243289089",
-            "chan_point": "30b8df68aef7bd70d81a60c3a870c0acc20d29b32e741435735e5de801a3d80b:1",
-            "last_update": 1710848555,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "20000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "343",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710795242,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "5000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "26",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710848555,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "895435672629542913",
-            "chan_point": "dced243e1d59d9b0572ea173d4e380665ebb46c95aaeb515e9da7b2316b764c6:1",
-            "last_update": 1710838442,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "50000000",
-                "fee_base_msat": "990",
-                "fee_rate_milli_msat": "943",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710838442,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "5000000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710792796,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0250baf7a558091eb9c93f43d595b795db61bd2b55ca016d8682fd310cb1b81e6c",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "811564925781278720",
-            "chan_point": "af11fadab13ad97fe87f89724c6af083a49ac74aa8015a9d16a6e65f33eb3df7:0",
-            "last_update": 1710790029,
-            "capacity": "4000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4000000000",
-                "last_update": 1710790029,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "1",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "250",
-                "disabled": false,
-                "max_htlc_msat": "3960000000",
-                "last_update": 1709357332,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03ecbf446779069cdbc506e809a137df875b1f76b9560bd39f4d9b143b82fa7df0",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "891181662241030148",
-            "chan_point": "56743d6fecdf4670a686cde6a3a6c1887e15c9c898e0b37b65fa9994600dee1d:4",
-            "last_update": 1710844203,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710844203,
+                "fee_base_msat": "2147483647",
+                "fee_rate_milli_msat": "2147483647",
+                "disabled": true,
+                "max_htlc_msat": "15093000000",
+                "last_update": 1710855462,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "500",
                 "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710788394,
+                "max_htlc_msat": "1677000000",
+                "last_update": 1710855500,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
+            "node1_pub": "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5",
+            "node2_pub": "031fab3f6a8ae8588668fbe4bf4cae14c3aaa4134330b1798b81e60aaf9662ff20"
         },
         {
-            "channel_id": "898519802822721536",
-            "chan_point": "baae2ebbb19129e71ada03ce5d059b9c0708bda6cf83837520df24794aae7cec:0",
-            "last_update": 1710856794,
+            "channel_id": "917417109119041536",
+            "chan_point": "9af4014c8a9dafc53ef2913a4bde5e2111cf10205c1905ae585e5511de108bcc:0",
+            "last_update": 1710854361,
+            "capacity": "99995000",
+            "node1_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "999",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710854361,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "750",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710822543,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "914489109751398401",
+            "chan_point": "c51bb911ae676ddcbd7207a596dbea51151ba678399287ab8221f27cf93fdbf2:1",
+            "last_update": 1710790753,
+            "capacity": "25000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "500",
+                "disabled": false,
+                "max_htlc_msat": "24750000000",
+                "last_update": 1710777543,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 222,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "2000",
+                "disabled": false,
+                "max_htlc_msat": "24750000000",
+                "last_update": 1710790753,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5",
+            "node2_pub": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac"
+        },
+        {
+            "channel_id": "850763614782029825",
+            "chan_point": "595e98da49698fdb9d9e25fbe9279c7f15897193bb13da9faef8ef1213a13fa5:1",
+            "last_update": 1710609731,
             "capacity": "500000",
             "node1_policy": {
-                "time_lock_delta": 100,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1050",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "50",
                 "disabled": false,
                 "max_htlc_msat": "495000000",
-                "last_update": 1710797471,
+                "last_update": 1707058294,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "300",
+                "disabled": true,
                 "max_htlc_msat": "495000000",
-                "last_update": 1710856794,
+                "last_update": 1710609731,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7",
-            "node2_pub": "02679d067ec30e5bb4ad13e277d655e2f3779dda5979b615c8fdf1be0b096ae257"
+            "node1_pub": "027d5369f807773ed75dc87dd12c585210b72827263f4a1009f052e67c12ac92f5",
+            "node2_pub": "02aeb397b7212dc1de5252684f9a1f1957d8bcc9864193b538ce78f9558685d666"
         },
         {
-            "channel_id": "821039417349177345",
-            "chan_point": "3922e6904a4812734fab2a9e027493c285cdc16ffa3610e9e225fb001530bb8a:1",
-            "last_update": 1710786594,
-            "capacity": "50000000",
+            "channel_id": "912038298208501760",
+            "chan_point": "42df48fd0764c7777e7e0f290e9538f3082222648941e6078c348f6f02a4457d:0",
+            "last_update": 1710855461,
+            "capacity": "6710669",
             "node1_policy": {
                 "time_lock_delta": 140,
                 "min_htlc": "100",
                 "fee_base_msat": "2000",
                 "fee_rate_milli_msat": "2500",
                 "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710755091,
+                "max_htlc_msat": "6643563000",
+                "last_update": 1710855461,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "500",
                 "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710786594,
+                "max_htlc_msat": "6643563000",
+                "last_update": 1710846063,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7",
+            "node1_pub": "0338bbdb38184852f728ef833e9ca0d01e134e9490f5b3fd3219b3ad9eaa0fc49d",
+            "node2_pub": "02535215135eb832df0f9858ff775bd4ae0b8911c59e2828ff7d03b535b333e149"
+        },
+        {
+            "channel_id": "891582983965769729",
+            "chan_point": "2dd71734bb100d72ae15439e6e707f6ca451040f21dc8f79df75d8fac835caf4:1",
+            "last_update": 1710855891,
+            "capacity": "10000000",
+            "node1_policy": {
+                "time_lock_delta": 140,
+                "min_htlc": "100",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "2500",
+                "disabled": false,
+                "max_htlc_msat": "9900000000",
+                "last_update": 1710855891,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "500",
+                "disabled": false,
+                "max_htlc_msat": "9900000000",
+                "last_update": 1710847863,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "0338bbdb38184852f728ef833e9ca0d01e134e9490f5b3fd3219b3ad9eaa0fc49d",
             "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
         },
         {
-            "channel_id": "890970556045918215",
-            "chan_point": "af2f60d891fa565c55c001dadc5b5b646036deccf66672a7794d15537db2d9a5:7",
-            "last_update": 1710831430,
-            "capacity": "88888888",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710831430,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710788394,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7",
-            "node2_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025"
-        },
-        {
-            "channel_id": "816102610256330752",
-            "chan_point": "8b18c9a9b1f32eb5be7ce42d63073f44e51548b465b1102b9d671a2cd9bcf658:0",
-            "last_update": 1710700194,
-            "capacity": "40000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
-                "disabled": false,
-                "max_htlc_msat": "40000000000",
-                "last_update": 1710700194,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "4000",
-                "disabled": false,
-                "max_htlc_msat": "39590000000",
-                "last_update": 1708895374,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7",
-            "node2_pub": "037e27d212432eaf499e4fb648d996944f3454c094dab36336bac573f82211a335"
-        },
-        {
-            "channel_id": "891147577330302987",
-            "chan_point": "44267c22d8d42675c44f3292e0da57247570fcc6f049c5d81a6e4faeaf26dea7:11",
-            "last_update": 1710853804,
-            "capacity": "333333333",
+            "channel_id": "854880186313605121",
+            "chan_point": "78dc9a67189d0d44d3678cb35bb8b297fde81743c3ebdfaa1651fe4ad731542e:1",
+            "last_update": 1710786746,
+            "capacity": "1000000",
             "node1_policy": {
                 "time_lock_delta": 40,
-                "min_htlc": "100000",
-                "fee_base_msat": "1",
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "330000000000",
-                "last_update": 1710795594,
+                "max_htlc_msat": "990000000",
+                "last_update": 1710770149,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "993",
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "330000000000",
-                "last_update": 1710853804,
+                "max_htlc_msat": "990000000",
+                "last_update": 1710786746,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
+            "node1_pub": "033e8bc45cc79dabebd18507ba39b101c839240932174bff6ddf34631305881cc3",
+            "node2_pub": "02abb5e57ff442770d9dc1d1ab66f45b015ac7aa033e4407051d060a471b71b08b"
         },
         {
-            "channel_id": "890970556046049287",
-            "chan_point": "18f9e8f228d824a96ee6d6f0f6825677e49b4da0e6659bfc987d263db4319a50:7",
-            "last_update": 1710842454,
-            "capacity": "88888888",
+            "channel_id": "781908898078588929",
+            "chan_point": "2d4c7735462b434dc79bd300e9d788cb78af0643c668531dab090c5d539fb3d1:1",
+            "last_update": 1710844710,
+            "capacity": "1500000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "1500000000",
+                "last_update": 1710844710,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "400000000",
+                "last_update": 1710684918,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "033e8bc45cc79dabebd18507ba39b101c839240932174bff6ddf34631305881cc3",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "793454869742813185",
+            "chan_point": "5327c98b3ce6a42c8baeebdc740bf24fbf0bedf5aa1f56eeebcc2b58fab5d54f:1",
+            "last_update": 1710791299,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "90",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710787110,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "10000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "90",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710791299,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "033e8bc45cc79dabebd18507ba39b101c839240932174bff6ddf34631305881cc3",
+            "node2_pub": "03440f4dd43f5e30ffa0fd37eb99e2c27241d71e4fc5b3ea1e9c04a289a51c7ae0"
+        },
+        {
+            "channel_id": "835777271311630337",
+            "chan_point": "26bedad6cbd11dd2054557a51631971287141b0b487ef09e1482601e8f24f28f:1",
+            "last_update": 1710785354,
+            "capacity": "1620000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1603800000",
+                "last_update": 1710778110,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 222,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "50",
+                "disabled": false,
+                "max_htlc_msat": "1603800000",
+                "last_update": 1710785354,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "033e8bc45cc79dabebd18507ba39b101c839240932174bff6ddf34631305881cc3",
+            "node2_pub": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac"
+        },
+        {
+            "channel_id": "817806853236391936",
+            "chan_point": "2d7da2726a4724f8a350315840bd7e45b383c4e909e749b235d62339880b67fb:0",
+            "last_update": 1710791182,
+            "capacity": "90000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "89100000",
+                "last_update": 1710509231,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "89100000",
+                "last_update": 1710791182,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02bf145fe009fef1230f3f435b5e448db3470a1fdbff95d41cefa71b7d6f14fcda",
+            "node2_pub": "035d681f3696fc5039d304c621f6f39ba6e0aa0ad482065417720d4f820f8dcb0e"
+        },
+        {
+            "channel_id": "885613735298072577",
+            "chan_point": "aae3c5dac5bc5a9b5813bb1f37592ca1aa0747d3b8089facdbf584d368ba94cb:1",
+            "last_update": 1710846929,
+            "capacity": "24639",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "50",
+                "disabled": false,
+                "max_htlc_msat": "24393000",
+                "last_update": 1710710327,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "24393000",
+                "last_update": 1710846929,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02b568dfb3cb52a0bde61b706f333a4eb4b77b0d38f0a9a591a338a05ae5130296",
+            "node2_pub": "02626318f968469fb1dcd0453536bbabaab8861be75d8cde7900e57aab1bd4f3ac"
+        },
+        {
+            "channel_id": "817627632791715840",
+            "chan_point": "349640c4fbb05af12ebc1bc904758dae19e90b3aa3ad2de840ad3b7c84889e56:0",
+            "last_update": 1710803782,
+            "capacity": "80000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "79200000",
+                "last_update": 1710775588,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "79200000",
+                "last_update": 1710803782,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02b568dfb3cb52a0bde61b706f333a4eb4b77b0d38f0a9a591a338a05ae5130296",
+            "node2_pub": "035d681f3696fc5039d304c621f6f39ba6e0aa0ad482065417720d4f820f8dcb0e"
+        },
+        {
+            "channel_id": "868515230059724800",
+            "chan_point": "5c1b233a9778af0356a5e02dd8d758ebb8b85ddbcf8252d793217d1a28dedd67:0",
+            "last_update": 1710635188,
+            "capacity": "80000",
             "node1_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "800",
+                "fee_rate_milli_msat": "1",
+                "disabled": true,
+                "max_htlc_msat": "79200000",
+                "last_update": 1710635188,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710838794,
+                "max_htlc_msat": "79200000",
+                "last_update": 1707066297,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02b568dfb3cb52a0bde61b706f333a4eb4b77b0d38f0a9a591a338a05ae5130296",
+            "node2_pub": "02f5be5f3d54b66bf531b96f06327f59cd139f6e2c301cc0131a3f632025c2704c"
+        },
+        {
+            "channel_id": "909468739601629185",
+            "chan_point": "ca9c5d9014ff6701875ec69d4db910fb7592f39ed5ad44eac23ff1f1031267f2:1",
+            "last_update": 1710783381,
+            "capacity": "500000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "167",
+                "disabled": true,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710783379,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "100",
+                "fee_rate_milli_msat": "100",
+                "disabled": true,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710783381,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02c87bce43398e73f65df561b4e776306fc1e74657d67131d76866ba617a0e63c2",
+            "node2_pub": "03eaf4f94ad680855a7818c2f156ae4a86482dea2f396320c336989ce5f49da880"
+        },
+        {
+            "channel_id": "913193885013966849",
+            "chan_point": "087e6845eefd047bb0dd3ee591a2dbea28b504b8a07fd733f5eb51bf89b0ca24:1",
+            "last_update": 1710834571,
+            "capacity": "500000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "100",
+                "disabled": false,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710779061,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
+                "fee_rate_milli_msat": "30",
                 "disabled": false,
-                "max_htlc_msat": "88000000000",
-                "last_update": 1710842454,
+                "max_htlc_msat": "495000000",
+                "last_update": 1710834571,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "033e9ce4e8f0e68f7db49ffb6b9eecc10605f3f3fcb3c630545887749ab515b9c7",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
+            "node1_pub": "02c87bce43398e73f65df561b4e776306fc1e74657d67131d76866ba617a0e63c2",
+            "node2_pub": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972"
+        },
+        {
+            "channel_id": "769006129141776384",
+            "chan_point": "e5ebf62a8e888892b505156f95c8c6c7cb60ecf9801ec9f6650d3f303e53cba9:0",
+            "last_update": 1710704923,
+            "capacity": "250000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1000",
+                "disabled": false,
+                "max_htlc_msat": "247500000",
+                "last_update": 1710531493,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "247500000",
+                "last_update": 1710704923,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02b196899ff33d892562c557a37f56a3702f14eba8aee8585625ed8cf4217f2ab3",
+            "node2_pub": "021227d4be948ab84613d5dbd47b6e148cfb811432d27eb92e80d28382b1b27d27"
+        },
+        {
+            "channel_id": "770339836665790464",
+            "chan_point": "fd89d822c95341eb4948000720b9747ce4b517e3ec6726db5774bdda4f25164c:0",
+            "last_update": 1710773323,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1000",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710771935,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710773323,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02b196899ff33d892562c557a37f56a3702f14eba8aee8585625ed8cf4217f2ab3",
+            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
+        },
+        {
+            "channel_id": "860278788451991553",
+            "chan_point": "34f76ac4003f888ceeeeb9f71b3912ca731bebf78c3a808d3abfb4abd5beb96a:1",
+            "last_update": 1710851757,
+            "capacity": "100000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "99000000",
+                "last_update": 1710851757,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "99000000",
+                "last_update": 1710817465,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03c0223a47deb4abe67071ad16f66c5c8dc38bbd5bd117589f80ba1d51eb7ddb96",
+            "node2_pub": "025dfb3926e67a64b45a164865a737ecfc37071d11ac4846b0d59c4979c8bb08b8"
+        },
+        {
+            "channel_id": "865665295861612544",
+            "chan_point": "95a81b50d4b7055f0af96915ff3226e0d8b97d6a1e3d6975e02a295301468c8f:0",
+            "last_update": 1710594913,
+            "capacity": "100000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "99000000",
+                "last_update": 1710125353,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "99000000",
+                "last_update": 1710594913,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03c0223a47deb4abe67071ad16f66c5c8dc38bbd5bd117589f80ba1d51eb7ddb96",
+            "node2_pub": "039157862ec407b1aa2353d879279916e76c8d2fcc4ac10d3f225972c8e58fbc43"
+        },
+        {
+            "channel_id": "850260038455197696",
+            "chan_point": "81b147059ab5ee28ccb9e1af5158254e6a0ceb3170ca1ebd2c062bad44ddf479:0",
+            "last_update": 1710798303,
+            "capacity": "5000223",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "0",
+                "disabled": false,
+                "max_htlc_msat": "4950221000",
+                "last_update": 1710798303,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "4950221000",
+                "last_update": 1710798303,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02aeb397b7212dc1de5252684f9a1f1957d8bcc9864193b538ce78f9558685d666",
+            "node2_pub": "031678745383bd273b4c3dbefc8ffbf4847d85c2f62d3407c0c980430b3257c403"
         },
         {
             "channel_id": "918392376041340929",
@@ -20871,241 +5114,18 @@
             "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
         },
         {
-            "channel_id": "892044778759127040",
-            "chan_point": "5279b3922e463d52ef44d5a0c0dd1079f0ee8453442f5c069629a033144b00ba:0",
-            "last_update": 1710826203,
-            "capacity": "150000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "148500000",
-                "last_update": 1710826203,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "148500000",
-                "last_update": 1710816458,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
-        },
-        {
-            "channel_id": "892405418556588032",
-            "chan_point": "1b360279b3b120c6284a7be743234ff7957aeae20a42ae532755eada0c363c23:0",
-            "last_update": 1710838058,
-            "capacity": "10000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "215",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710838058,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "400",
-                "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710817254,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "912343962520846339",
-            "chan_point": "647a7dfd87558e1a5524a47a7cc84a137d13464b07a9f3931347326505d066e7:3",
-            "last_update": 1710855978,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710796658,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "471",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710855978,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "02708a3f6146d89fc77cb8af4ebd877241cf44a18108981a67a6ba438de1f2d322",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "775082030449819649",
-            "chan_point": "33b0f7cbfdbdf7dbb5ae62dc4d2d0f6fcb87c599cfbf80df6967ea9ebe7adfcf:1",
-            "last_update": 1710853484,
-            "capacity": "6000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
-                "disabled": false,
-                "max_htlc_msat": "5940000000",
-                "last_update": 1710853484,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "3000000000",
-                "last_update": 1710853484,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "03c539a7b630001d2f324a487b949b4c294e9de0e05bc7f9c6e85af841af263cc5",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "885690701113524225",
-            "chan_point": "ae73749ec2222756ccea6ebf60ddf539a146c01f61cdf12f2f6648301010b622:1",
-            "last_update": 1710856582,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "100000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710796047,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "638",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710856582,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "885704994699345921",
-            "chan_point": "4e6b3c65d0db869a930c099f8255e603ee0cc9cf66238d7fdbbab7ef6896d8a2:1",
-            "last_update": 1710849830,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "210",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710846513,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710849830,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "031bdbb93de14f5c3b1295fb964e6acce26d1dbfef8b18dfffdd45586551dcf1be",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
-        },
-        {
-            "channel_id": "849827930352517121",
-            "chan_point": "6dbdd06bc5b667d95341d1617d96b1f8b8c3560a71b3f36056e0e598fbb1ad02:1",
-            "last_update": 1710420746,
-            "capacity": "12000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "0",
-                "fee_base_msat": "47000",
-                "fee_rate_milli_msat": "680",
-                "disabled": false,
-                "max_htlc_msat": "11880000000",
-                "last_update": 1710262453,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 34,
-                "min_htlc": "0",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "10",
-                "disabled": false,
-                "max_htlc_msat": "11880000000",
-                "last_update": 1710420746,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f",
-            "node2_pub": "02c61e171140fc1aac5d3e0bcfefdc79ea954306dfa29265f02def849dc7e80419"
-        },
-        {
-            "channel_id": "864558087632715777",
-            "chan_point": "88ee144f1a1654294401a7f3ac7841e8d643bbce9171d5ba4803d4d5904ecc63:1",
-            "last_update": 1710396331,
-            "capacity": "16777215",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "0",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "3300",
-                "disabled": false,
-                "max_htlc_msat": "16609443000",
-                "last_update": 1710396331,
-                "custom_records": {}
-            },
-            "node2_policy": null,
-            "custom_records": {},
-            "node1_pub": "0298f6074a454a1f5345cb2a7c6f9fce206cd0bf675d177cdbf0ca7508dd28852f",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
-        },
-        {
-            "channel_id": "889153063205470208",
-            "chan_point": "cfa1dd7feea6bad907279097bdd152175f5e0323b0f816457a0580608f2a71a4:0",
-            "last_update": 1710823491,
+            "channel_id": "918425361248288768",
+            "chan_point": "036f4a9be00df25cc8abfcdeeae828e0fbc7d82c92109e907aaf9837501680f7:0",
+            "last_update": 1710829005,
             "capacity": "16770000",
             "node1_policy": {
-                "time_lock_delta": 140,
-                "min_htlc": "100",
-                "fee_base_msat": "2000",
-                "fee_rate_milli_msat": "2500",
-                "disabled": false,
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1000",
+                "disabled": true,
                 "max_htlc_msat": "1677000000",
-                "last_update": 1710823491,
+                "last_update": 1710829005,
                 "custom_records": {}
             },
             "node2_policy": {
@@ -21115,331 +5135,1056 @@
                 "fee_rate_milli_msat": "2147483647",
                 "disabled": false,
                 "max_htlc_msat": "15093000000",
-                "last_update": 1710804837,
+                "last_update": 1710816411,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "02a6674aecc34ab056ae493c67e26c623c5ee02f3b9f69d1b40797ec3f226ec147",
-            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
+            "node1_pub": "031fab3f6a8ae8588668fbe4bf4cae14c3aaa4134330b1798b81e60aaf9662ff20",
+            "node2_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4"
         },
         {
-            "channel_id": "898985995747196928",
-            "chan_point": "02a28b76d0bd067dd1ee8b8a0a496c9de55f783ba877973fee7af258eed96b68:0",
-            "last_update": 1710839650,
-            "capacity": "5000000",
+            "channel_id": "763640512349143040",
+            "chan_point": "50ad5a9f0c31ec00e8e5dfc4a3947ea363542be0db57a538c014d1693c00782f:0",
+            "last_update": 1710398772,
+            "capacity": "100000",
             "node1_policy": {
-                "time_lock_delta": 100,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "50",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "20",
                 "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710839650,
+                "max_htlc_msat": "99000000",
+                "last_update": 1709879445,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "0",
+                "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "10",
                 "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710790254,
+                "max_htlc_msat": "99000000",
+                "last_update": 1710398772,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "02679d067ec30e5bb4ad13e277d655e2f3779dda5979b615c8fdf1be0b096ae257",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
+            "node1_pub": "0202b5d54467d075893d46b6205067bbab2bcbc632513cd15661ad803d2dcb4ce3",
+            "node2_pub": "03b9de7a7d7e8a474b859a59e314cf2a143ae9c569ce78c46289b3ad16cb8c03f9"
         },
         {
-            "channel_id": "899935973880627200",
-            "chan_point": "62f35f6c2e78fad41d9f307219c8e83557b2a7f742d46b7454e75ea321e6a313:0",
-            "last_update": 1710856871,
+            "channel_id": "908048170593550337",
+            "chan_point": "0d45ab108774a44b8ed9a0a09c6ae6ac6390447c8c4f31762c9984e268dbf63a:1",
+            "last_update": 1710856405,
             "capacity": "500000",
             "node1_policy": {
-                "time_lock_delta": 100,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "7000",
+                "fee_base_msat": "100",
                 "fee_rate_milli_msat": "1",
                 "disabled": false,
                 "max_htlc_msat": "495000000",
-                "last_update": 1710856871,
+                "last_update": 1710856405,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 100,
+                "time_lock_delta": 40,
                 "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "146",
+                "fee_base_msat": "100",
+                "fee_rate_milli_msat": "100",
                 "disabled": false,
                 "max_htlc_msat": "495000000",
-                "last_update": 1710849598,
+                "last_update": 1710801772,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "02679d067ec30e5bb4ad13e277d655e2f3779dda5979b615c8fdf1be0b096ae257",
-            "node2_pub": "02ec23ef38b0af053817b793fc97d82acba48ec64895eb3f1cf2b1357123d35e15"
+            "node1_pub": "0202b5d54467d075893d46b6205067bbab2bcbc632513cd15661ad803d2dcb4ce3",
+            "node2_pub": "03eaf4f94ad680855a7818c2f156ae4a86482dea2f396320c336989ce5f49da880"
         },
         {
-            "channel_id": "909786498421030913",
-            "chan_point": "3d2331b5c5659fd00a63f6a93697fd10557251f0a67182a7ee4e0686d7867717:1",
-            "last_update": 1710798461,
-            "capacity": "4900000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "9000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "15000",
-                "disabled": false,
-                "max_htlc_msat": "800000000",
-                "last_update": 1710798461,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "4851000000",
-                "last_update": 1710779805,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025",
-            "node2_pub": "02b61154d89b98662f4c58e1005963e918da6a8fdb5adbea85ad22a20b8e7fc0ad"
-        },
-        {
-            "channel_id": "666868095977324545",
-            "chan_point": "f3ec3b606a0f179b72109b5c2ee3c2cfa71912af631a444483034c7749873074:1",
-            "last_update": 1710846510,
-            "capacity": "16000000",
-            "node1_policy": {
-                "time_lock_delta": 144,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1000",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710788229,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 100,
-                "min_htlc": "1000",
-                "fee_base_msat": "300",
-                "fee_rate_milli_msat": "5000",
-                "disabled": false,
-                "max_htlc_msat": "15840000000",
-                "last_update": 1710846510,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
-        },
-        {
-            "channel_id": "869287087164620801",
-            "chan_point": "114b80c2f977fec0a8203746fe66646f1d42d93217239116b42fd15eaba71df5:1",
-            "last_update": 1710853887,
-            "capacity": "50000000",
-            "node1_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "100000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710797231,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 78,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "1597",
-                "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710853887,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025",
-            "node2_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a"
-        },
-        {
-            "channel_id": "914460522418733056",
-            "chan_point": "164a121989ce3a449fd6a1d9fb477cadc36aaba0a31ecae3fd308399dce819b1:0",
-            "last_update": 1710795604,
+            "channel_id": "756393631196446720",
+            "chan_point": "f64829c1e94063373474fc4be07bb1e594b4fd639be17b437af1d84fa1c629c1:0",
+            "last_update": 1710811915,
             "capacity": "1000000",
             "node1_policy": {
                 "time_lock_delta": 40,
-                "min_htlc": "1000000",
-                "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "1",
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "2000",
                 "disabled": false,
                 "max_htlc_msat": "990000000",
-                "last_update": 1710795604,
+                "last_update": 1662603210,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 118,
-                "min_htlc": "1000000",
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
                 "fee_base_msat": "0",
-                "fee_rate_milli_msat": "0",
-                "disabled": false,
+                "fee_rate_milli_msat": "750",
+                "disabled": true,
                 "max_htlc_msat": "990000000",
-                "last_update": 1710787112,
+                "last_update": 1710811915,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a",
-            "node2_pub": "0217890e3aad8d35bc054f43acc00084b25229ecff0ab68debd82883ad65ee8266"
+            "node1_pub": "031678745383bd273b4c3dbefc8ffbf4847d85c2f62d3407c0c980430b3257c403",
+            "node2_pub": "024a65932bdad1c4ef070289a6dd9f71b315e61d871b38c79339d0cc3d26e100e1"
         },
         {
-            "channel_id": "864673536444334081",
-            "chan_point": "a459faf334b335cb2fe4f4a0df75906d65ed341a0db67d217aed0e911d238779:1",
-            "last_update": 1710856840,
+            "channel_id": "771570190275051521",
+            "chan_point": "6b2d5942bdadd04f26ad4f7ee86cceabd68531f66c7b370d27e02d9222c02bd1:1",
+            "last_update": 1710819115,
+            "capacity": "1000000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "750",
+                "disabled": true,
+                "max_htlc_msat": "990000000",
+                "last_update": 1710819115,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "200",
+                "fee_rate_milli_msat": "200",
+                "disabled": false,
+                "max_htlc_msat": "990000000",
+                "last_update": 1648881967,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "031678745383bd273b4c3dbefc8ffbf4847d85c2f62d3407c0c980430b3257c403",
+            "node2_pub": "03d213f4115a55f0d0ab185434fcb6d3f119fdede11e901fe57f8b91d57ed316e6"
+        },
+        {
+            "channel_id": "887983182865104897",
+            "chan_point": "713685d0215c28e1ea8f56357459afb65fc86fd26075d2cc760589ab82f2f053:1",
+            "last_update": 1710842515,
             "capacity": "50000000",
             "node1_policy": {
-                "time_lock_delta": 119,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "728",
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710856840,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710842515,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710246269,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "031678745383bd273b4c3dbefc8ffbf4847d85c2f62d3407c0c980430b3257c403",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "756389233140760576",
+            "chan_point": "207b45f0cb6cb068b332bbdade71c936097d97277aafc212fea2548598398291:0",
+            "last_update": 1710393060,
+            "capacity": "250000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1000",
+                "disabled": true,
+                "max_htlc_msat": "247500000",
+                "last_update": 1710393060,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "100",
+                "disabled": false,
+                "max_htlc_msat": "247500000",
+                "last_update": 1662580373,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "024a65932bdad1c4ef070289a6dd9f71b315e61d871b38c79339d0cc3d26e100e1",
+            "node2_pub": "021227d4be948ab84613d5dbd47b6e148cfb811432d27eb92e80d28382b1b27d27"
+        },
+        {
+            "channel_id": "918390177017757696",
+            "chan_point": "d46c48c0d9410ab9597860b8ba10c14ed4c1d86338f80a7f7ff36ecf881269b3:0",
+            "last_update": 1710806052,
+            "capacity": "16770000",
+            "node1_policy": {
+                "time_lock_delta": 72,
+                "min_htlc": "1000",
+                "fee_base_msat": "2147483647",
+                "fee_rate_milli_msat": "2147483647",
+                "disabled": false,
+                "max_htlc_msat": "15093000000",
+                "last_update": 1710804699,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 140,
+                "min_htlc": "100",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "2500",
+                "disabled": false,
+                "max_htlc_msat": "1677000000",
+                "last_update": 1710806052,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "024729f3d5f7794f4df09bfdb7ca23a4fbe6c38997cdd213c694a2cca1c27cbb17",
+            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
+        },
+        {
+            "channel_id": "899069558556065792",
+            "chan_point": "9483b700e1dfa3512defbb27097dc48da750ae6ea07b3baeb3c1a34da4cdec52:0",
+            "last_update": 1710846357,
+            "capacity": "40000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "100",
+                "fee_rate_milli_msat": "10",
+                "disabled": true,
+                "max_htlc_msat": "39600000",
+                "last_update": 1710846357,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 80,
-                "min_htlc": "100000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10",
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
                 "disabled": false,
-                "max_htlc_msat": "49500000000",
-                "last_update": 1710836249,
+                "max_htlc_msat": "39600000",
+                "last_update": 1700598649,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a",
-            "node2_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226"
+            "node1_pub": "025dfb3926e67a64b45a164865a737ecfc37071d11ac4846b0d59c4979c8bb08b8",
+            "node2_pub": "0321743efb2d44a9c1ff8194f03728e119bbf6cde88201b9ac8e6e48f96c99d597"
         },
         {
-            "channel_id": "893283928513904641",
-            "chan_point": "ced9802a90b8d23d837295caad8133e13000d3c68d456e90d1a3a94d1f8f296c:1",
-            "last_update": 1710837891,
-            "capacity": "27044530",
+            "channel_id": "877726938508689409",
+            "chan_point": "5175773efb30bcae88dca5c47c6dcf8ba78b3fd8c31397d08db8f7b9e7e85019:1",
+            "last_update": 1710785354,
+            "capacity": "84803717",
+            "node1_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "1000",
+                "disabled": false,
+                "max_htlc_msat": "83955680000",
+                "last_update": 1710777182,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 222,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "2000",
+                "disabled": false,
+                "max_htlc_msat": "83955680000",
+                "last_update": 1710785354,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac",
+            "node2_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f"
+        },
+        {
+            "channel_id": "889215735335550977",
+            "chan_point": "6dafd3c899572ba7c9cb984fa9108c8a7eb1a93e46df25966fc17090f4a240c2:1",
+            "last_update": 1710776050,
+            "capacity": "1000000",
             "node1_policy": {
                 "time_lock_delta": 140,
                 "min_htlc": "100",
                 "fee_base_msat": "2000",
                 "fee_rate_milli_msat": "2500",
                 "disabled": false,
-                "max_htlc_msat": "26774085000",
-                "last_update": 1710837891,
+                "max_htlc_msat": "990000000",
+                "last_update": 1710776050,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 80,
+                "time_lock_delta": 222,
                 "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "10000",
-                "disabled": false,
-                "max_htlc_msat": "26774085000",
-                "last_update": 1710835344,
-                "custom_records": {}
-            },
-            "custom_records": {},
-            "node1_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226",
-            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
-        },
-        {
-            "channel_id": "855827965403856897",
-            "chan_point": "1e7166182957f07806f6b5a74122d9b4425aedf73e2a2a19cec3233835614fc2:1",
-            "last_update": 1710839861,
-            "capacity": "5000000",
-            "node1_policy": {
-                "time_lock_delta": 40,
-                "min_htlc": "9000",
                 "fee_base_msat": "1000",
-                "fee_rate_milli_msat": "19",
+                "fee_rate_milli_msat": "2000",
                 "disabled": false,
-                "max_htlc_msat": "2500000000",
-                "last_update": 1710839861,
-                "custom_records": {}
-            },
-            "node2_policy": {
-                "time_lock_delta": 80,
-                "min_htlc": "1000",
-                "fee_base_msat": "0",
-                "fee_rate_milli_msat": "900",
-                "disabled": false,
-                "max_htlc_msat": "4950000000",
-                "last_update": 1710779805,
+                "max_htlc_msat": "990000000",
+                "last_update": 1710772753,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226",
-            "node2_pub": "02b61154d89b98662f4c58e1005963e918da6a8fdb5adbea85ad22a20b8e7fc0ad"
+            "node1_pub": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac",
+            "node2_pub": "0335e4265f783f37378e969c6a123557cf5d22cc97ec42ea3abff5dfaa64afea83"
         },
         {
-            "channel_id": "792726993058267136",
-            "chan_point": "2b1e5c37414fb6b2c37534892a8de1b5a080814c28bc4b598425c6382a02a319:0",
-            "last_update": 1710775854,
-            "capacity": "10000000",
+            "channel_id": "861583908627218433",
+            "chan_point": "21c74ee01ff0eda80631adcb10469619adecd70f3d937d27d4fec60f0225019d:1",
+            "last_update": 1710856349,
+            "capacity": "3000000",
             "node1_policy": {
-                "time_lock_delta": 34,
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "159",
+                "disabled": false,
+                "max_htlc_msat": "2970000000",
+                "last_update": 1710856349,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 222,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "2000",
+                "disabled": false,
+                "max_htlc_msat": "2970000000",
+                "last_update": 1710795398,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac",
+            "node2_pub": "03382704812aca55bf853b353ecd3edef7e16a9420d7beb7e7d6b6c7fe2082252a"
+        },
+        {
+            "channel_id": "907088297038446592",
+            "chan_point": "6a5795e372ac56b4555dcc179a1f125d39f2f48800f079cd3ef8584cafae4817:0",
+            "last_update": 1710848353,
+            "capacity": "100000000",
+            "node1_policy": {
+                "time_lock_delta": 144,
                 "min_htlc": "1",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "999",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710774858,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 222,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "2000",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710848353,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03d607f3e69fd032524a867b288216bfab263b6eaee4e07783799a6fe69bb84fac",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "737654654585667584",
+            "chan_point": "0bebc81ceefe54c2568e4b762f2878eb4e7a85514f9346ba4352034521447269:0",
+            "last_update": 1710812050,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 37,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1700",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710786335,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 140,
+                "min_htlc": "1000",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "2500",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710812050,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
+            "node2_pub": "0335e4265f783f37378e969c6a123557cf5d22cc97ec42ea3abff5dfaa64afea83"
+        },
+        {
+            "channel_id": "894843035960147968",
+            "chan_point": "cfcfe8f1dc8cf0f20a6292facfc00d7e820e89cff3de64bd057801fc3ec3fc8d:0",
+            "last_update": 1710757535,
+            "capacity": "100000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
                 "fee_base_msat": "1000",
                 "fee_rate_milli_msat": "1000",
                 "disabled": false,
-                "max_htlc_msat": "9900000000",
-                "last_update": 1710404331,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710757535,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710312917,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "884413068699238401",
+            "chan_point": "92dcfce24fc43ea96273efbe4304ea5a2f34c69ab8067d06bea37b3436926cad:1",
+            "last_update": 1710816935,
+            "capacity": "550000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1000",
+                "disabled": false,
+                "max_htlc_msat": "544500000",
+                "last_update": 1710816935,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "544500000",
+                "last_update": 1710801275,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "028d98b9969fbed53784a36617eb489a59ab6dc9b9d77fcdca9ff55307cd98e3c4",
+            "node2_pub": "03ea17fd97ca7382a192dd4533c8e95ca946ef0827b14984e682af699bcaeb5a53"
+        },
+        {
+            "channel_id": "892859516987572224",
+            "chan_point": "726039ab50c25e38a2df12dc67394879c36bb8420dc481b843d0833c8ee93303:0",
+            "last_update": 1710835918,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710802736,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710835918,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "021cb32426ed1a6be9533801e7c56a70ffc1c360a3a31819c3ae0a72e141d78000",
+            "node2_pub": "0328946a0693c2a4dd7e5afc2ce2e020c54e07d6693a293b4e1c1fd7e2d09a3eeb"
+        },
+        {
+            "channel_id": "907853557235646464",
+            "chan_point": "72d24dea72f3e930a219cfccfa352cc10040d1bcf49db365025d263e82c7de83:0",
+            "last_update": 1710776927,
+            "capacity": "50000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "50",
+                "disabled": false,
+                "max_htlc_msat": "49500000",
+                "last_update": 1710776927,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "49500000",
+                "last_update": 1710630223,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03919a0a495cfd08779a3c23168827243cabe597e8ee5ea0c7827b6c407e260fe2",
+            "node2_pub": "02626318f968469fb1dcd0453536bbabaab8861be75d8cde7900e57aab1bd4f3ac"
+        },
+        {
+            "channel_id": "763639412848394241",
+            "chan_point": "490f8ac59304fd951b06e6b56e07fba5623ccf567ed5ec0aa0f00f994a80995d:1",
+            "last_update": 1710846930,
+            "capacity": "100000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1",
+                "fee_rate_milli_msat": "100",
+                "disabled": false,
+                "max_htlc_msat": "99000000",
+                "last_update": 1709509568,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "10",
+                "disabled": false,
+                "max_htlc_msat": "99000000",
+                "last_update": 1710846930,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02626318f968469fb1dcd0453536bbabaab8861be75d8cde7900e57aab1bd4f3ac",
+            "node2_pub": "03b9de7a7d7e8a474b859a59e314cf2a143ae9c569ce78c46289b3ad16cb8c03f9"
+        },
+        {
+            "channel_id": "855546490317897729",
+            "chan_point": "e1998ecf9d5bdf045a2b2e0fc868cb66532bc8e3c3910fac54039cb72e7b666b:1",
+            "last_update": 1710789782,
+            "capacity": "1100000",
+            "node1_policy": {
+                "time_lock_delta": 200,
+                "min_htlc": "1000",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "2000",
+                "disabled": false,
+                "max_htlc_msat": "1089000000",
+                "last_update": 1710789782,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1089000000",
+                "last_update": 1710777136,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "035fcbf3d34c71ffe7404c5660242f9289991021cc3d52098d0038f839552365a3",
+            "node2_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f"
+        },
+        {
+            "channel_id": "817245002822582272",
+            "chan_point": "4f774c8da0276be4aa4a488bff1877f1f0d42ce6d919b294d401ae9fceb5402b:0",
+            "last_update": 1710845182,
+            "capacity": "60000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "59400000",
+                "last_update": 1710845182,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "100",
+                "disabled": false,
+                "max_htlc_msat": "59400000",
+                "last_update": 1710775336,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "035fcbf3d34c71ffe7404c5660242f9289991021cc3d52098d0038f839552365a3",
+            "node2_pub": "035d681f3696fc5039d304c621f6f39ba6e0aa0ad482065417720d4f820f8dcb0e"
+        },
+        {
+            "channel_id": "858923090495012865",
+            "chan_point": "6ecf4b8b50ffcaa4180c686d37ac2f7d5208a385b3ff6cdfacd7bd49b0795716:1",
+            "last_update": 1710780782,
+            "capacity": "650000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "643500000",
+                "last_update": 1710775476,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "1000",
+                "disabled": false,
+                "max_htlc_msat": "643500000",
+                "last_update": 1710780782,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f",
+            "node2_pub": "0209a06852f1257d70e5cea44a0919871fa20859eb33a62445f774e9fe96247a75"
+        },
+        {
+            "channel_id": "837860845868220417",
+            "chan_point": "3188e2c87379e1784b904fc4ee2f6e75d846d87a9b8dd1db0e5217c11d8ce4ea:1",
+            "last_update": 1710775382,
+            "capacity": "3500000",
+            "node1_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "500",
+                "fee_rate_milli_msat": "1000",
+                "disabled": true,
+                "max_htlc_msat": "3465000000",
+                "last_update": 1710775382,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "3465000000",
+                "last_update": 1710537660,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f",
+            "node2_pub": "033f481fe0e9344228b58e0297162bfa8d648d5043c12b6323df5eac61bd39094c"
+        },
+        {
+            "channel_id": "861833497883574273",
+            "chan_point": "0482621aeb0de1762640b99dfc600326903a52d11c8dcdf02a5e5d2652732c8f:1",
+            "last_update": 1710843782,
+            "capacity": "20000000",
+            "node1_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "4000",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710843782,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "19800000000",
+                "last_update": 1710773696,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "030c3f19d742ca294a55c00376b3b355c3c90d61c6b6b39554dbc7ac19b141c14f",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "840309458235949057",
+            "chan_point": "012e468c6298ff7a689d671bfca97387e45ab7a7b6e7fc3dbfa46e55a95c6b59:1",
+            "last_update": 1710825499,
+            "capacity": "2000000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710825118,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "10000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "90",
+                "disabled": false,
+                "max_htlc_msat": "1980000000",
+                "last_update": 1710825499,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03440f4dd43f5e30ffa0fd37eb99e2c27241d71e4fc5b3ea1e9c04a289a51c7ae0",
+            "node2_pub": "0328946a0693c2a4dd7e5afc2ce2e020c54e07d6693a293b4e1c1fd7e2d09a3eeb"
+        },
+        {
+            "channel_id": "826733788095447041",
+            "chan_point": "dffc24350df473a58d4715c31f8ed35a7440387dbf59e16895a01a79c3d64ce2:1",
+            "last_update": 1710805699,
+            "capacity": "1000000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "10000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "90",
+                "disabled": false,
+                "max_htlc_msat": "1000000000",
+                "last_update": 1710805699,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "800000000",
+                "last_update": 1710798104,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03440f4dd43f5e30ffa0fd37eb99e2c27241d71e4fc5b3ea1e9c04a289a51c7ae0",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "909819483881668608",
+            "chan_point": "735fca87374ceba0dff8adec0bffafb1a870638f79f2b44246f1686644d8cdc9:0",
+            "last_update": 1710783381,
+            "capacity": "200000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "30",
+                "disabled": true,
+                "max_htlc_msat": "198000000",
+                "last_update": 1710783323,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "100",
+                "fee_rate_milli_msat": "100",
+                "disabled": true,
+                "max_htlc_msat": "198000000",
+                "last_update": 1710783381,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03eaf4f94ad680855a7818c2f156ae4a86482dea2f396320c336989ce5f49da880",
+            "node2_pub": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972"
+        },
+        {
+            "channel_id": "900662750928764928",
+            "chan_point": "c5babe10624dc1f24fd3e20eb59d0e6dbfc7dedf1ea0eaccb70f55a7abf3b38c:0",
+            "last_update": 1710844661,
+            "capacity": "100000000",
+            "node1_policy": {
+                "time_lock_delta": 140,
+                "min_htlc": "100",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "2500",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710844661,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "999",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710009152,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02535215135eb832df0f9858ff775bd4ae0b8911c59e2828ff7d03b535b333e149",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "838462278610059264",
+            "chan_point": "6a7091a5715eda464ead722f2acbc4c5c1aeddab5fd4ae44c1ae9025b7f1d6d2:0",
+            "last_update": 1710846461,
+            "capacity": "50000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "0",
+                "disabled": false,
+                "max_htlc_msat": "49500000000",
+                "last_update": 1710846461,
                 "custom_records": {}
             },
             "node2_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "0",
-                "fee_rate_milli_msat": "500",
+                "fee_rate_milli_msat": "0",
                 "disabled": false,
-                "max_htlc_msat": "10000000000",
-                "last_update": 1710775854,
+                "max_htlc_msat": "49500000000",
+                "last_update": 1710771291,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226",
-            "node2_pub": "02f97f34b35a34142321a3a0c1ad4ef576be6895fdfe4ef72ff45ccef406f14a54"
+            "node1_pub": "02535215135eb832df0f9858ff775bd4ae0b8911c59e2828ff7d03b535b333e149",
+            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
         },
         {
-            "channel_id": "765730683991425025",
-            "chan_point": "3d2ab7137bc005193d6ca9d78b9de21c88b4f6bd0e1d259feae4eb5786c96915:1",
-            "last_update": 1710799709,
+            "channel_id": "846395255002038273",
+            "chan_point": "ee07f74fc67ad1534106327880fae377fe91c9c7776f9d46699d28f99e9684c5:1",
+            "last_update": 1710848050,
             "capacity": "10000000",
             "node1_policy": {
                 "time_lock_delta": 80,
                 "min_htlc": "1000",
                 "fee_base_msat": "0",
-                "fee_rate_milli_msat": "300",
+                "fee_rate_milli_msat": "0",
                 "disabled": false,
                 "max_htlc_msat": "9900000000",
-                "last_update": 1710786654,
+                "last_update": 1710788861,
                 "custom_records": {}
             },
             "node2_policy": {
-                "time_lock_delta": 100,
+                "time_lock_delta": 80,
                 "min_htlc": "1000",
-                "fee_base_msat": "490",
-                "fee_rate_milli_msat": "368",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "0",
                 "disabled": false,
                 "max_htlc_msat": "9900000000",
-                "last_update": 1710799709,
+                "last_update": 1710848050,
                 "custom_records": {}
             },
             "custom_records": {},
-            "node1_pub": "035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226",
-            "node2_pub": "03fbe1c1baedbc99b2642ae524d9c2a6f12b771a3ab91e0f56ca6efc6f7f7d53b6"
+            "node1_pub": "02535215135eb832df0f9858ff775bd4ae0b8911c59e2828ff7d03b535b333e149",
+            "node2_pub": "0335e4265f783f37378e969c6a123557cf5d22cc97ec42ea3abff5dfaa64afea83"
+        },
+        {
+            "channel_id": "898725411427385345",
+            "chan_point": "96fe24d1c0ae58e89df72f3a0898f2bacc0dd58d11938325a54c46ad7b728804:1",
+            "last_update": 1710856837,
+            "capacity": "1000000",
+            "node1_policy": {
+                "time_lock_delta": 50,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "10",
+                "disabled": false,
+                "max_htlc_msat": "50000000",
+                "last_update": 1710856837,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "600",
+                "disabled": false,
+                "max_htlc_msat": "990000000",
+                "last_update": 1710832983,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02841286ba5314ac9a4a29eb8d558b30fec348f22e22351ff8896288dede68e6a7",
+            "node2_pub": "03382704812aca55bf853b353ecd3edef7e16a9420d7beb7e7d6b6c7fe2082252a"
+        },
+        {
+            "channel_id": "910155934451761152",
+            "chan_point": "888c6225644dc0f6fa8d22807a3cf9acb99bc1558806e6b2d5f15dad6cacfb59:0",
+            "last_update": 1710834571,
+            "capacity": "250000",
+            "node1_policy": {
+                "time_lock_delta": 50,
+                "min_htlc": "1000",
+                "fee_base_msat": "100",
+                "fee_rate_milli_msat": "10",
+                "disabled": false,
+                "max_htlc_msat": "50000000",
+                "last_update": 1710782196,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "30",
+                "disabled": false,
+                "max_htlc_msat": "247500000",
+                "last_update": 1710834571,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "02841286ba5314ac9a4a29eb8d558b30fec348f22e22351ff8896288dede68e6a7",
+            "node2_pub": "03c7ec8ecec5386a6ce9476d8d55fa5bb22d113dce7c1c47c7df71b1741ffde972"
+        },
+        {
+            "channel_id": "885818244503437313",
+            "chan_point": "0a0ac608d703bb383fd51e2ef0eebfb40e737d916f4e7810785ec8b9f7915d4e:1",
+            "last_update": 1710611588,
+            "capacity": "700000",
+            "node1_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "315000000",
+                "last_update": 1710558538,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": true,
+                "max_htlc_msat": "315000000",
+                "last_update": 1710611588,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "033f481fe0e9344228b58e0297162bfa8d648d5043c12b6323df5eac61bd39094c",
+            "node2_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        },
+        {
+            "channel_id": "899068459022417920",
+            "chan_point": "f8751c293cfefc7e80bb4ae6c452ce17d33541ef420081b913ffc985ec246c16:0",
+            "last_update": 1710780553,
+            "capacity": "51000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "50490000",
+                "last_update": 1700598649,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1234",
+                "fee_rate_milli_msat": "1",
+                "disabled": true,
+                "max_htlc_msat": "50490000",
+                "last_update": 1710780553,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "0321743efb2d44a9c1ff8194f03728e119bbf6cde88201b9ac8e6e48f96c99d597",
+            "node2_pub": "039157862ec407b1aa2353d879279916e76c8d2fcc4ac10d3f225972c8e58fbc43"
+        },
+        {
+            "channel_id": "846395255027269632",
+            "chan_point": "7fc299cd258401fef62f746434cefa05d42cd8895eec4f65d435ec2cd3bb3ec5:0",
+            "last_update": 1710848050,
+            "capacity": "20000000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "0",
+                "disabled": false,
+                "max_htlc_msat": "19800000000",
+                "last_update": 1710787491,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "0",
+                "disabled": false,
+                "max_htlc_msat": "19800000000",
+                "last_update": 1710848050,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "0335e4265f783f37378e969c6a123557cf5d22cc97ec42ea3abff5dfaa64afea83",
+            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
+        },
+        {
+            "channel_id": "917416009602236416",
+            "chan_point": "10f782b804347657cdb925866a7b9616f15dd8fd203b3de709245ecc808939a7:0",
+            "last_update": 1710785691,
+            "capacity": "99995000",
+            "node1_policy": {
+                "time_lock_delta": 140,
+                "min_htlc": "100",
+                "fee_base_msat": "2000",
+                "fee_rate_milli_msat": "2500",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710785691,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 144,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "499",
+                "disabled": false,
+                "max_htlc_msat": "20000000000",
+                "last_update": 1710265468,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+            "node2_pub": "027cd974e47086291bb8a5b0160a889c738f2712a703b8ea939985fd16f3aae67e"
+        },
+        {
+            "channel_id": "865735664596090880",
+            "chan_point": "317d529be3e15cccad634f20811a98c2ba686188b9cad9803a322e8b29c5e4bc:0",
+            "last_update": 1710845901,
+            "capacity": "75000",
+            "node1_policy": {
+                "time_lock_delta": 80,
+                "min_htlc": "1000",
+                "fee_base_msat": "0",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "74250000",
+                "last_update": 1710845901,
+                "custom_records": {}
+            },
+            "node2_policy": {
+                "time_lock_delta": 40,
+                "min_htlc": "1000",
+                "fee_base_msat": "1000",
+                "fee_rate_milli_msat": "1",
+                "disabled": false,
+                "max_htlc_msat": "74250000",
+                "last_update": 1710845871,
+                "custom_records": {}
+            },
+            "custom_records": {},
+            "node1_pub": "039157862ec407b1aa2353d879279916e76c8d2fcc4ac10d3f225972c8e58fbc43",
+            "node2_pub": "03382704812aca55bf853b353ecd3edef7e16a9420d7beb7e7d6b6c7fe2082252a"
         }
     ]
 }


### PR DESCRIPTION
LND graph files label this field pub_key, but we were previously generating sub-graphs with a library that output id instead. Updating this to perfectly fit lnd's describegraph output.

This commit also updates to use latest reduced versions of the graph in tests (LN 10/100) which have pub_key rather than ID.