### PR TITLE
Add option --exclude=[] to network export

### DIFF
--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -77,7 +77,8 @@ class KubernetesBackend(BackendInterface):
 
         for service_name in warnet.services:
             if "k8s" in services[service_name]["backends"]:
-                self.client.delete_namespaced_pod(f'{services[service_name]["container_name_suffix"]}-service', self.namespace)
+                self.client.delete_namespaced_pod(services[service_name]["container_name_suffix"], self.namespace)
+                self.client.delete_namespaced_service(f'{services[service_name]["container_name_suffix"]}-service', self.namespace)
 
         return True
 

--- a/src/cli/network.py
+++ b/src/cli/network.py
@@ -2,6 +2,7 @@ import base64  # noqa: I001
 from pathlib import Path
 
 import click
+import json
 from rich import print
 from rich.console import Console
 from rich.table import Table
@@ -144,10 +145,13 @@ def connected(network: str):
 @network.command()
 @click.option("--network", default="warnet", show_default=True)
 @click.option("--activity", type=str)
-def export(network: str, activity: str):
+@click.option("--exclude", type=str, default="[]")
+def export(network: str, activity: str, exclude: str):
     """
     Export all [network] data for a "simln" service running in a container
     on the network. Optionally add JSON string [activity] to simln config.
+    Optionally provide a list of tank indexes to [exclude].
     Returns True on success.
     """
-    print(rpc_call("network_export", {"network": network, "activity": activity}))
+    exclude = json.loads(exclude)
+    print(rpc_call("network_export", {"network": network, "activity": activity, "exclude": exclude}))

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -270,7 +270,7 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
-    def network_export(self, network: str, activity: str | None) -> bool:
+    def network_export(self, network: str, activity: str | None, exclude: list[int]) -> bool:
         """
         Export all data for a simln container running on the network
         """
@@ -286,7 +286,7 @@ class Server:
         tar_buffer = io.BytesIO()
         with tarfile.open(fileobj=tar_buffer, mode="w") as tar_file:
             # tank LN nodes add their credentials to tar archive
-            wn.export(config, tar_file)
+            wn.export(config, tar_file, exclude=exclude)
             # write config file
             config_bytes = json.dumps(config).encode('utf-8')
             config_stream = io.BytesIO(config_bytes)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -238,9 +238,10 @@ class Warnet:
         except Exception as e:
             logger.error(f"An error occurred while writing to {prometheus_path}: {e}")
 
-    def export(self, config: object, tar_file):
+    def export(self, config: object, tar_file, exclude: list[int]):
         for tank in self.tanks:
-            tank.export(config, tar_file)
+            if tank.index not in exclude:
+                tank.export(config, tar_file)
 
     def wait_for_health(self):
         self.container_interface.wait_for_healthy_tanks(self)


### PR DESCRIPTION
Closes https://github.com/carlaKC/attackathon/issues/19
Closes https://github.com/bitcoin-dev-project/warnet/issues/339

Excludes tanks from simln configuration by tank index. Syntax example:

`warcli network export --exclude=[1,23,49,86]`

Argument is a string that is json-parsed into an array of integers