### PR TITLE
enable sync_all via base class

### DIFF
--- a/src/warnet/test_framework_bridge.py
+++ b/src/warnet/test_framework_bridge.py
@@ -37,9 +37,6 @@ class WarnetTestFramework(BitcoinTestFramework):
     def run_test(self):
         pass
 
-    def sync_all(self):
-        pass
-
     def handle_sigterm(self, signum, frame):
         print("SIGTERM received, stopping...")
         self.shutdown()


### PR DESCRIPTION
# Issue
Calling `sync_all()` from within a scenario does nothing.

# Cause
`WarnetTestFramework` explicitly `pass`es on `sync_all()`.

# Solution
Enable `sync_all()` by removing it from `WarnetTestFramework` which exposes it via the base class `BitcoinTestFramework`. 