### PR TITLE
Use threads to parallelize tx_flood scenario

### DIFF
--- a/src/scenarios/miner_std.py
+++ b/src/scenarios/miner_std.py
@@ -47,6 +47,7 @@ class MinerStd(WarnetTestFramework):
         while not self.warnet.network_connected():
             self.log.info("Waiting for complete network connection...")
             sleep(5)
+        self.log.info("Network connected. Starting miners.")
 
         max_miners = 1
         if self.options.allnodes:
@@ -60,9 +61,13 @@ class MinerStd(WarnetTestFramework):
                 if miner.mature:
                     num = 101
                     miner.mature = False
-                self.generatetoaddress(miner.node, num, miner.addr)
-                height = miner.node.getblockcount()
-                self.log.info(f"generated {num} block(s) from node {miner.node.index}. New chain height: {height}")
+                try:
+                    self.generatetoaddress(miner.node, num, miner.addr, sync_fun=self.no_op)
+                    height = miner.node.getblockcount()
+                    self.log.info(f"generated {num} block(s) from node {miner.node.index}. New chain height: {height}")
+                except Exception as e:
+                    self.log.error(f"node {miner.node.index} error: {e}")
+
             sleep(self.options.interval)
 
 

--- a/src/scenarios/miner_std.py
+++ b/src/scenarios/miner_std.py
@@ -67,8 +67,7 @@ class MinerStd(WarnetTestFramework):
                     self.log.info(f"generated {num} block(s) from node {miner.node.index}. New chain height: {height}")
                 except Exception as e:
                     self.log.error(f"node {miner.node.index} error: {e}")
-
-            sleep(self.options.interval)
+                sleep(self.options.interval)
 
 
 if __name__ == "__main__":

--- a/src/scenarios/tx_flood.py
+++ b/src/scenarios/tx_flood.py
@@ -5,9 +5,6 @@ from time import sleep
 from scenarios.utils import ensure_miner
 from warnet.test_framework_bridge import WarnetTestFramework
 
-BLOCKS = 100
-TXS = 100
-
 
 def cli_help():
     return "Make a big transaction mess"
@@ -44,7 +41,7 @@ class TXFlood(WarnetTestFramework):
                     sats = int(float((bal / 20) / num_out) * 1e8)
                     amounts[choice(self.addrs)] = randrange(sats // 4, sats) / 1e8
                 wallet.sendmany(dummy="", amounts=amounts)
-                self.log.error(f"node {node.index} sent tx with {num_out} outputs")
+                self.log.info(f"node {node.index} sent tx with {num_out} outputs")
             except Exception as e:
                 self.log.error(f"node {node.index} error: {e}")
 

--- a/src/scenarios/tx_flood.py
+++ b/src/scenarios/tx_flood.py
@@ -20,25 +20,23 @@ class TXFlood(WarnetTestFramework):
         self.threads = []
 
     def orders(self, node):
-        try:
-            wallet = ensure_miner(node)
-            for address_type in ["legacy", "p2sh-segwit", "bech32", "bech32m"]:
-                self.addrs.append(wallet.getnewaddress(address_type=address_type))
-            while True:
-                sleep(1)
+        wallet = ensure_miner(node)
+        for address_type in ["legacy", "p2sh-segwit", "bech32", "bech32m"]:
+            self.addrs.append(wallet.getnewaddress(address_type=address_type))
+        while True:
+            sleep(1)
+            try:
                 bal = wallet.getbalance()
-                self.log.info(f"node {node.index} balance: {bal}")
                 if bal < 1:
                     continue
                 amounts = {}
                 num_out = randrange(1, len(self.nodes) // 2)
                 for _ in range(num_out):
-                    sats = int(float((bal / 2) / num_out) * 1e8)
+                    sats = int(float((bal / 20) / num_out) * 1e8)
                     amounts[choice(self.addrs)] = randrange(sats // 4, sats) / 1e8
                 wallet.sendmany(dummy="", amounts=amounts)
-                self.log.info(f"node {node.index} sendmany:\n  {amounts}")
-        except Exception as e:
-            self.log.error(f"thread for node {node.index} crashed: {e}")
+            except Exception as e:
+                self.log.error(f"node {node.index} error: {e}")
 
     def run_test(self):
         self.log.info(f"Starting TX mess with {len(self.nodes)} threads")

--- a/src/scenarios/tx_flood.py
+++ b/src/scenarios/tx_flood.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+import threading
+from random import randrange, choice
+from time import sleep
 from scenarios.utils import ensure_miner
 from warnet.test_framework_bridge import WarnetTestFramework
 
@@ -7,24 +10,52 @@ TXS = 100
 
 
 def cli_help():
-    return "Generate 100 blocks with 100 TXs each"
+    return "Make a big transaction mess"
 
 
 class TXFlood(WarnetTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        self.addrs = []
+        self.threads = []
+
+    def orders(self, node):
+        try:
+            wallet = ensure_miner(node)
+            for address_type in ["legacy", "p2sh-segwit", "bech32", "bech32m"]:
+                self.addrs.append(wallet.getnewaddress(address_type=address_type))
+            while True:
+                sleep(1)
+                bal = wallet.getbalance()
+                self.log.info(f"node {node.index} balance: {bal}")
+                if bal < 1:
+                    continue
+                amounts = {}
+                num_out = randrange(1, len(self.nodes) // 2)
+                for _ in range(num_out):
+                    sats = int(float((bal / 2) / num_out) * 1e8)
+                    amounts[choice(self.addrs)] = randrange(sats // 4, sats) / 1e8
+                wallet.sendmany(dummy="", amounts=amounts)
+                self.log.info(f"node {node.index} sendmany:\n  {amounts}")
+        except Exception as e:
+            self.log.error(f"thread for node {node.index} crashed: {e}")
 
     def run_test(self):
-        miner = ensure_miner(self.nodes[0])
-        addr = miner.getnewaddress()
-        self.generatetoaddress(self.nodes[0], 200, addr)
-        for b in range(BLOCKS):
-            for t in range(TXS):
-                txid = self.nodes[0].sendtoaddress(address=addr, amount=0.001)
-                self.log.info(f"sending tx {t}/{TXS}: {txid}")
-            block = self.generate(self.nodes[0], 1)
-            self.log.info(f"generating block {b}/{BLOCKS}: {block}")
+        self.log.info(f"Starting TX mess with {len(self.nodes)} threads")
+        for node in self.nodes:
+            t = threading.Thread(target=lambda: self.orders(node))
+            t.daemon = False
+            t.start()
+            self.threads.append({"thread": t, "node": node})
 
+        while len(self.threads) > 0:
+            for thread in self.threads:
+                if not thread["thread"].is_alive():
+                    self.log.info(f"restarting thread for node {thread['node'].index}")
+                    thread["thread"] = threading.Thread(target=lambda: self.orders(thread["node"]))
+                    thread["thread"].daemon = False
+                    thread["thread"].start()
+            sleep(30)
 
 if __name__ == "__main__":
     TXFlood().main()


### PR DESCRIPTION
This PR also improves the random attributes of transactions generated, and improves `miner_std` as well.

`warcli scenarios run miner_std --interval=1 --allnodes --mature`
Will generate 101 blocks on each tank (so something is immediately spendable) and then generate 1 block per tank after that, all at 1 second intervals

`warcli scenarios run tx_flood`
Spawns a separate thread in `rpc-0` for every tank, which tries to spend a transaction every second. An address book of all address types from all tanks is maintained in the scenario and random amounts of bitcoin are sent to a random number of addresses from that table. Each tx spends up to half the wallet's available balance although that could probably be reduced so the wallet can send more transactions between blocks. Will play with the values or maybe add some options.

Going to test on 200 node cluster before switching out of draft.