### PR TITLE
Allow asserting againt TestBase log file

### DIFF
--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -36,14 +36,6 @@ class DAGConnectionTest(TestBase):
         self.log_unexpected_msgs = ["Test failed."]
         self.wait_for_all_scenarios()
         self.assert_log_msgs_passed()
-        self.stop_running_scenario()
-
-    def stop_running_scenario(self):
-        running_scenarios = self.rpc("scenarios_list_running")
-        if running_scenarios:
-            pid = running_scenarios[0]["pid"]
-            self.log.warning(f"Stopping scenario with PID {pid}")
-            self.warcli(f"scenarios stop {pid}", False)
 
 
 if __name__ == "__main__":

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -30,19 +30,19 @@ class DAGConnectionTest(TestBase):
 
     def run_connect_dag_scenario(self):
         self.log.info("Running connect_dag scenario")
-        self.warcli("scenarios run-file test/framework_tests/connect_dag.py")
         self.log_expected_msgs = [
             "Successfully ran the connect_dag.py scenario using a temporary file"
         ]
         self.log_unexpected_msgs = ["Test failed."]
+        self.warcli("scenarios run-file test/framework_tests/connect_dag.py")
         self.wait_for_all_scenarios()
         self.assert_log_msgs()
 
     def run_connect_dag_scenario_post_connection(self):
         self.log.info("Running connect_dag scenario")
-        self.warcli("scenarios run-file test/framework_tests/connect_dag.py")
         self.log_expected_msgs = ["Successfully ran the connect_dag.py scenario"]
         self.log_unexpected_msgs = ["Test failed"]
+        self.warcli("scenarios run-file test/framework_tests/connect_dag.py")
         self.wait_for_all_scenarios()
         self.assert_log_msgs()
 

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -36,7 +36,7 @@ class DAGConnectionTest(TestBase):
         ]
         self.log_unexpected_msgs = ["Test failed."]
         self.wait_for_all_scenarios()
-        self.assert_log_msgs_passed()
+        self.assert_log_msgs()
 
     def run_connect_dag_scenario_post_connection(self):
         self.log.info("Running connect_dag scenario")
@@ -44,7 +44,7 @@ class DAGConnectionTest(TestBase):
         self.log_expected_msgs = ["Successfully ran the connect_dag.py scenario"]
         self.log_unexpected_msgs = ["Test failed"]
         self.wait_for_all_scenarios()
-        self.assert_log_msgs_passed()
+        self.assert_log_msgs()
 
 
 if __name__ == "__main__":

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -18,6 +18,7 @@ class DAGConnectionTest(TestBase):
         try:
             self.setup_network()
             self.run_connect_dag_scenario()
+            self.run_connect_dag_scenario_post_connection()
         finally:
             self.stop_server()
 
@@ -34,6 +35,14 @@ class DAGConnectionTest(TestBase):
             "Successfully ran the connect_dag.py scenario using a temporary file"
         ]
         self.log_unexpected_msgs = ["Test failed."]
+        self.wait_for_all_scenarios()
+        self.assert_log_msgs_passed()
+
+    def run_connect_dag_scenario_post_connection(self):
+        self.log.info("Running connect_dag scenario")
+        self.warcli("scenarios run-file test/framework_tests/connect_dag.py")
+        self.log_expected_msgs = ["Successfully ran the connect_dag.py scenario"]
+        self.log_unexpected_msgs = ["Test failed"]
         self.wait_for_all_scenarios()
         self.assert_log_msgs_passed()
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -112,7 +112,7 @@ class TestBase:
         # TODO: check for conflicting warnet process
         #       maybe also ensure that no conflicting docker networks exist
 
-        # For kubernetes we assume the server is started outside test base
+        # For kubernetes we assume the server is started outside test base,
         # but we can still read its log output
         self.log.info("Starting Warnet server")
         self.server = Popen(

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -64,11 +64,11 @@ class TestBase:
             self.server = None
 
     def _print_and_assert_msgs(self, message):
+        print(message)
         if (self.log_expected_msgs or self.log_unexpected_msgs) and assert_log(
             message, self.log_expected_msgs, self.log_unexpected_msgs
         ):
             self.log_msg_assertions_passed = True
-        print(message)
 
     def assert_log_msgs(self):
         assert (

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -114,7 +114,7 @@ class TestBase:
         # but we can still read its log output
         self.log.info("Starting Warnet server")
         self.server = Popen(
-            ["kubectl", "logs", "-f", "rpc-0"],
+            ["kubectl", "logs", "-f", "rpc-0", "--since=1s"],
             stdout=PIPE,
             stderr=PIPE,
             bufsize=1,

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -53,7 +53,7 @@ class TestBase:
             self.log_msg_assertions_passed = True
         print(message)
 
-    def assert_log_msgs_passed(self):
+    def assert_log_msgs(self):
         assert (
             self.log_msg_assertions_passed
         ), f"Log assertion failed. Expected message not found: {self.log_expected_msgs}"

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -46,19 +46,6 @@ class TestBase:
         self.log = logging.getLogger("test")
         self.log.info("Logging started")
 
-    def _print_and_assert_msgs(self, message):
-        if (self.log_expected_msgs or self.log_unexpected_msgs) and assert_log(
-            message, self.log_expected_msgs, self.log_unexpected_msgs
-        ):
-            self.log_msg_assertions_passed = True
-        print(message)
-
-    def assert_log_msgs(self):
-        assert (
-            self.log_msg_assertions_passed
-        ), f"Log assertion failed. Expected message not found: {self.log_expected_msgs}"
-        self.log_msg_assertions_passed = False
-
     def cleanup(self, signum=None, frame=None):
         if self.server is None:
             return
@@ -75,6 +62,19 @@ class TestBase:
             self.server.wait()
             self.server_thread.join()
             self.server = None
+
+    def _print_and_assert_msgs(self, message):
+        if (self.log_expected_msgs or self.log_unexpected_msgs) and assert_log(
+            message, self.log_expected_msgs, self.log_unexpected_msgs
+        ):
+            self.log_msg_assertions_passed = True
+        print(message)
+
+    def assert_log_msgs(self):
+        assert (
+            self.log_msg_assertions_passed
+        ), f"Log assertion failed. Expected message not found: {self.log_expected_msgs}"
+        self.log_msg_assertions_passed = False
 
     def warcli(self, cmd, network=True):
         self.log.debug(f"Executing warcli command: {cmd}")

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -47,10 +47,8 @@ class TestBase:
         self.log.info("Logging started")
 
     def print_and_assert_msgs(self, message):
-        if (
-            self.log_expected_msgs
-            or self.log_unexpected_msgs
-            and assert_log(self.log_expected_msgs, self.log_unexpected_msgs)
+        if (self.log_expected_msgs or self.log_unexpected_msgs) and assert_log(
+            message, self.log_expected_msgs, self.log_unexpected_msgs
         ):
             self.log_msg_assertions_passed = True
         print(message)

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -5,7 +5,7 @@ import logging.config
 import os
 import threading
 from pathlib import Path
-from subprocess import PIPE, STDOUT, Popen, run
+from subprocess import PIPE, Popen, run
 from tempfile import mkdtemp
 from time import sleep
 
@@ -100,7 +100,7 @@ class TestBase:
         self.server = Popen(
             ["kubectl", "logs", "-f", "rpc-0"],
             stdout=PIPE,
-            stderr=STDOUT,
+            stderr=PIPE,
             bufsize=1,
             universal_newlines=True,
         )

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -56,7 +56,7 @@ class TestBase:
     def assert_log_msgs_passed(self):
         assert (
             self.log_msg_assertions_passed
-        ), f"Log assertion failed: {self.log_expected_msgs}, {self.log_unexpected_msgs}"
+        ), f"Log assertion failed. Expected message not found: {self.log_expected_msgs}"
 
     def cleanup(self, signum=None, frame=None):
         if self.server is None:

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -57,6 +57,7 @@ class TestBase:
         assert (
             self.log_msg_assertions_passed
         ), f"Log assertion failed. Expected message not found: {self.log_expected_msgs}"
+        self.log_msg_assertions_passed = False
 
     def cleanup(self, signum=None, frame=None):
         if self.server is None:

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -55,6 +55,11 @@ class TestBase:
             self.log_msg_assertions_passed = True
         print(message)
 
+    def assert_log_msgs_passed(self):
+        assert (
+            self.log_msg_assertions_passed
+        ), f"Log assertion failed: {self.log_expected_msgs}, {self.log_unexpected_msgs}"
+
     def cleanup(self, signum=None, frame=None):
         if self.server is None:
             return

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -119,7 +119,7 @@ class TestBase:
         )
 
         self.server_thread = threading.Thread(
-            target=self.output_reader, args=(self.server.stdout, print)
+            target=self.output_reader, args=(self.server.stdout, self.print_and_assert_msgs)
         )
         self.server_thread.daemon = True
         self.server_thread.start()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -46,7 +46,7 @@ class TestBase:
         self.log = logging.getLogger("test")
         self.log.info("Logging started")
 
-    def print_and_assert_msgs(self, message):
+    def _print_and_assert_msgs(self, message):
         if (self.log_expected_msgs or self.log_unexpected_msgs) and assert_log(
             message, self.log_expected_msgs, self.log_unexpected_msgs
         ):
@@ -123,7 +123,7 @@ class TestBase:
         )
 
         self.server_thread = threading.Thread(
-            target=self.output_reader, args=(self.server.stdout, self.print_and_assert_msgs)
+            target=self.output_reader, args=(self.server.stdout, self._print_and_assert_msgs)
         )
         self.server_thread.daemon = True
         self.server_thread.start()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -21,6 +21,9 @@ class TestBase:
         self.setup_environment()
         self.setup_logging()
         atexit.register(self.cleanup)
+        self.log_expected_msgs: None | [str] = None
+        self.log_unexpected_msgs: None | [str] = None
+        self.log_msg_assertions_passed = False
         self.log.info("Warnet test base initialized")
 
     def setup_environment(self):
@@ -42,6 +45,15 @@ class TestBase:
         logging.config.dictConfig(logging_config)
         self.log = logging.getLogger("test")
         self.log.info("Logging started")
+
+    def print_and_assert_msgs(self, message):
+        if (
+            self.log_expected_msgs
+            or self.log_unexpected_msgs
+            and assert_log(self.log_expected_msgs, self.log_unexpected_msgs)
+        ):
+            self.log_msg_assertions_passed = True
+        print(message)
 
     def cleanup(self, signum=None, frame=None):
         if self.server is None:


### PR DESCRIPTION
### Issue
I want to use an `assert_log` function against the output of rpc-0. Specifically, I want to assert the existence of some text that is produced by a scenario and logged by rpc-0. I don't believe that is possible today.

Also, when scenarios fail today, that failure [does not bubble up](https://github.com/mplsgrant/warnet/actions/runs/9654531220/job/26628947670#step:8:333) to the test framework.

### Cause
- The `server_thread` in `TestBase` prints the log output of rpc-0, but it does not store that information anywhere in a way that allows tests to access it.
- The current `server` in `TestBase` reads the entire history of `kubectl log -f pod/rpc-0` which causes assert statements in test cases to incorrectly check old/stale log entries.

### Solution
Allow `TestBase` to examine the output of the kubectl process log and create assertions against it. Limit that log output to the current run by preventing kubectl from logging old messages by using the `--since` flag.