### PR TITLE
Enforce ruff format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
+  ruff-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # - uses: chartboost/ruff-action@v1
+      # Until this gets updated we need to use this commit hash (or later)
+      - uses: chartboost/ruff-action@491342200cdd1cf4d5132a30ddc546b3b5bc531b
+        with:
+          args: 'format --check'
+          changed-files: 'true'
   build-image:
-    needs: [ruff]
+    needs: [ruff, ruff-format]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/justfile
+++ b/justfile
@@ -108,3 +108,8 @@ installlogging:
 
 connectlogging:
     ./src/templates/k8s/connect_logging.sh
+
+# Format and lint all files
+lint:
+    ruff format .
+    ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ where = ["src"]
 [tool.ruff]
 extend-exclude = [
     "src/test_framework/*.py",
-    "src/scenarios/*"
 ]
 line-length = 100
 indent-width = 4

--- a/scripts/apidocs.py
+++ b/scripts/apidocs.py
@@ -25,11 +25,14 @@ def print_cmd(cmd, super=""):
                 p["name"],
                 p["type"]["param_type"] if p["type"]["param_type"] != "Unprocessed" else "String",
                 "yes" if p["required"] else "",
-                '"' + p["default"] + '"' if p["default"] and p["type"]["param_type"] == "String"
-                else Path(p["default"]).relative_to(Path.cwd()) if p["default"] and p["type"]["param_type"] == "Path"
-                else p["default"]
+                '"' + p["default"] + '"'
+                if p["default"] and p["type"]["param_type"] == "String"
+                else Path(p["default"]).relative_to(Path.cwd())
+                if p["default"] and p["type"]["param_type"] == "Path"
+                else p["default"],
             ]
-            for p in cmd["params"] if p["name"] != "help"
+            for p in cmd["params"]
+            if p["name"] != "help"
         ]
         doc += tabulate(data, headers=headers, tablefmt="github")
     doc += "\n\n"

--- a/scripts/graphdocs.py
+++ b/scripts/graphdocs.py
@@ -33,14 +33,9 @@ headers = ["key", "for", "type", "default", "explanation"]
 data = []
 for section in sections:
     data += [
-        [
-            name,
-            section,
-            p["type"],
-            p.get("default", ""),
-            p["comment"]
-        ]
-        for name, p in graph_schema[section]["properties"].items() if "comment" in p
+        [name, section, p["type"], p.get("default", ""), p["comment"]]
+        for name, p in graph_schema[section]["properties"].items()
+        if "comment" in p
     ]
 
 doc += tabulate(data, headers=headers, tablefmt="github")

--- a/src/backend/kubernetes_backend.py
+++ b/src/backend/kubernetes_backend.py
@@ -569,7 +569,9 @@ class KubernetesBackend:
     def get_tank_ip_addr(self, index: int) -> str | None:
         service_name = self.get_service_name(index, ServiceType.BITCOIN)
         try:
-            endpoints = self.client.read_namespaced_endpoints(name=service_name, namespace=self.namespace)
+            endpoints = self.client.read_namespaced_endpoints(
+                name=service_name, namespace=self.namespace
+            )
         except ApiValueError as e:
             self.log.info(f"ip addr request for {service_name} raised {str(e)}")
             return None

--- a/src/scenarios/ln_init.py
+++ b/src/scenarios/ln_init.py
@@ -43,7 +43,9 @@ class LNInit(WarnetTestFramework):
         # confirm funds in block 299
         self.generatetoaddress(self.nodes[0], 1, miner_addr)
 
-        self.log.info(f"Waiting for funds to be spendable: {split} BTC each for {len(recv_addrs)} LN nodes")
+        self.log.info(
+            f"Waiting for funds to be spendable: {split} BTC each for {len(recv_addrs)} LN nodes"
+        )
 
         def funded_lnnodes():
             for tank in self.warnet.tanks:
@@ -52,11 +54,14 @@ class LNInit(WarnetTestFramework):
                 if int(tank.lnnode.get_wallet_balance()["confirmed_balance"]) < (split * 100000000):
                     return False
             return True
-        self.wait_until(funded_lnnodes, timeout=5*60)
+
+        self.wait_until(funded_lnnodes, timeout=5 * 60)
 
         ln_nodes_uri = ln_nodes.copy()
         while len(ln_nodes_uri) > 0:
-            self.log.info(f"Waiting for all LN nodes to have URI, LN nodes remaining: {ln_nodes_uri}")
+            self.log.info(
+                f"Waiting for all LN nodes to have URI, LN nodes remaining: {ln_nodes_uri}"
+            )
             for index in ln_nodes_uri:
                 lnnode = self.warnet.tanks[index].lnnode
                 if lnnode.getURI():
@@ -68,7 +73,11 @@ class LNInit(WarnetTestFramework):
             (src, dst, data) = edge
             # Copy the L1 p2p topology (where applicable) to L2
             # so we get a more robust p2p graph for lightning
-            if "channel_open" not in data and self.warnet.tanks[src].lnnode and self.warnet.tanks[dst].lnnode:
+            if (
+                "channel_open" not in data
+                and self.warnet.tanks[src].lnnode
+                and self.warnet.tanks[dst].lnnode
+            ):
                 self.warnet.tanks[src].lnnode.connect_to_tank(dst)
 
         # Start confirming channel opens in block 300
@@ -90,12 +99,16 @@ class LNInit(WarnetTestFramework):
                 assert chan_pt[64:] == ":0"
                 chan_opens.append((edge, chan_pt))
                 self.log.info(f"  pending channel point: {chan_pt}")
-                self.wait_until(lambda chan_pt=chan_pt: chan_pt[:64] in self.nodes[0].getrawmempool())
+                self.wait_until(
+                    lambda chan_pt=chan_pt: chan_pt[:64] in self.nodes[0].getrawmempool()
+                )
                 self.generatetoaddress(self.nodes[0], 1, miner_addr)
                 assert chan_pt[:64] not in self.nodes[0].getrawmempool()
                 height = self.nodes[0].getblockcount()
                 self.log.info(f"  confirmed in block {height}")
-                self.log.info(f"  channel_id should be: {int.from_bytes(height.to_bytes(3, 'big') + (1).to_bytes(3, 'big') + (0).to_bytes(2, 'big'), 'big')}")
+                self.log.info(
+                    f"  channel_id should be: {int.from_bytes(height.to_bytes(3, 'big') + (1).to_bytes(3, 'big') + (0).to_bytes(2, 'big'), 'big')}"
+                )
 
         # Ensure all channel opens are sufficiently confirmed
         self.generatetoaddress(self.nodes[0], 10, miner_addr)
@@ -109,7 +122,9 @@ class LNInit(WarnetTestFramework):
                 if my_edges == len(chan_opens) and my_nodes == len(ln_nodes):
                     ln_nodes_gossip.remove(index)
                 else:
-                    self.log.info(f" node {index} not synced (channels: {my_edges}/{len(chan_opens)}, nodes: {my_nodes}/{len(ln_nodes)})")
+                    self.log.info(
+                        f" node {index} not synced (channels: {my_edges}/{len(chan_opens)}, nodes: {my_nodes}/{len(ln_nodes)})"
+                    )
             sleep(5)
 
         self.log.info("Updating channel policies")
@@ -133,7 +148,9 @@ class LNInit(WarnetTestFramework):
                 for chan_index, my_chan in enumerate(my_channels):
                     your_chan = your_channels[chan_index]
                     if not channel_match(my_chan, your_chan, allow_flip=False):
-                        print(f"Channel policy doesn't match between tanks {me} & {you}: {my_chan['channel_id']}")
+                        print(
+                            f"Channel policy doesn't match between tanks {me} & {you}: {my_chan['channel_id']}"
+                        )
                         match = False
                         break
                 if match:
@@ -144,7 +161,10 @@ class LNInit(WarnetTestFramework):
                 break
             sleep(5)
 
-        self.log.info(f"Warnet LN ready with {len(recv_addrs)} nodes and {len(chan_opens)} channels.")
+        self.log.info(
+            f"Warnet LN ready with {len(recv_addrs)} nodes and {len(chan_opens)} channels."
+        )
+
 
 if __name__ == "__main__":
     LNInit().main()

--- a/src/scenarios/miner_std.py
+++ b/src/scenarios/miner_std.py
@@ -9,12 +9,14 @@ from warnet.test_framework_bridge import WarnetTestFramework
 def cli_help():
     return "Generate blocks over time. Options: [--allnodes | --interval=<number> | --mature ]"
 
+
 class Miner:
     def __init__(self, node, mature):
         self.node = node
         self.wallet = ensure_miner(self.node)
         self.addr = self.wallet.getnewaddress()
         self.mature = mature
+
 
 class MinerStd(WarnetTestFramework):
     def set_test_params(self):
@@ -64,7 +66,9 @@ class MinerStd(WarnetTestFramework):
                 try:
                     self.generatetoaddress(miner.node, num, miner.addr, sync_fun=self.no_op)
                     height = miner.node.getblockcount()
-                    self.log.info(f"generated {num} block(s) from node {miner.node.index}. New chain height: {height}")
+                    self.log.info(
+                        f"generated {num} block(s) from node {miner.node.index}. New chain height: {height}"
+                    )
                 except Exception as e:
                     self.log.error(f"node {miner.node.index} error: {e}")
                 sleep(self.options.interval)

--- a/src/scenarios/tx_flood.py
+++ b/src/scenarios/tx_flood.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import threading
-from random import randrange, choice
+from random import choice, randrange
 from time import sleep
+
 from scenarios.utils import ensure_miner
 from warnet.test_framework_bridge import WarnetTestFramework
 
@@ -49,7 +50,7 @@ class TXFlood(WarnetTestFramework):
         self.log.info(f"Starting TX mess with {len(self.nodes)} threads")
         for node in self.nodes:
             sleep(1)  # stagger
-            t = threading.Thread(target=lambda: self.orders(node))
+            t = threading.Thread(target=lambda n=node: self.orders(n))
             t.daemon = False
             t.start()
             self.threads.append({"thread": t, "node": node})
@@ -58,7 +59,9 @@ class TXFlood(WarnetTestFramework):
             for thread in self.threads:
                 if not thread["thread"].is_alive():
                     self.log.info(f"restarting thread for node {thread['node'].index}")
-                    thread["thread"] = threading.Thread(target=lambda: self.orders(thread["node"]))
+                    thread["thread"] = threading.Thread(
+                        target=lambda n=thread["node"]: self.orders(n)
+                    )
                     thread["thread"].daemon = False
                     thread["thread"].start()
             sleep(30)

--- a/src/scenarios/tx_flood.py
+++ b/src/scenarios/tx_flood.py
@@ -48,7 +48,7 @@ class TXFlood(WarnetTestFramework):
     def run_test(self):
         self.log.info(f"Starting TX mess with {len(self.nodes)} threads")
         for node in self.nodes:
-            sleep(1) # stagger
+            sleep(1)  # stagger
             t = threading.Thread(target=lambda: self.orders(node))
             t.daemon = False
             t.start()
@@ -62,6 +62,7 @@ class TXFlood(WarnetTestFramework):
                     thread["thread"].daemon = False
                     thread["thread"].start()
             sleep(30)
+
 
 if __name__ == "__main__":
     TXFlood().main()

--- a/src/scenarios/utils.py
+++ b/src/scenarios/utils.py
@@ -1,5 +1,3 @@
-
-
 def ensure_miner(node):
     wallets = node.listwallets()
     if "miner" not in wallets:

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -40,6 +40,7 @@ class Tank:
 
     def __init__(self, index: int, warnet):
         from warnet.lnnode import LNNode
+
         self.index = index
         self.warnet = warnet
         self.network_name = warnet.network_name
@@ -97,6 +98,7 @@ class Tank:
                 "ln_config": node.get("ln_config", ""),
             }
             from warnet.lnnode import LNNode
+
             self.lnnode = LNNode(self.warnet, self, self.warnet.container_interface, options)
 
         logger.debug(

--- a/src/warnet/test_framework_bridge.py
+++ b/src/warnet/test_framework_bridge.py
@@ -262,7 +262,7 @@ class WarnetTestFramework(BitcoinTestFramework):
             dest="v2transport",
             default=False,
             action="store_true",
-            help="use BIP324 v2 connections between all nodes by default"
+            help="use BIP324 v2 connections between all nodes by default",
         )
 
         self.add_options(parser)
@@ -335,16 +335,19 @@ class WarnetTestFramework(BitcoinTestFramework):
 
         def get_peer_ip(peer):
             try:  # we encounter a regular ip address
-                ip_addr = str(ipaddress.ip_address(peer['addr'].split(':')[0]))
+                ip_addr = str(ipaddress.ip_address(peer["addr"].split(":")[0]))
                 return ip_addr
             except ValueError as err:  # or we encounter a service name
                 try:
                     # NETWORK-tank-TANK_INDEX-service
                     # NETWORK-test-TEST-tank-TANK_INDEX-service
-                    tank_index = int(peer['addr'].split('-')[-2])
+                    tank_index = int(peer["addr"].split("-")[-2])
                 except (ValueError, IndexError) as inner_err:
-                    raise ValueError("could not derive tank index from service name: {} {}"
-                                     .format(peer['addr'], inner_err)) from err
+                    raise ValueError(
+                        "could not derive tank index from service name: {} {}".format(
+                            peer["addr"], inner_err
+                        )
+                    ) from err
 
                 ip_addr = self.warnet.tanks[tank_index].get_ip_addr()
                 return ip_addr
@@ -354,19 +357,42 @@ class WarnetTestFramework(BitcoinTestFramework):
         # See comments in net_processing:
         # * Must have a version message before anything else
         # * Must have a verack message before anything else
-        self.wait_until(lambda: any(peer['addr'] == to_ip_port and peer['version'] != 0
-                                    for peer in from_connection.getpeerinfo()))
-        self.wait_until(lambda: any(get_peer_ip(peer) == from_ip_port and peer['version'] != 0
-                                    for peer in to_connection.getpeerinfo()))
-        self.wait_until(lambda: any(peer['addr'] == to_ip_port and peer['bytesrecv_per_msg'].pop('verack', 0) >= 21
-                                    for peer in from_connection.getpeerinfo()))
-        self.wait_until(lambda: any(get_peer_ip(peer) == from_ip_port
-                                    and peer['bytesrecv_per_msg'].pop('verack', 0) >= 21
-                                    for peer in to_connection.getpeerinfo()))
+        self.wait_until(
+            lambda: any(
+                peer["addr"] == to_ip_port and peer["version"] != 0
+                for peer in from_connection.getpeerinfo()
+            )
+        )
+        self.wait_until(
+            lambda: any(
+                get_peer_ip(peer) == from_ip_port and peer["version"] != 0
+                for peer in to_connection.getpeerinfo()
+            )
+        )
+        self.wait_until(
+            lambda: any(
+                peer["addr"] == to_ip_port and peer["bytesrecv_per_msg"].pop("verack", 0) >= 21
+                for peer in from_connection.getpeerinfo()
+            )
+        )
+        self.wait_until(
+            lambda: any(
+                get_peer_ip(peer) == from_ip_port
+                and peer["bytesrecv_per_msg"].pop("verack", 0) >= 21
+                for peer in to_connection.getpeerinfo()
+            )
+        )
         # The message bytes are counted before processing the message, so make
         # sure it was fully processed by waiting for a ping.
-        self.wait_until(lambda: any(peer['addr'] == to_ip_port and peer["bytesrecv_per_msg"].pop("pong", 0) >= 29
-                                    for peer in from_connection.getpeerinfo()))
-        self.wait_until(lambda: any(get_peer_ip(peer) == from_ip_port
-                                    and peer["bytesrecv_per_msg"].pop("pong", 0) >= 29
-                                    for peer in to_connection.getpeerinfo()))
+        self.wait_until(
+            lambda: any(
+                peer["addr"] == to_ip_port and peer["bytesrecv_per_msg"].pop("pong", 0) >= 29
+                for peer in from_connection.getpeerinfo()
+            )
+        )
+        self.wait_until(
+            lambda: any(
+                get_peer_ip(peer) == from_ip_port and peer["bytesrecv_per_msg"].pop("pong", 0) >= 29
+                for peer in to_connection.getpeerinfo()
+            )
+        )

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -21,14 +21,7 @@ from test_framework.p2p import MESSAGEMAP
 logger = logging.getLogger("utils")
 
 
-SUPPORTED_TAGS = [
-    "27.0",
-    "26.0",
-    "25.1",
-    "24.2",
-    "23.2",
-    "22.2"
-]
+SUPPORTED_TAGS = ["27.0", "26.0", "25.1", "24.2", "23.2", "22.2"]
 DEFAULT_TAG = SUPPORTED_TAGS[0]
 WEIGHTED_TAGS = [
     tag for index, tag in enumerate(reversed(SUPPORTED_TAGS)) for _ in range(index + 1)

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -20,12 +20,13 @@ base.warcli("scenarios run-file test/framework_tests/connect_dag.py")
 
 counter = 0
 seconds = 180
-while (len(base.rpc("scenarios_list_running")) == 1
-       and base.rpc("scenarios_list_running")[0]["active"]):
+while (
+    len(base.rpc("scenarios_list_running")) == 1 and base.rpc("scenarios_list_running")[0]["active"]
+):
     time.sleep(1)
     counter += 1
     if counter > seconds:
-        pid = base.rpc("scenarios_list_running")[0]['pid']
+        pid = base.rpc("scenarios_list_running")[0]["pid"]
         base.warcli(f"scenarios stop {pid}", False)
         print(f"{os.path.basename(__file__)} more than {seconds} seconds")
         assert counter < seconds

--- a/test/framework_tests/connect_dag.py
+++ b/test/framework_tests/connect_dag.py
@@ -85,8 +85,10 @@ class ConnectDag(WarnetTestFramework):
         nine_peers = self.nodes[9].getpeerinfo()
 
         for tank in self.warnet.tanks:
-            self.log.info(f"Tank {tank.index}: {tank.warnet.tanks[tank.index].get_dns_addr()} pod:"
-                          f" {tank.warnet.tanks[tank.index].get_ip_addr()}")
+            self.log.info(
+                f"Tank {tank.index}: {tank.warnet.tanks[tank.index].get_dns_addr()} pod:"
+                f" {tank.warnet.tanks[tank.index].get_ip_addr()}"
+            )
 
         self.assert_connection(zero_peers, 2, ConnectionType.DNS)
         self.assert_connection(one_peers, 2, ConnectionType.DNS)
@@ -110,18 +112,22 @@ class ConnectDag(WarnetTestFramework):
         self.assert_connection(eight_peers, 9, ConnectionType.DNS)
         self.assert_connection(nine_peers, 8, ConnectionType.IP)
 
-        self.log.info(f"Successfully ran the connect_dag.py scenario using a temporary file: "
-                      f"{os.path.basename(__file__)} ")
+        self.log.info(
+            f"Successfully ran the connect_dag.py scenario using a temporary file: "
+            f"{os.path.basename(__file__)} "
+        )
 
     def assert_connection(self, connector, connectee_index, connection_type: ConnectionType):
         if connection_type == ConnectionType.DNS:
-            assert any(d.get("addr") ==
-                       self.warnet.tanks[connectee_index].get_dns_addr() for d in connector), \
-                f"Could not find {self.options.network_name}-tank-00000{connectee_index}-service"
+            assert any(
+                d.get("addr") == self.warnet.tanks[connectee_index].get_dns_addr()
+                for d in connector
+            ), f"Could not find {self.options.network_name}-tank-00000{connectee_index}-service"
         elif connection_type == ConnectionType.IP:
-            assert any(d.get("addr").split(":")[0] ==
-                       self.warnet.tanks[connectee_index].get_ip_addr() for d in connector), \
-                f"Could not find Tank {connectee_index}'s ip addr"
+            assert any(
+                d.get("addr").split(":")[0] == self.warnet.tanks[connectee_index].get_ip_addr()
+                for d in connector
+            ), f"Could not find Tank {connectee_index}'s ip addr"
         else:
             raise ValueError("ConnectionType must be of type DNS or IP")
 

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -39,6 +39,7 @@ assert count > 1
 msgs = base.warcli("messages 0 1")
 assert "verack" in msgs
 
+
 def got_addrs():
     addrman = json.loads(base.warcli("rpc 0 getrawaddrman"))
     for key in ["tried", "new"]:
@@ -48,6 +49,8 @@ def got_addrs():
         if len(set(groups)) > 1:
             return True
     return False
+
+
 base.wait_for_predicate(got_addrs)
 
 base.stop_server()


### PR DESCRIPTION
- Enables `ruff format --check .` which checks formatting
	- this should only operate on changed files
- Format all files
- Include scenarios in formatting & reformat all scenarios
- Fixup lint issues in tx_flood changes (not binding to values in lambda)
- Add a justfile command to check formatting and linting `just lint`

After these changes, PRs will fail CI checks if the entire file is not formatted and lint-free, which can be done with:

```
ruff format .
ruff check .
```

If we do this, I could add a precommit hook perhaps which does this? Although IMO it's better to configure your editor to do it automagically if possible, otherwise you get into a mess between what is staged, suddenly getting reformatted, and the reformatting going into a subsequent commit (if you only stage partial changes).

Added a `just lint` helper command for now.