### PR TITLE
sort import to make ruff happy

### DIFF
--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -14,7 +14,7 @@ from kubernetes.client.models.v1_pod import V1Pod
 from kubernetes.client.models.v1_service import V1Service
 from kubernetes.client.rest import ApiException
 from kubernetes.dynamic import DynamicClient
-from kubernetes.dynamic.exceptions import ResourceNotFoundError, NotFoundError
+from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from kubernetes.stream import stream
 from warnet.services import services
 from warnet.status import RunningStatus


### PR DESCRIPTION
# Issue

Current CI is failing because ruff is unhappy that some of our imports are unsorted.

# Solution

Perform a `ruff --fix` to sort the imports.
