### PR TITLE
`connect_nodes` - account for test networks

### DIFF
--- a/src/backend/kubernetes_backend.py
+++ b/src/backend/kubernetes_backend.py
@@ -420,9 +420,7 @@ class KubernetesBackend:
         logging_crd_name = "servicemonitors.monitoring.coreos.com"
         api = client.ApiextensionsV1Api()
         crds = api.list_custom_resource_definition()
-        if any(crd.metadata.name == logging_crd_name for crd in crds.items):
-            return True
-        return False
+        return bool(any(crd.metadata.name == logging_crd_name for crd in crds.items))
 
     def apply_prometheus_service_monitors(self, tanks):
         for tank in tanks:

--- a/src/scenarios/connect_dag.py
+++ b/src/scenarios/connect_dag.py
@@ -58,6 +58,12 @@ class ConnectDag(WarnetTestFramework):
         self.connect_nodes(5, 4)
         self.connect_nodes(5, 6)
         self.connect_nodes(6, 7)
+
+        # Nodes 8 & 9 shall come pre-connected. Attempt to connect them anyway to test the handling
+        # of dns node addresses
+        self.connect_nodes(8, 9)
+        self.connect_nodes(9, 8)
+
         self.sync_all()
 
         zero_peers = self.nodes[0].getpeerinfo()

--- a/src/scenarios/connect_dag.py
+++ b/src/scenarios/connect_dag.py
@@ -116,8 +116,7 @@ class ConnectDag(WarnetTestFramework):
         if connection_type == ConnectionType.DNS:
             assert any(d.get("addr") ==
                        self.warnet.tanks[connectee_index].get_dns_addr() for d in connector), \
-                (f"Could not find {self.options.network_name}-"
-                 f"tank-00000{connectee_index}-service")
+                f"Could not find {self.options.network_name}-tank-00000{connectee_index}-service"
         elif connection_type == ConnectionType.IP:
             assert any(d.get("addr").split(":")[0] ==
                        self.warnet.tanks[connectee_index].get_ip_addr() for d in connector), \

--- a/src/warnet/test_framework_bridge.py
+++ b/src/warnet/test_framework_bridge.py
@@ -337,8 +337,15 @@ class WarnetTestFramework(BitcoinTestFramework):
             try:  # we encounter a regular ip address
                 ip_addr = str(ipaddress.ip_address(peer['addr'].split(':')[0]))
                 return ip_addr
-            except ValueError:  # or we encounter a service name
-                tank_index = int(peer['addr'].split('-')[2])  # NETWORK-tank-INDEX-service
+            except ValueError as err:  # or we encounter a service name
+                try:
+                    # NETWORK-tank-TANK_INDEX-service
+                    # NETWORK-test-TEST-tank-TANK_INDEX-service
+                    tank_index = int(peer['addr'].split('-')[-2])
+                except (ValueError, IndexError) as inner_err:
+                    raise ValueError("could not derive tank index from service name: {} {}"
+                                     .format(peer['addr'], inner_err)) from err
+
                 ip_addr = self.warnet.tanks[tank_index].get_ip_addr()
                 return ip_addr
 

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -16,7 +16,7 @@ base.wait_for_all_tanks_status(target="running")
 base.wait_for_all_edges()
 
 # Start scenario
-base.warcli("scenarios run connect_dag")
+base.warcli("scenarios run-file test/framework_tests/connect_dag.py")
 
 counter = 0
 seconds = 180

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -16,7 +16,7 @@ base.wait_for_all_tanks_status(target="running")
 base.wait_for_all_edges()
 
 # Start scenario
-base.warcli(f"scenarios run connect_dag --network_name={base.network_name}")
+base.warcli(f"scenarios run connect_dag")
 
 counter = 0
 seconds = 180

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -16,7 +16,7 @@ base.wait_for_all_tanks_status(target="running")
 base.wait_for_all_edges()
 
 # Start scenario
-base.warcli(f"scenarios run connect_dag")
+base.warcli("scenarios run connect_dag")
 
 counter = 0
 seconds = 180

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from test_base import TestBase
 
-graph_file_path = Path(os.path.dirname(__file__)) / "data" / "eight_unconnected.graphml"
+graph_file_path = Path(os.path.dirname(__file__)) / "data" / "ten_semi_unconnected.graphml"
 
 base = TestBase()
 

--- a/test/data/ten_semi_unconnected.graphml
+++ b/test/data/ten_semi_unconnected.graphml
@@ -73,5 +73,22 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdr
       <data key="exporter">False</data>
       <data key="collect_logs">False</data>
     </node>
+    <node id="8">
+      <data key="version">26.0</data>
+      <data key="bitcoin_config" />
+      <data key="tc_netem" />
+      <data key="build_args" />
+      <data key="exporter">False</data>
+      <data key="collect_logs">False</data>
+    </node>
+    <node id="9">
+      <data key="version">26.0</data>
+      <data key="bitcoin_config" />
+      <data key="tc_netem" />
+      <data key="build_args" />
+      <data key="exporter">False</data>
+      <data key="collect_logs">False</data>
+    </node>
+    <edge id="0" source="8" target="9"></edge>
   </graph>
 </graphml>

--- a/test/framework_tests/connect_dag.py
+++ b/test/framework_tests/connect_dag.py
@@ -110,7 +110,7 @@ class ConnectDag(WarnetTestFramework):
         self.assert_connection(eight_peers, 9, ConnectionType.DNS)
         self.assert_connection(nine_peers, 8, ConnectionType.IP)
 
-        self.log.info(f"Successfully ran the {os.path.basename(__file__)} scenario.")
+        self.log.info(f"Successfully ran the scenario file: {os.path.basename(__file__)} ")
 
     def assert_connection(self, connector, connectee_index, connection_type: ConnectionType):
         if connection_type == ConnectionType.DNS:

--- a/test/framework_tests/connect_dag.py
+++ b/test/framework_tests/connect_dag.py
@@ -110,7 +110,8 @@ class ConnectDag(WarnetTestFramework):
         self.assert_connection(eight_peers, 9, ConnectionType.DNS)
         self.assert_connection(nine_peers, 8, ConnectionType.IP)
 
-        self.log.info(f"Successfully ran the scenario file: {os.path.basename(__file__)} ")
+        self.log.info(f"Successfully ran the connect_dag.py scenario using a temporary file: "
+                      f"{os.path.basename(__file__)} ")
 
     def assert_connection(self, connector, connectee_index, connection_type: ConnectionType):
         if connection_type == ConnectionType.DNS:

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -14,7 +14,7 @@ base.wait_for_all_tanks_status(target="running")
 
 # Use rpc instead of warcli so we get raw JSON object
 scenarios = base.rpc("scenarios_available")
-assert len(scenarios) == 5
+assert len(scenarios) == 4
 
 # Start scenario
 base.warcli("scenarios run miner_std --allnodes --interval=1")


### PR DESCRIPTION
### Issue
Sometimes `connect_nodes` produces an error:

```shell
2024-06-24T23:39:30+0000 - INFO -     tank_index = int(peer['addr'].split('-')[2])  # NETWORK-tank-INDEX-service
2024-06-24T23:39:30+0000 - INFO -                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-24T23:39:30+0000 - INFO - ValueError: invalid literal for int() with base 10: 'vqyr11r'
```

### Cause
`connect_nodes` does not handle test networks properly. Specifically, it handles this dns format:

`NETWORK-tank-INDEX-service`

But not the "test" format:

`NETWORK-test-TEST-tank-INDEX-service`

### Solution
Modify `connect_nodes` to handle the "test" format, and update the test coverage to account for this.
