### PR TITLE
clean up backend types and return values

### DIFF
--- a/src/backends/backend_interface.py
+++ b/src/backends/backend_interface.py
@@ -103,21 +103,21 @@ class BackendInterface(ABC):
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
-    def get_tank_ipv4(self, index: int) -> str:
+    def get_tank_ipv4(self, index: int) -> str | None:
         """
         Get the ipv4 address assigned to a bitcoind tank from the backend
         """
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
-    def get_tank_dns_addr(self, index: int) -> str:
+    def get_tank_dns_addr(self, index: int) -> str | None:
         """
         Get the dns address of the tank (consistent with `getpeerinfo`'s addr field)
         """
         raise NotImplementedError("This method should be overridden by child class")
 
     @abstractmethod
-    def get_tank_ip_addr(self, index: int) -> str:
+    def get_tank_ip_addr(self, index: int) -> str | None:
         """
         Get the ip address of the tank (consistent with `getpeerinfo`'s addr field)
         """

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -109,7 +109,7 @@ class ComposeBackend(BackendInterface):
             case _:
                 raise Exception("Unsupported service type")
 
-    def get_container(self, tank_index: int, service: ServiceType) -> Container:
+    def get_container(self, tank_index: int, service: ServiceType) -> Container | None:
         container_name = self.get_container_name(tank_index, service)
         if len(self.client.containers.list(filters={"name": container_name})) == 0:
             return None
@@ -177,18 +177,18 @@ class ComposeBackend(BackendInterface):
         out = out[: stat["size"]]
         return out
 
-    def get_tank_ipv4(self, index: int) -> str:
+    def get_tank_ipv4(self, index: int) -> str | None:
         c = self.get_container(index, ServiceType.BITCOIN)
         if c:
             return self.get_ipv4_address(c)
         else:
             return None
 
-    def get_tank_ip_addr(self, index: int) -> str:
-        self.get_tank_ipv4(index)
+    def get_tank_ip_addr(self, index: int) -> str | None:
+        return self.get_tank_ipv4(index)
 
-    def get_tank_dns_addr(self, index: int) -> str:
-        self.get_tank_ip_addr(index)
+    def get_tank_dns_addr(self, index: int) -> str | None:
+        return self.get_tank_ip_addr(index)
 
     def get_messages(self, a_index: int, b_index: int, bitcoin_network: str = "regtest"):
         # Find the ip of peer B

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -554,7 +554,7 @@ class KubernetesBackend(BackendInterface):
             ),
         )
 
-    def get_tank_ipv4(self, index: int) -> str:
+    def get_tank_ipv4(self, index: int) -> str | None:
         pod_name = self.get_pod_name(index, ServiceType.BITCOIN)
         pod = self.get_pod(pod_name)
         if pod:


### PR DESCRIPTION
### Issue
Getting type errors when running PyCharm's automated checker. Some related to #371.

### Cause
The inconsistent types and return values exist but do not trigger any tests.

### Solution
Update the types and return values as appropriate.