### PR TITLE
Add Server-Side Copy Command Feature to Warnet Framework

### DIFF
--- a/src/backend/kubernetes_backend.py
+++ b/src/backend/kubernetes_backend.py
@@ -254,6 +254,9 @@ class KubernetesBackend:
             container=BITCOIN_CONTAINER_NAME,
         )
         return logs
+    
+    def copy_files(self):
+        return
 
     def ln_cli(self, tank: Tank, command: list[str]):
         if tank.lnnode is None:

--- a/src/cli/copy.py
+++ b/src/cli/copy.py
@@ -1,0 +1,93 @@
+import os
+import shutil
+import tempfile
+from cli.rpc import rpc_call
+import click
+
+
+@click.command()
+@click.argument("source", required=True)
+@click.argument("destination", required=True)
+@click.option("-r", "--recursive", is_flag=True, help="Copy files recursively.")
+@click.option("--network", default="warnet", show_default=True)
+def cp(source: str, destination: str, recursive: bool, network: str):
+    """Copy files to and from tanks."""
+    print(f"source: {source}")
+    print(f"destination: {destination}")
+    print(f"recursive: {recursive}")
+
+    if ":" not in source and ":" not in destination:
+        raise click.UsageError(
+            "Either source or destination must include a tank identifier."
+        )
+
+    if ":" in source:
+        # Copy from tank to local
+        if recursive and os.path.isfile(destination):
+            raise click.UsageError(f"destination path not a directory: {destination}.")
+
+        rpc_call(
+            "tank_copy",
+            {
+                "source": source,
+                "destination": None,
+                "recursive": recursive,
+                "network": network,
+            },
+        )
+        # destination: for be the current system file path
+        #
+    elif ":" in destination:
+        # Copy from local to tank
+        if recursive and os.path.isfile(source):
+            raise click.UsageError(f"source path not a directory: {source}.")
+
+        if recursive and os.path.isdir(source):
+            # Archive the directory
+            with tempfile.NamedTemporaryFile(
+                delete=False, suffix=".tar.gz"
+            ) as temp_file:
+                archive_path = temp_file.name
+                shutil.make_archive(
+                    archive_path.replace(".tar.gz", ""), "gztar", source
+                )
+
+            # Upload the archive
+            upload_file(archive_path + ".tar.gz", destination, network)
+            os.remove(archive_path)  # Clean up the temporary archive
+        else:
+            upload_file(source, destination, network)
+
+    elif ":" in source and ":" in destination:
+        # Copy from tank to tank
+        print(
+            rpc_call(
+                "tank_copy",
+                {
+                    "source": source,
+                    "destination": destination,
+                    "recursive": recursive,
+                    "network": network,
+                },
+            )
+        )
+    else:
+        raise click.UsageError("Unexpected error in determining source or destination.")
+
+
+def upload_file(local_path, destination, network):
+    """Uploads a single file using JSON-RPC."""
+    with open(local_path, "rb") as f:
+        file_data = f.read()
+
+    print(
+        rpc_call(
+            "tank_copy",
+            {
+                "source": None,
+                "destination": destination,
+                "file_data": file_data.decode("latin1"),  # Encode file data as needed
+                "network": network,
+            },
+        )
+    )

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -4,6 +4,7 @@ from cli.image import image
 from cli.network import network
 from cli.rpc import rpc_call
 from cli.scenarios import scenarios
+from cli.copy import cp
 from requests.exceptions import ConnectionError
 from rich import print as richprint
 
@@ -17,6 +18,7 @@ cli.add_command(graph)
 cli.add_command(image)
 cli.add_command(network)
 cli.add_command(scenarios)
+cli.add_command(cp)
 
 
 @cli.command(name="help")
@@ -48,7 +50,9 @@ def help_command(ctx, commands):
     # Get the help info
     help_info = cmd_obj.get_help(ctx).strip()
     # Get rid of the duplication
-    help_info = help_info.replace("Usage: warcli help [COMMANDS]...", "Usage: warcli", 1)
+    help_info = help_info.replace(
+        "Usage: warcli help [COMMANDS]...", "Usage: warcli", 1
+    )
     richprint(help_info)
 
 
@@ -58,7 +62,9 @@ cli.add_command(help_command)
 @cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("node", type=int)
 @click.argument("method", type=str)
-@click.argument("params", type=str, nargs=-1)  # this will capture all remaining arguments
+@click.argument(
+    "params", type=str, nargs=-1
+)  # this will capture all remaining arguments
 @click.option("--network", default="warnet", show_default=True)
 def rpc(node, method, params, network):
     """
@@ -66,7 +72,8 @@ def rpc(node, method, params, network):
     """
     print(
         rpc_call(
-            "tank_bcli", {"network": network, "node": node, "method": method, "params": params}
+            "tank_bcli",
+            {"network": network, "node": node, "method": method, "params": params},
         )
     )
 
@@ -105,7 +112,11 @@ def messages(node_a, node_b, network):
     """
     Fetch messages sent between <node_a> and <node_b> in [network]
     """
-    print(rpc_call("tank_messages", {"network": network, "node_a": node_a, "node_b": node_b}))
+    print(
+        rpc_call(
+            "tank_messages", {"network": network, "node_a": node_a, "node_b": node_b}
+        )
+    )
 
 
 @cli.command()

--- a/src/warnet/warnet.py
+++ b/src/warnet/warnet.py
@@ -12,7 +12,12 @@ import networkx
 import yaml
 from backend.kubernetes_backend import KubernetesBackend
 from templates import TEMPLATES
-from warnet.services import AO_CONF_NAME, FO_CONF_NAME, GRAFANA_PROVISIONING, PROM_CONF_NAME
+from warnet.services import (
+    AO_CONF_NAME,
+    FO_CONF_NAME,
+    GRAFANA_PROVISIONING,
+    PROM_CONF_NAME,
+)
 from warnet.tank import Tank
 from warnet.utils import gen_config_dir, load_schema, validate_graph_schema
 
@@ -135,7 +140,9 @@ class Warnet:
         self.network_name = network_name
         # Get network graph edges from graph file (required for network restarts)
         self.graph = networkx.read_graphml(
-            Path(self.config_dir / self.graph_name), node_type=int, force_multigraph=True
+            Path(self.config_dir / self.graph_name),
+            node_type=int,
+            force_multigraph=True,
         )
         validate_graph_schema(self.graph)
         self.tanks_from_graph()
@@ -254,7 +261,10 @@ class Warnet:
                         "static_configs": [{"targets": [f"{tank.exporter_name}:9332"]}],
                     }
                 )
-        config = {"global": {"scrape_interval": "15s"}, "scrape_configs": scrape_configs}
+        config = {
+            "global": {"scrape_interval": "15s"},
+            "scrape_configs": scrape_configs,
+        }
         prometheus_path = self.config_dir / PROM_CONF_NAME
         try:
             with open(prometheus_path, "w") as file:
@@ -273,7 +283,9 @@ class Warnet:
 
     def network_connected(self):
         for tank in self.tanks:
-            peerinfo = json.loads(self.container_interface.get_bitcoin_cli(tank, "getpeerinfo"))
+            peerinfo = json.loads(
+                self.container_interface.get_bitcoin_cli(tank, "getpeerinfo")
+            )
             manuals = 0
             for peer in peerinfo:
                 if peer["connection_type"] == "manual":


### PR DESCRIPTION
**Description:**
This pull request introduces a new feature to the Warnet framework, enabling file copy operations similar to `scp`, `docker cp`, and `kubectl cp`. The feature allows users to specify source and destination paths from/to tank using the syntax `tank:path`, facilitating file transfers within, to and from the Warnet environment.

**Key Changes:**
1. **Feature Implementation:**
   - Added support for the `tank:path` syntax to specify source and destination file paths.
   - Implemented the core logic to handle file copy operations. [not done]

**Related Issues:**
- https://github.com/bitcoin-dev-project/warnet/issues/210

**Reviewer Notes:**
- Please review the implementation and provide feedback on the flow.





