### PR TITLE
add: addrman-observer support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include src/schema/*.json
 include src/templates/bitcoin.conf
 include src/templates/fork_observer_config.toml
+include src/templates/addrman_observer_config.toml
 include src/templates/addrman.patch
 include src/templates/isroutable.patch
 graft src/templates/k8s

--- a/src/templates/addrman_observer_config.toml
+++ b/src/templates/addrman_observer_config.toml
@@ -1,0 +1,8 @@
+# addrman-observer base configuration file
+
+# path to the location of the static www files
+www_path = "./www"
+
+# webserver listen address
+address = "0.0.0.0:3882"
+

--- a/src/warnet/services.py
+++ b/src/warnet/services.py
@@ -1,4 +1,5 @@
 FO_CONF_NAME = "fork_observer_config.toml"
+AO_CONF_NAME = "addrman_observer_config.toml"
 GRAFANA_PROVISIONING = "grafana-provisioning"
 PROM_CONF_NAME = "prometheus.yml"
 
@@ -32,6 +33,14 @@ services = {
         "warnet_port": "23001",
         "container_port": "2323",
         "config_files": [f"{FO_CONF_NAME}:/app/config.toml"],
+    },
+    "addrmanobserver": {
+        "backends": ["compose"],
+        "image": "b10c/addrman-observer:latest",
+        "container_name_suffix": "addrman-observer",
+        "warnet_port": "23005",
+        "container_port": "3882",
+        "config_files": [f"{AO_CONF_NAME}:/app/config.toml"],
     },
     "grafana": {
         "backends": ["compose"],

--- a/test/data/services.graphml
+++ b/test/data/services.graphml
@@ -15,7 +15,7 @@
   <key id="source_policy"   attr.name="source_policy"    attr.type="string"   for="edge" />
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
   <graph edgedefault="directed">
-    <data key="services">cadvisor forkobserver grafana nodeexporter prometheus</data>
+    <data key="services">cadvisor forkobserver addrmanobserver grafana nodeexporter prometheus</data>
     <node id="0">
         <data key="version">26.0</data>
         <data key="bitcoin_config">-uacomment=w0 -debug=validation</data>

--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -70,6 +70,15 @@ if base.backend == "compose":
     else:
         raise Exception("forkobserver not OK")
 
+    node_id = 0
+    ao_res = requests.get(f"http://localhost:23005/{node_id}")
+    assert ao_res.status_code == 200
+    addrman = ao_res.json()
+    if "new" in addrman and "tried" in addrman:
+        print("forkobserver OK")
+    else:
+        raise Exception("addrmanobserver not OK")
+
     grafana_res = requests.get("http://localhost:23002/api/datasources/uid/prometheusdatasource/health")
     assert grafana_res.status_code == 200
     health = grafana_res.json()

--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -75,7 +75,7 @@ if base.backend == "compose":
     assert ao_res.status_code == 200
     addrman = ao_res.json()
     if "new" in addrman and "tried" in addrman:
-        print("forkobserver OK")
+        print("addrmanobserver OK")
     else:
         raise Exception("addrmanobserver not OK")
 


### PR DESCRIPTION
Adds an [addrman-observer](https://github.com/0xb10c/addrman-observer) service and tests. While the addrman-observer front-end is still WIP, it should be usable for warnet.

On the frontend, you should be able to add `?url=<tank_id>` to load the addrman of that tank. The same thing should also work with the `fetch from URL` and tank names.