### PR TITLE
make `just start` run warnet-rpc:latest

### DIFF
--- a/src/templates/rpc/entrypoint.sh
+++ b/src/templates/rpc/entrypoint.sh
@@ -9,9 +9,9 @@ echo "Checking for mounted source code at ${SOURCE_DIR}..."
 
 check_setup_toml() {
     if [ -f "${SOURCE_DIR}/pyproject.toml" ]; then
-        return 0
-    else
         return 1
+    else
+        return 0
     fi
 }
 


### PR DESCRIPTION
**Issue** 

When I run `just start` on my vm, it fails.

<details><summary>$ kubectl describe pod rpc-0</summary>

```
Name:             rpc-0
Namespace:        warnet
Priority:         0
Service Account:  default
Node:             minikube/192.168.49.2
Start Time:       Fri, 19 Apr 2024 18:58:23 +0000
Labels:           apps.kubernetes.io/pod-index=0
                  controller-revision-hash=rpc-7bd75bbd77
                  io.kompose.service=rpc
                  statefulset.kubernetes.io/pod-name=rpc-0
Annotations:      <none>
Status:           Running
IP:               10.244.0.2
IPs:
  IP:           10.244.0.2
Controlled By:  StatefulSet/rpc
Containers:
  warnet-rpc:
    Container ID:   docker://d71a80f8b79a0da95e108f6242a8552f200bbcfad5fee08f7ad9faf612139378
    Image:          bitcoindevproject/warnet-rpc:dev
    Image ID:       docker-pullable://bitcoindevproject/warnet-rpc@sha256:a94f9b872c52414b0dffcc255c8b02386c037476b0ef66267d1c36c83066b381
    Port:           9276/TCP
    Host Port:      0/TCP
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    127
      Started:      Fri, 19 Apr 2024 19:02:56 +0000
      Finished:     Fri, 19 Apr 2024 19:03:26 +0000
    Ready:          False
    Restart Count:  5
    Liveness:       exec [/bin/bash -c /root/warnet/src/templates/rpc/livenessProbe.sh] delay=20s timeout=1s period=5s #success=1 #failure=3
    Readiness:      http-get http://:9276/-/healthy delay=1s timeout=2s period=2s #success=1 #failure=2
    Environment:    <none>
    Mounts:
      /root/warnet from source-code (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-k7gmc (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             False 
  ContainersReady   False 
  PodScheduled      True 
Volumes:
  source-code:
    Type:          HostPath (bare host directory volume)
    Path:          /mnt/src
    HostPathType:  Directory
  kube-api-access-k7gmc:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  6m16s                  default-scheduler  Successfully assigned warnet/rpc-0 to minikube
  Normal   Pulled     6m11s                  kubelet            Successfully pulled image "bitcoindevproject/warnet-rpc:dev" in 4.858s (4.858s including waiting)
  Normal   Created    6m10s                  kubelet            Created container warnet-rpc
  Normal   Started    6m9s                   kubelet            Started container warnet-rpc
  Warning  Unhealthy  5m41s (x2 over 5m46s)  kubelet            Liveness probe failed: /bin/bash: line 1: /root/warnet/src/templates/rpc/livenessProbe.sh: No such file or directory
  Normal   Pulling    5m39s (x2 over 6m15s)  kubelet            Pulling image "bitcoindevproject/warnet-rpc:dev"
  Normal   Pulled     5m38s                  kubelet            Successfully pulled image "bitcoindevproject/warnet-rpc:dev" in 696ms (696ms including waiting)
  Warning  Unhealthy  74s (x103 over 6m8s)   kubelet            Readiness probe failed: Get "http://10.244.0.2:9276/-/healthy": dial tcp 10.244.0.2:9276: connect: connection refused
```

</details>

**Cause**

Currently, `just start` (and also `just startd`) runs the warnet-rpc:dev container and the accompanying liveness probe and volume configurations.

**Solution**

Point `just start` to `warnet-rpc-statefulset.yaml` which pulls in `warnet-rpc:latest`

**Results**

I tested running warnet with my tweak, and it works great.