### PR TITLE
reduce the goods by one

### DIFF
--- a/src/scenarios/ln_init.py
+++ b/src/scenarios/ln_init.py
@@ -35,7 +35,7 @@ class LNInit(WarnetTestFramework):
         # 298 block base
         self.generatetoaddress(self.nodes[0], 297, miner_addr)
         # divvy up the goods
-        split = miner.getbalance() // len(recv_addrs)
+        split = (miner.getbalance() - 1) // len(recv_addrs)
         sends = {}
         for addr in recv_addrs:
             sends[addr] = split


### PR DESCRIPTION
# Issue
Sometimes the `ln_init` routine fails with an error about insufficient funds.

# Cause
The `ln_init.py` process will fail due to insufficient funds if the number of coins it generates is evenly divisible relative to the number of recipients. This leaves the wallet without any money for fees.

# Solution
Set aside one bitcoin before dividing up the goods.