### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: deploy
+
+on:
+  workflow_run:
+    workflows: ["test"]
+    types:
+      - completed
+
+jobs:
+  deploy-to-dockerhub:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_RPC_REPO }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            maintainer=bitcoindevproject
+            org.opencontainers.image.title=warnet-rpc
+            org.opencontainers.image.description=Warnet RPC server
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push production RPC image
+        uses: docker/build-push-action@v5
+        with:
+          file: src/templates/rpc/Dockerfile_rpc
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build and push dev RPC image
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          file: src/templates/rpc/Dockerfile_rpc_dev
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_RPC_REPO }}:dev
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: test
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
-  build:
+  build-image:
     needs: [ruff]
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
           name: warnet
           path: /tmp/warnet.tar
   test:
-    needs: [build]
+    needs: [build-image]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -56,59 +56,9 @@ jobs:
       - name: Run tests
         run: ./test/${{matrix.test}} ${{matrix.backend}}
   build-test:
-    needs: [build, test]
+    needs: [build-image]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/compose
       - run: ./test/build_branch_test.py compose
-  deploy:
-    needs: [build-test]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_RPC_REPO }}
-          tags: |
-            type=ref,event=tag
-            type=ref,event=pr
-            type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            maintainer=bitcoindevproject
-            org.opencontainers.image.title=warnet-rpc
-            org.opencontainers.image.description=Warnet RPC server
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push production RPC image
-        uses: docker/build-push-action@v5
-        with:
-          file: src/templates/rpc/Dockerfile_rpc
-          platforms: linux/amd64,linux/arm64
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Build and push dev RPC image
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v5
-        with:
-          file: src/templates/rpc/Dockerfile_rpc_dev
-          platforms: linux/amd64,linux/arm64
-          context: .
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_RPC_REPO }}:dev
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
Splits our single workflow into two. This means that we can use `on: pull_request`, which works much better™️  with other actions (like checkout).

It also means (I think) that PRs which themselves modify the workflow(s), should be exercised _in the PR_ (unconfirmed, but I think it should work like that), which grant has been running into a few times recently...

The rationale for `on: pull_request_target` was that the github token given to `on: pull_request` does not have enough permissions to read repo secrets and things, so it could not deploy. This is not so with `pull_request_target`.

By splitting deploy into `on: workflow`, the token its natively given has the appropriate permissions.

The image from the `build` job is shared with the `test` job in the same workflow as an artifact. It is not shared directly (e.g. as an artifact) with the `deploy` workflow, but the build steps use a shared cache (see `cache_from` and `cache_to`), which achieves basically the same result.