### PR TITLE
WIP: add remote executor and tank roles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ on:
       - main
 
 jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+  # ruff:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: chartboost/ruff-action@v1
   ruff-format:
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +20,8 @@ jobs:
         with:
           args: 'format --check'
   build-image:
-    needs: [ruff, ruff-format]
+    # needs: [ruff, ruff-format]
+    needs: [ruff-format]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/resources/graphs/default.graphml
+++ b/resources/graphs/default.graphml
@@ -15,6 +15,7 @@
   <key id="channel_open"    attr.name="channel_open"     attr.type="string"   for="edge" />
   <key id="source_policy"   attr.name="source_policy"    attr.type="string"   for="edge" />
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
+  <key id="role"            attr.name="role"             attr.type="string"   for="node" />
   <graph edgedefault="directed">
     <node id="0">
         <data key="version">27.1-exe</data>

--- a/resources/graphs/default.graphml
+++ b/resources/graphs/default.graphml
@@ -17,8 +17,8 @@
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">27.0</data>
-        <data key="bitcoin_config">-uacomment=w0</data>
+        <data key="version">27.1-exe</data>
+        <data key="bitcoin_config">-uacomment=miner</data>
         <data key="exporter">true</data>
         <data key="collect_logs">true</data>
     </node>

--- a/resources/graphs/default.graphml
+++ b/resources/graphs/default.graphml
@@ -22,6 +22,7 @@
         <data key="bitcoin_config">-uacomment=miner</data>
         <data key="exporter">true</data>
         <data key="collect_logs">true</data>
+        <data key="role">miner</data>
     </node>
     <node id="1">
         <data key="version">27.0</data>

--- a/resources/images/bitcoin/Dockerfile
+++ b/resources/images/bitcoin/Dockerfile
@@ -22,8 +22,8 @@ RUN --mount=type=cache,target=/var/cache/apk \
     sqlite-dev \
     zeromq-dev
 
-COPY isroutable.patch /tmp/
-COPY addrman.patch /tmp/
+COPY resources/images/bitcoin/isroutable.patch /tmp/
+COPY resources/images/bitcoin/addrman.patch /tmp/
 
 
 # Clone and patch and build stage
@@ -70,6 +70,7 @@ RUN addgroup bitcoin --gid ${GID} --system \
 RUN --mount=type=cache,target=/var/cache/apk sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories \
     && apk --no-cache add \
     bash \
+    inotify-tools \
     libevent \
     libzmq \
     shadow \
@@ -77,7 +78,8 @@ RUN --mount=type=cache,target=/var/cache/apk sed -i 's/http\:\/\/dl-cdn.alpineli
     su-exec
 
 COPY --from=build /opt/bitcoin /usr/local
-COPY entrypoint.sh /
+COPY resources/images/bitcoin/entrypoint.sh /
+COPY resources/scripts/file-executor.sh /file-executor.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]
 EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332

--- a/resources/images/bitcoin/entrypoint.sh
+++ b/resources/images/bitcoin/entrypoint.sh
@@ -40,4 +40,6 @@ if [ -n "$BITCOIN_ARGS" ]; then
 fi
 
 echo
+mkdir /tmp/exe
+/file-executor.sh /tmp/exe &
 exec "$@"

--- a/resources/scripts/file-executor.sh
+++ b/resources/scripts/file-executor.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Check if inotifywait is installed
+if ! command -v inotifywait &> /dev/null; then
+  echo "inotifywait could not be found. Please install inotify-tools."
+  exit 1
+fi
+
+# Check we have a directory to watch
+if [ $# -eq 0 ]; then
+  echo "Please provide a directory to watch"
+  exit 1
+fi
+
+WATCH_DIR="$1"
+MAX_CONCURRENT=5
+declare -A RUNNING_PROCESSES
+
+watch_directory() {
+  inotifywait -m "$WATCH_DIR" -e create -e moved_to |
+    while read -r path action file; do
+      full_path="$path$file"
+      if [[ -x "$full_path" ]]; then
+        case "$action" in
+        CREATE)
+          echo "New executable created: $full_path"
+          ;;
+        MOVED_TO)
+          echo "Executable moved into directory: $full_path"
+          ;;
+        esac
+        run_executable "$full_path" &
+      fi
+    done
+}
+
+run_executable() {
+  local executable="$1"
+  while [[ ${#RUNNING_PROCESSES[@]} -ge $MAX_CONCURRENT ]]; do
+    sleep 1
+    for pid in "${!RUNNING_PROCESSES[@]}"; do
+      if ! kill -0 "$pid" 2>/dev/null; then
+        unset "RUNNING_PROCESSES[$pid]"
+      fi
+    done
+  done
+
+  "$executable" &
+  local pid=$!
+  RUNNING_PROCESSES[$pid]=$executable
+  wait $pid
+  unset "RUNNING_PROCESSES[$pid]"
+}
+
+cleanup() {
+  echo "Cleaning up..."
+  for pid in "${!RUNNING_PROCESSES[@]}"; do
+    kill "$pid" 2>/dev/null
+  done
+  exit 0
+}
+
+trap cleanup SIGINT SIGTERM
+
+watch_directory

--- a/resources/scripts/miner.sh
+++ b/resources/scripts/miner.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Generate a Poisson-distributed sleep time between 1 and 20 seconds
+generate_poisson_sleep() {
+  local lambda=10 # Average rate (lambda) for Poisson distribution
+  local sleep_time
+  sleep_time=$(awk -v lambda="$lambda" 'BEGIN {
+    sum = 0;
+    while (sum <= lambda) {
+      sum += -log(1 - rand());
+    }
+    print int(sum);
+  }')
+
+  # Ensure sleep time is between 1 and 20 seconds
+  if [ "$sleep_time" -lt 1 ]; then
+    sleep_time=1
+  elif [ "$sleep_time" -gt 20 ]; then
+    sleep_time=20
+  fi
+
+  echo "$sleep_time"
+}
+
+echo "Running miner role with Poisson-distributed sleep between blocks"
+
+echo "Creating a new wallet called \"miner\""
+bitcoin-cli -regtest -rpcuser=warnet_user -rpcpassword=2themoon createwallet "miner"
+sleep "$(generate_poisson_sleep)"
+
+echo "Beginning mining process"
+while true; do
+  bitcoin-cli -regtest -rpcuser=warnet_user -rpcpassword=2themoon -generate 1
+  sleep "$(generate_poisson_sleep)"
+done

--- a/resources/scripts/tx.sh
+++ b/resources/scripts/tx.sh
@@ -6,73 +6,122 @@ WALLET_NAME="miner"
 
 # Function to generate a random number between min and max (inclusive)
 random_range() {
-  local min=$1
-  local max=$2
-  echo $((RANDOM % (max - min + 1) + min))
+    local min=$1
+    local max=$2
+    echo $((RANDOM % (max - min + 1) + min))
 }
 
 # Function to get a random element from an array
 random_choice() {
-  local arr=("$@")
-  echo "${arr[RANDOM % ${#arr[@]}]}"
+    local arr=("$@")
+    echo "${arr[RANDOM % ${#arr[@]}]}"
+}
+
+# Function to remove an item from an array
+remove_item() {
+    local array=("$@")
+    unset array[0]
+    echo "${array[@]}"
 }
 
 # Create an array of addresses
 create_addresses() {
-  local address_types=("legacy" "p2sh-segwit" "bech32" "bech32m")
-  local addresses=()
-  for type in "${address_types[@]}"; do
-    local new_address
-    new_address=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" getnewaddress "" "$type")
-    addresses+=("$new_address")
-  done
-  printf '%s\n' "${addresses[@]}"
+    local address_types=("legacy" "p2sh-segwit" "bech32" "bech32m")
+    local addresses=()
+    for type in "${address_types[@]}"; do
+        for i in {1..10}; do
+            local new_address
+            new_address=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" getnewaddress "" "$type")
+            addresses+=("$new_address")
+        done
+    done
+    printf '%s\n' "${addresses[@]}"
+}
+
+# Prepare amounts with unique addresses
+prepare_amounts() {
+    local balance=$1
+    local num_out=$2
+    local addresses=("${@:3}")
+    local amounts=""
+    local used_addresses=()
+
+    echo "Preparing amounts for transaction:"
+    echo "Balance: $balance"
+    echo "Number of outputs: $num_out"
+
+    for ((i = 0; i < num_out; i++)); do
+        sats=$(echo "scale=0; ($balance / 20 / $num_out) * 100000000" | bc)
+        amount=$(echo "scale=8; $(random_range $((sats / 2)) "$sats") / 100000000" | bc)
+
+        # Select a random address that hasn't been used yet
+        address=$(random_choice "${addresses[@]}")
+        while [[ " ${used_addresses[*]} " =~ " ${address} " ]]; do
+            addresses=($(remove_item "${addresses[@]}"))
+            address=$(random_choice "${addresses[@]}")
+        done
+
+        used_addresses+=("$address")
+        amounts+="\"$address\":$amount,"
+
+        echo "Output $((i + 1)):"
+        echo "  Address: $address"
+        echo "  Sats calculation: ($balance / 2 / $num_out) * 100000000 = $sats"
+        echo "  Amount range: $((sats / 2)) to $sats satoshis"
+        echo "  Final amount: $amount BTC"
+    done
+
+    amounts=${amounts%,} # Remove trailing comma
+    echo "Final amounts string: $amounts"
+    echo "$amounts"
 }
 
 # Main loop
 main() {
-  # Check if wallet exists, create if it doesn't
-  if ! bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" listwallets | grep -q "$WALLET_NAME"; then
-    bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" createwallet "$WALLET_NAME"
-  fi
-
-  # Use mapfile to read the addresses into an array
-  local addresses
-  mapfile -t addresses < <(create_addresses)
-  echo "Got addresses ${addresses[*]}"
-  bitcoin-cli -regtest -rpcwallet="$WALLET_NAME" generatetoaddress 110 "${addresses[3]}"
-  local interval=1
-
-  while true; do
-    # Get balance
-    balance=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" getbalance)
-    echo "Current balance: $balance"
-    if (( $(echo "$balance < 1" | bc -l) )); then
-      bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" generatetoaddress 110 "${addresses[3]}"
-      sleep "$interval"
-      continue
+    # Check if wallet exists, create if it doesn't
+    if ! bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" listwallets | grep -q "$WALLET_NAME"; then
+        bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" createwallet "$WALLET_NAME"
     fi
 
-    # Determine number of outputs
-    num_out=$(random_range 1 $((${#addresses[@]} / 2)))
+    # Use mapfile to read the addresses into an array
+    local addresses
+    mapfile -t addresses < <(create_addresses)
+    echo "Created ${#addresses[@]} addresses"
+    sleep $((RANDOM % 60 + 1))
+    bitcoin-cli -regtest -rpcwallet="$WALLET_NAME" generatetoaddress 101 "${addresses[0]}"
+    local interval=1
 
-    # Prepare amounts
-    amounts=""
-    for ((i = 0; i < num_out; i++)); do
-      sats=$(echo "scale=0; ($balance / 20 / $num_out) * 100000000" | bc)
-      amount=$(echo "scale=8; $(random_range $((sats / 4)) "$sats") / 100000000" | bc)
-      address=$(random_choice "${addresses[@]}")
-      amounts+="\"$address\":$amount,"
+    while true; do
+        # Get balance
+        balance=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" getbalance)
+        echo "Current balance: $balance"
+        if (($(echo "$balance < 1" | bc -l))); then
+            echo "Balance too low, generating more blocks..."
+            sleep $((RANDOM % 60 + 1))
+            bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" generatetoaddress 101 "${addresses[0]}"
+            sleep "$interval"
+            continue
+        fi
+
+        # Set number of outputs to about 20
+        num_out=20
+
+        # Prepare amounts with unique addresses
+        amounts=$(prepare_amounts "$balance" "$num_out" "${addresses[@]}")
+
+        echo "Attempting to send transaction..."
+        # Send transaction
+        tx_id=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" sendmany "" "{$amounts}")
+
+        if [ $? -eq 0 ]; then
+            echo "Successfully sent transaction with $num_out outputs. Transaction ID: $tx_id"
+        else
+            echo "Failed to send transaction. Error message:"
+            echo "$tx_id"
+        fi
+
+        sleep "$interval"
     done
-    amounts=${amounts%,} # Remove trailing comma
-
-    # Send transaction
-    tx_id=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" sendmany "" "{$amounts}")
-
-    echo "Sent transaction with $num_out outputs. Transaction ID: $tx_id"
-
-    sleep "$interval"
-  done
 }
 
 main

--- a/resources/scripts/tx.sh
+++ b/resources/scripts/tx.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+RPC_USER="warnet_user"
+RPC_PASS="2themoon"
+WALLET_NAME="miner"
+
+# Function to generate a random number between min and max (inclusive)
+random_range() {
+  local min=$1
+  local max=$2
+  echo $((RANDOM % (max - min + 1) + min))
+}
+
+# Function to get a random element from an array
+random_choice() {
+  local arr=("$@")
+  echo "${arr[RANDOM % ${#arr[@]}]}"
+}
+
+# Create an array of addresses
+create_addresses() {
+  local address_types=("legacy" "p2sh-segwit" "bech32" "bech32m")
+  local addresses=()
+  for type in "${address_types[@]}"; do
+    local new_address
+    new_address=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" getnewaddress "" "$type")
+    addresses+=("$new_address")
+  done
+  printf '%s\n' "${addresses[@]}"
+}
+
+# Main loop
+main() {
+  # Check if wallet exists, create if it doesn't
+  if ! bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" listwallets | grep -q "$WALLET_NAME"; then
+    bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" createwallet "$WALLET_NAME"
+  fi
+
+  # Use mapfile to read the addresses into an array
+  local addresses
+  mapfile -t addresses < <(create_addresses)
+  echo "Got addresses ${addresses[*]}"
+  bitcoin-cli -regtest -rpcwallet="$WALLET_NAME" generatetoaddress 110 "${addresses[3]}"
+  local interval=1
+
+  while true; do
+    # Get balance
+    balance=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" getbalance)
+    echo "Current balance: $balance"
+    if (( $(echo "$balance < 1" | bc -l) )); then
+      bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" generatetoaddress 110 "${addresses[3]}"
+      sleep "$interval"
+      continue
+    fi
+
+    # Determine number of outputs
+    num_out=$(random_range 1 $((${#addresses[@]} / 2)))
+
+    # Prepare amounts
+    amounts=""
+    for ((i = 0; i < num_out; i++)); do
+      sats=$(echo "scale=0; ($balance / 20 / $num_out) * 100000000" | bc)
+      amount=$(echo "scale=8; $(random_range $((sats / 4)) "$sats") / 100000000" | bc)
+      address=$(random_choice "${addresses[@]}")
+      amounts+="\"$address\":$amount,"
+    done
+    amounts=${amounts%,} # Remove trailing comma
+
+    # Send transaction
+    tx_id=$(bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcwallet="$WALLET_NAME" sendmany "" "{$amounts}")
+
+    echo "Sent transaction with $num_out outputs. Transaction ID: $tx_id"
+
+    sleep "$interval"
+  done
+}
+
+main

--- a/src/warnet/backend/kubernetes_backend.py
+++ b/src/warnet/backend/kubernetes_backend.py
@@ -886,40 +886,50 @@ class KubernetesBackend:
 
     def copy_file_to_pod(self, pod_name, src_path, dest_path):
         import os
+
         tmp_path = "/tmp/" + os.path.basename(dest_path)
+        self.log.debug(f"Copying file {src_path} to {dest_path} on {pod_name}")
 
         # Read the file content
         try:
-            with open(src_path, 'rb') as file_content:
+            with open(src_path, "rb") as file_content:
                 content = file_content.read()
         except Exception as e:
             print(f"Failed to read source file: {e}")
             return
 
         # Create a temp dir in the pod
-        exec_command = ['mkdir', '-p', os.path.dirname(tmp_path)]
+        exec_command = ["mkdir", "-p", os.path.dirname(tmp_path)]
         try:
-            resp = stream(self.client.connect_get_namespaced_pod_exec,
-                          pod_name,
-                          self.namespace,
-                          command=exec_command,
-                          stderr=True, stdin=False,
-                          stdout=True, tty=False)
+            resp = stream(
+                self.client.connect_get_namespaced_pod_exec,
+                pod_name,
+                self.namespace,
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
             print(f"Temporary directory creation response: {resp}")
         except Exception as e:
             print(f"Failed to create temporary directory in pod: {e}")
             return
 
         # Write the file to the temp dir in the pod
-        exec_command = ['sh', '-c', f'cat > {tmp_path}']
+        exec_command = ["sh", "-c", f"cat > {tmp_path}"]
         try:
-            resp = stream(self.client.connect_get_namespaced_pod_exec,
-                          pod_name,
-                          self.namespace,
-                          command=exec_command,
-                          stderr=True, stdin=True,
-                          stdout=True, tty=False,
-                          _preload_content=False)
+            resp = stream(
+                self.client.connect_get_namespaced_pod_exec,
+                pod_name,
+                self.namespace,
+                command=exec_command,
+                stderr=True,
+                stdin=True,
+                stdout=True,
+                tty=False,
+                _preload_content=False,
+            )
 
             resp.write_stdin(content.decode())
             resp.close()
@@ -929,56 +939,72 @@ class KubernetesBackend:
             return
 
         # Make it executable before copying to final dir
-        exec_command = ['chmod', '+x', tmp_path]
+        exec_command = ["chmod", "+x", tmp_path]
         try:
-            resp = stream(self.client.connect_get_namespaced_pod_exec,
-                          pod_name,
-                          self.namespace,
-                          command=exec_command,
-                          stderr=True, stdin=False,
-                          stdout=True, tty=False)
+            resp = stream(
+                self.client.connect_get_namespaced_pod_exec,
+                pod_name,
+                self.namespace,
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
             print(f"File permission change response: {resp}")
         except Exception as e:
             print(f"Failed to change file permissions in pod: {e}")
             return
 
         # Create the final dir in the pod if not exists
-        exec_command = ['mkdir', '-p', os.path.dirname(dest_path)]
+        exec_command = ["mkdir", "-p", os.path.dirname(dest_path)]
         try:
-            resp = stream(self.client.connect_get_namespaced_pod_exec,
-                          pod_name,
-                          self.namespace,
-                          command=exec_command,
-                          stderr=True, stdin=False,
-                          stdout=True, tty=False)
+            resp = stream(
+                self.client.connect_get_namespaced_pod_exec,
+                pod_name,
+                self.namespace,
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
             print(f"Final directory creation response: {resp}")
         except Exception as e:
             print(f"Failed to create final directory in pod: {e}")
             return
 
         # Move +x file to the final directory
-        exec_command = ['mv', tmp_path, dest_path]
+        exec_command = ["mv", tmp_path, dest_path]
         try:
-            resp = stream(self.client.connect_get_namespaced_pod_exec,
-                          pod_name,
-                          self.namespace,
-                          command=exec_command,
-                          stderr=True, stdin=False,
-                          stdout=True, tty=False)
+            resp = stream(
+                self.client.connect_get_namespaced_pod_exec,
+                pod_name,
+                self.namespace,
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
             print(f"File move response: {resp}")
         except Exception as e:
             print(f"Failed to move file to final directory in pod: {e}")
             return
 
         # Verify file was copied and is +x
-        exec_command = ['ls', '-l', dest_path]
+        exec_command = ["ls", "-l", dest_path]
         try:
-            resp = stream(self.client.connect_get_namespaced_pod_exec,
-                          pod_name,
-                          self.namespace,
-                          command=exec_command,
-                          stderr=True, stdin=False,
-                          stdout=True, tty=False)
+            resp = stream(
+                self.client.connect_get_namespaced_pod_exec,
+                pod_name,
+                self.namespace,
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
             print(f"File verification response: {resp}")
         except Exception as e:
             print(f"Failed to verify file in pod: {e}")

--- a/src/warnet/backend/kubernetes_backend.py
+++ b/src/warnet/backend/kubernetes_backend.py
@@ -883,3 +883,103 @@ class KubernetesBackend:
             _preload_content=False,
         )
         self.log.info(f"Finished unpacking config data for {service_name} to {destination_path}")
+
+    def copy_file_to_pod(self, pod_name, src_path, dest_path):
+        import os
+        tmp_path = "/tmp/" + os.path.basename(dest_path)
+
+        # Read the file content
+        try:
+            with open(src_path, 'rb') as file_content:
+                content = file_content.read()
+        except Exception as e:
+            print(f"Failed to read source file: {e}")
+            return
+
+        # Create a temp dir in the pod
+        exec_command = ['mkdir', '-p', os.path.dirname(tmp_path)]
+        try:
+            resp = stream(self.client.connect_get_namespaced_pod_exec,
+                          pod_name,
+                          self.namespace,
+                          command=exec_command,
+                          stderr=True, stdin=False,
+                          stdout=True, tty=False)
+            print(f"Temporary directory creation response: {resp}")
+        except Exception as e:
+            print(f"Failed to create temporary directory in pod: {e}")
+            return
+
+        # Write the file to the temp dir in the pod
+        exec_command = ['sh', '-c', f'cat > {tmp_path}']
+        try:
+            resp = stream(self.client.connect_get_namespaced_pod_exec,
+                          pod_name,
+                          self.namespace,
+                          command=exec_command,
+                          stderr=True, stdin=True,
+                          stdout=True, tty=False,
+                          _preload_content=False)
+
+            resp.write_stdin(content.decode())
+            resp.close()
+            print(f"Temporary file copy response: {resp.read_stdout()}")
+        except Exception as e:
+            print(f"Failed to copy file to temporary directory in pod: {e}")
+            return
+
+        # Make it executable before copying to final dir
+        exec_command = ['chmod', '+x', tmp_path]
+        try:
+            resp = stream(self.client.connect_get_namespaced_pod_exec,
+                          pod_name,
+                          self.namespace,
+                          command=exec_command,
+                          stderr=True, stdin=False,
+                          stdout=True, tty=False)
+            print(f"File permission change response: {resp}")
+        except Exception as e:
+            print(f"Failed to change file permissions in pod: {e}")
+            return
+
+        # Create the final dir in the pod if not exists
+        exec_command = ['mkdir', '-p', os.path.dirname(dest_path)]
+        try:
+            resp = stream(self.client.connect_get_namespaced_pod_exec,
+                          pod_name,
+                          self.namespace,
+                          command=exec_command,
+                          stderr=True, stdin=False,
+                          stdout=True, tty=False)
+            print(f"Final directory creation response: {resp}")
+        except Exception as e:
+            print(f"Failed to create final directory in pod: {e}")
+            return
+
+        # Move +x file to the final directory
+        exec_command = ['mv', tmp_path, dest_path]
+        try:
+            resp = stream(self.client.connect_get_namespaced_pod_exec,
+                          pod_name,
+                          self.namespace,
+                          command=exec_command,
+                          stderr=True, stdin=False,
+                          stdout=True, tty=False)
+            print(f"File move response: {resp}")
+        except Exception as e:
+            print(f"Failed to move file to final directory in pod: {e}")
+            return
+
+        # Verify file was copied and is +x
+        exec_command = ['ls', '-l', dest_path]
+        try:
+            resp = stream(self.client.connect_get_namespaced_pod_exec,
+                          pod_name,
+                          self.namespace,
+                          command=exec_command,
+                          stderr=True, stdin=False,
+                          stdout=True, tty=False)
+            print(f"File verification response: {resp}")
+        except Exception as e:
+            print(f"Failed to verify file in pod: {e}")
+            return

--- a/src/warnet/cli/graph.py
+++ b/src/warnet/cli/graph.py
@@ -21,7 +21,15 @@ def graph():
 @click.option("--random", is_flag=True)
 @click.option("--miners", type=int, help="Number of miners")
 @click.option("--tx", type=int, help="Number of transactors")
-def create(number: int, outfile: Path, version: str, bitcoin_conf: Path, random: bool = False, miners: int = 0, tx: int =0):
+def create(
+    number: int,
+    outfile: Path,
+    version: str,
+    bitcoin_conf: Path,
+    random: bool = False,
+    miners: int = 0,
+    tx: int = 0,
+):
     """
     Create a cycle graph with <number> nodes, and include 7 extra random outbounds per node.
     Returns XML file as string with or without --outfile option

--- a/src/warnet/cli/graph.py
+++ b/src/warnet/cli/graph.py
@@ -19,12 +19,14 @@ def graph():
 @click.option("--version", type=str, default=DEFAULT_TAG)
 @click.option("--bitcoin_conf", type=click.Path())
 @click.option("--random", is_flag=True)
-def create(number: int, outfile: Path, version: str, bitcoin_conf: Path, random: bool = False):
+@click.option("--miners", type=int, help="Number of miners")
+@click.option("--tx", type=int, help="Number of transactors")
+def create(number: int, outfile: Path, version: str, bitcoin_conf: Path, random: bool = False, miners: int = 0, tx: int =0):
     """
     Create a cycle graph with <number> nodes, and include 7 extra random outbounds per node.
     Returns XML file as string with or without --outfile option
     """
-    graph = create_cycle_graph(number, version, bitcoin_conf, random)
+    graph = create_cycle_graph(number, version, bitcoin_conf, random, miners, tx)
 
     if outfile:
         file_path = Path(outfile)

--- a/src/warnet/graph_schema.json
+++ b/src/warnet/graph_schema.json
@@ -58,7 +58,10 @@
         "comment": "Specify a lnd Circuit Breaker image from Dockerhub with the format repository/image:tag"},
       "ln_config": {
         "type": "string",
-        "comment": "A string of arguments for the lightning network node in command-line format, e.g. '--protocol.wumbo-channels --bitcoin.timelockdelta=80'"}
+        "comment": "A string of arguments for the lightning network node in command-line format, e.g. '--protocol.wumbo-channels --bitcoin.timelockdelta=80'"},
+      "role": {
+        "type": "string",
+        "comment": "The role of the node (miner, tx)'"}
     },
     "additionalProperties": false,
     "oneOf": [

--- a/src/warnet/graph_schema.json
+++ b/src/warnet/graph_schema.json
@@ -22,6 +22,9 @@
       "image": {
         "type": "string",
         "comment": "Bitcoin Core Warnet tank image on Dockerhub with the format repository/image:tag"},
+      "role": {
+        "type": "string",
+        "comment": "The role of the tank, e.g. 'miner'"},
       "bitcoin_config": {
         "type": "string",
         "default": "",

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -469,6 +469,8 @@ class Server:
                     wn.warnet_up()
                     wn.wait_for_health()
                     wn.apply_network_conditions()
+                    time.sleep(1) # Can probably remove
+                    wn.apply_roles()
                     self.logger.info("Warnet started successfully")
                 except Exception as e:
                     trace = traceback.format_exc()

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -469,7 +469,7 @@ class Server:
                     wn.warnet_up()
                     wn.wait_for_health()
                     wn.apply_network_conditions()
-                    time.sleep(1) # Can probably remove
+                    time.sleep(1)  # Can probably remove
                     wn.apply_roles()
                     self.logger.info("Warnet started successfully")
                 except Exception as e:

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -197,7 +197,11 @@ class Tank:
     def apply_roles(self):
         if self.role is None:
             return
-        self.warnet.container_interface.copy_file_to_pod(self.warnet.container_interface.get_pod_name(self.index, ServiceType.BITCOIN), f"scripts/{self.role}.sh", f"/tmp/exe/{self.role}.sh")
+        self.warnet.container_interface.copy_file_to_pod(
+            self.warnet.container_interface.get_pod_name(self.index, ServiceType.BITCOIN),
+            f"resources/scripts/{self.role}.sh",
+            f"/tmp/exe/{self.role}.sh",
+        )
 
     def export(self, config: object, tar_file):
         if self.lnnode is not None:

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -48,6 +48,7 @@ class Tank:
         self.image: str = ""
         self.bitcoin_config = ""
         self.netem = None
+        self.role = ""
         self.exporter = False
         self.metrics = None
         self.collect_logs = False
@@ -192,6 +193,11 @@ class Tank:
             logger.error(
                 f"Error applying network conditions to tank {self.index}: `{self.netem}` ({e})"
             )
+
+    def apply_roles(self):
+        if self.role is None:
+            return
+        self.warnet.container_interface.copy_file_to_pod(self.warnet.container_interface.get_pod_name(self.index, ServiceType.BITCOIN), f"scripts/{self.role}.sh", f"/tmp/exe/{self.role}.sh")
 
     def export(self, config: object, tar_file):
         if self.lnnode is not None:

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -21,7 +21,7 @@ from warnet import SRC_DIR
 logger = logging.getLogger("utils")
 
 
-SUPPORTED_TAGS = ["27.0", "26.0", "25.1", "24.2", "23.2", "22.2"]
+SUPPORTED_TAGS = ["27.1-exe", "27.0", "26.0", "25.1", "24.2", "23.2", "22.2"]
 DEFAULT_TAG = SUPPORTED_TAGS[0]
 WEIGHTED_TAGS = [
     tag for index, tag in enumerate(reversed(SUPPORTED_TAGS)) for _ in range(index + 1)

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -380,7 +380,9 @@ def set_execute_permission(file_path):
     os.chmod(file_path, current_permissions | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def create_cycle_graph(n: int, version: str, bitcoin_conf: Path | None, random_version: bool, miners: int, tx: int):
+def create_cycle_graph(
+    n: int, version: str, bitcoin_conf: Path | None, random_version: bool, miners: int, tx: int
+):
     try:
         # Use nx.MultiDiGraph() so we get directed edges (source->target)
         # and still allow parallel edges (L1 p2p connections + LN channels)

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -166,6 +166,10 @@ class Warnet:
         for tank in self.tanks:
             tank.apply_network_conditions()
 
+    def apply_roles(self):
+        for tank in self.tanks:
+            tank.apply_roles()
+
     def warnet_build(self):
         self.container_interface.build()
 


### PR DESCRIPTION
Some real commits and some example commits to-be-removed.

Addresses the idea in https://github.com/bitcoin-dev-project/warnet/issues/272

This installs a "file watcher" inside the tank docker image, which will watch `/tmp/exe/` for executable files and run them as soon as they are added.

Add the ability to assign a "role" to a tank on the graph. This will (stupidly) attempt to copy a script from `scripts/{role}.sh` into the tank `/tmp/exe/` during warnet creation. This happens after the file watcher is started, (and likely bitcoind is initialised) so it will immediately execute.

A simple miner script, which mines blocks every 0 - 20 seconds, is applied as the role to tank `0`.

Currently this uses a custom [image](https://hub.docker.com/layers/bitcoindevproject/bitcoin/27.1-exe/images/sha256-7bba6af27eff756b5d96310d3e60ba3ed2d5a026f7a53569a09d2c044ec974fa?context=repo) (x86_64 linux only, I think) for the tank, with the new executor program installed, but this could obviously be rebuilt into the main images if we move forward with it.

This should let us (and hackers?) make the nodes do pretty wild things, unconstrained by `rpc-0`'s load/RPC timings.

Could also be used as a start to achieving https://github.com/bitcoin-dev-project/warnet/issues/390