### PR TITLE
add helm to quick_start

### DIFF
--- a/quick_start.sh
+++ b/quick_start.sh
@@ -96,6 +96,14 @@ else
     exit 1
 fi
 
+helm_path=$(command -v helm || true)
+if [ -n "$helm_path" ]; then
+    print_partial_message " ⭐️ Found " "helm" ": $helm_path" "$BOLD"
+else
+    print_partial_message " 💥 Could not find " "helm" ". Please follow this link to install it..." "$BOLD"
+    print_message "" "   https://helm.sh/docs/intro/install/" "$BOLD"
+    exit 127
+fi
 
 just_path=$(command -v just || true)
 if [ -n "$just_path" ]; then


### PR DESCRIPTION
### Issue
Logging does not work when using `quick_start.sh`

### Cause
`quick_start.sh` does not help the user install `helm`

### Solution
Add `helm` to `quick_start.sh`