### PR TITLE
image: build by commit hash, not branch

### DIFF
--- a/src/cli/image.py
+++ b/src/cli/image.py
@@ -12,17 +12,17 @@ def image():
 
 @image.command()
 @click.option("--repo", required=True, type=str)
-@click.option("--branch", required=True, type=str)
+@click.option("--commit-sha", required=True, type=str)
 @click.option("--registry", required=True, type=str)
 @click.option("--tag", required=True, type=str)
 @click.option("--build-args", required=False, type=str)
 @click.option("--arches", required=False, type=str)
 @click.option("--action", required=False, type=str)
-def build(repo, branch, registry, tag, build_args, arches, action="load"):
+def build(repo, commit_sha, registry, tag, build_args, arches, action="load"):
     """
-    Build bitcoind and bitcoin-cli from <repo>/<branch> as <registry>:<tag>.
+    Build bitcoind and bitcoin-cli from <repo> at <commit_sha> as <registry>:<tag>.
     Optionally deploy to remote registry using --action=push, otherwise image is loaded to local registry.
     """
-    res = build_image(repo, branch, registry, tag, build_args, arches, action)
+    res = build_image(repo, commit_sha, registry, tag, build_args, arches, action)
     if not res:
         sys.exit(1)

--- a/src/cli/image_build.py
+++ b/src/cli/image_build.py
@@ -14,7 +14,7 @@ def run_command(command):
 
 def build_image(
     repo: str,
-    branch: str,
+    commit_sha: str,
     docker_registry: str,
     tag: str,
     build_args: str,
@@ -38,7 +38,7 @@ def build_image(
             return False
 
     print(f"{repo=:}")
-    print(f"{branch=:}")
+    print(f"{commit_sha=:}")
     print(f"{docker_registry=:}")
     print(f"{tag=:}")
     print(f"{build_args=:}")
@@ -70,7 +70,7 @@ def build_image(
         f"docker buildx build"
         f" --platform {platforms}"
         f" --build-arg REPO={repo}"
-        f" --build-arg BRANCH={branch}"
+        f" --build-arg COMMIT_SHA={commit_sha}"
         f" --build-arg BUILD_ARGS={build_args}"
         f" --tag {image_full_name}"
         f" --file src/templates/Dockerfile ."

--- a/src/templates/Dockerfile
+++ b/src/templates/Dockerfile
@@ -1,7 +1,7 @@
 # Setup deps stage
-FROM alpine as deps
+FROM alpine AS deps
 ARG REPO
-ARG BRANCH
+ARG COMMIT_SHA
 ARG BUILD_ARGS
 
 RUN --mount=type=cache,target=/var/cache/apk \
@@ -27,14 +27,16 @@ COPY src/templates/addrman.patch /tmp/
 
 
 # Clone and patch and build stage
-FROM deps as build
+FROM deps AS build
 ENV BITCOIN_PREFIX=/opt/bitcoin
 WORKDIR /build
 
 RUN set -ex \
     && cd /build \
-    && git clone --depth 1 --branch "${BRANCH}" "https://github.com/${REPO}" \
+    && git clone --depth 1 "https://github.com/${REPO}" \
     && cd bitcoin \
+    && git fetch --depth 1 origin "$COMMIT_SHA" \
+    && git checkout "$COMMIT_SHA" \
     && git apply /tmp/isroutable.patch \
     && git apply /tmp/addrman.patch \
     && sed -i s:sys/fcntl.h:fcntl.h: src/compat/compat.h \


### PR DESCRIPTION
Build an image from any `repo + <commit_hash>`.

I think this is more flexible and more useful.

It's also a step towards https://github.com/bitcoin-dev-project/warnet/issues/389 and #181 