### PR TITLE
Fix scenario logging

### DIFF
--- a/src/backend/kubernetes_backend.py
+++ b/src/backend/kubernetes_backend.py
@@ -33,7 +33,7 @@ PROMETHEUS_METRICS_PORT = 9332
 LND_MOUNT_PATH = "/root/.lnd"
 
 
-logger = logging.getLogger("KubernetesBackend")
+logger = logging.getLogger("k8s")
 
 
 class KubernetesBackend:

--- a/src/logging_config/config.json
+++ b/src/logging_config/config.json
@@ -3,11 +3,11 @@
   "disable_existing_loggers": false,
   "formatters": {
     "simple": {
-      "format": "%(asctime)s %(levelname)-7s %(name)-8s %(message)s",
+      "format": "%(asctime)s | %(levelname)-7s | %(name)-8s %(message)s",
       "datefmt": "%Y-%m-%d %H:%M:%S"
     },
     "detailed": {
-      "format": "%(asctime)s %(levelname)-7s [%(module)21s:%(lineno)4d] %(message)s",
+      "format": "%(asctime)s | %(levelname)-7s | [%(module)21s:%(lineno)4d] %(message)s",
       "datefmt": "%Y-%m-%d %H:%M:%S"
     }
   },

--- a/src/logging_config/config.json
+++ b/src/logging_config/config.json
@@ -3,11 +3,11 @@
   "disable_existing_loggers": false,
   "formatters": {
     "simple": {
-      "format": "%(asctime)s │ %(levelname)-7s │ %(name)-17s │ %(message)s",
+      "format": "%(asctime)s %(levelname)-7s %(name)-8s %(message)s",
       "datefmt": "%Y-%m-%d %H:%M:%S"
     },
     "detailed": {
-      "format": "%(asctime)s │ %(levelname)-7s │ [%(module)21s:%(lineno)4d] │ %(message)s",
+      "format": "%(asctime)s %(levelname)-7s [%(module)21s:%(lineno)4d] %(message)s",
       "datefmt": "%Y-%m-%d %H:%M:%S"
     }
   },

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -100,6 +100,7 @@ class Server:
         logging_config["handlers"]["file"]["filename"] = str(self.log_file_path)
         logging.config.dictConfig(logging_config)
         self.logger = logging.getLogger("server")
+        self.scenario_logger = logging.getLogger("scenario")
         self.logger.info("Logging started")
 
         def log_request():
@@ -161,11 +162,11 @@ class Server:
         # Logs
         self.jsonrpc.register(self.logs_grep)
 
-    def proc_logger(self, proc):
-        # while not proc.stdout:
-        #     time.sleep(0.1)
+    def scenario_log(self, proc):
+        while not proc.stdout:
+            time.sleep(0.1)
         for line in proc.stdout:
-            self.logger.info(line.decode().rstrip())
+            self.scenario_logger.info(line.decode().rstrip())
 
     def get_warnet(self, network: str) -> Warnet:
         """
@@ -331,7 +332,7 @@ class Server:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            t = threading.Thread(target=lambda: self.proc_logger(proc))
+            t = threading.Thread(target=lambda: self.scenario_log(proc))
             t.daemon = True
             t.start()
             self.running_scenarios.append(

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -99,7 +99,7 @@ class Server:
             logging_config = json.load(f)
         logging_config["handlers"]["file"]["filename"] = str(self.log_file_path)
         logging.config.dictConfig(logging_config)
-        self.logger = logging.getLogger("warnet")
+        self.logger = logging.getLogger("server")
         self.logger.info("Logging started")
 
         def log_request():
@@ -162,8 +162,8 @@ class Server:
         self.jsonrpc.register(self.logs_grep)
 
     def proc_logger(self, proc):
-        while not proc.stdout:
-            time.sleep(0.1)
+        # while not proc.stdout:
+        #     time.sleep(0.1)
         for line in proc.stdout:
             self.logger.info(line.decode().rstrip())
 

--- a/src/warnet/test_framework_bridge.py
+++ b/src/warnet/test_framework_bridge.py
@@ -49,12 +49,21 @@ class WarnetTestFramework(BitcoinTestFramework):
     def setup(self):
         signal.signal(signal.SIGTERM, self.handle_sigterm)
 
-        # Must setuup warnet first to avoid double formatting
+        # Must setup warnet first to avoid double formatting
         self.warnet = Warnet.from_network(self.options.network)
         # hacked from _start_logging()
         # Scenarios will log plain messages to stdout only, which will can redirected by warnet
-        self.log = logging.getLogger("scenario")
+        self.log = logging.getLogger(self.__class__.__name__)
         self.log.setLevel(logging.INFO)  # set this to DEBUG to see ALL RPC CALLS
+
+        # Because scenarios run in their own subprocess, the logger here
+        # is not the same as the warnet server or other global loggers.
+        # Scenarios log directly to stdout which gets picked up by the
+        # subprocess manager in the server, and reprinted to the global log.
+        ch = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter(fmt="%(name)-8s %(message)s")
+        ch.setFormatter(formatter)
+        self.log.addHandler(ch)
 
         for i, tank in enumerate(self.warnet.tanks):
             ip = tank.ipv4

--- a/src/warnet/test_framework_bridge.py
+++ b/src/warnet/test_framework_bridge.py
@@ -53,7 +53,7 @@ class WarnetTestFramework(BitcoinTestFramework):
         self.warnet = Warnet.from_network(self.options.network)
         # hacked from _start_logging()
         # Scenarios will log plain messages to stdout only, which will can redirected by warnet
-        self.log = logging.getLogger("WarnetTestFramework")
+        self.log = logging.getLogger("scenario")
         self.log.setLevel(logging.INFO)  # set this to DEBUG to see ALL RPC CALLS
 
         for i, tank in enumerate(self.warnet.tanks):

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -39,7 +39,7 @@ class TestBase:
             logging_config = json.load(f)
         logging_config["handlers"]["file"]["filename"] = str(self.logfilepath)
         logging.config.dictConfig(logging_config)
-        self.log = logging.getLogger("TestFramework")
+        self.log = logging.getLogger("test")
         self.log.info("Logging started")
 
     def cleanup(self, signum=None, frame=None):


### PR DESCRIPTION
Also shortens logging module names and removed the `|` which is my personal style preference but I wont argue if reviewers wanna put those back.

scenarios get their own logging module name, and the name of the scenario is also included in the line:


```
2024-07-09 11:00:05 INFO    test     Running LN Init scenario
2024-07-09 11:00:05 DEBUG   test     Executing warcli command: rpc 0 getblockcount
2024-07-09 15:00:06 DEBUG   server   {'jsonrpc': '2.0', 'method': 'tank_bcli', 'params': {'network': 'warnet-test-50guo2yq', 'node': 0, 'method': 'getblockcount', 'params': []}, 'id': 1}
2024-07-09 15:00:06 DEBUG   k8s      Running bitcoin-cli cmd=bitcoin-cli -regtest -rpcuser=warnet_user -rpcport=18443 -rpcpassword=2themoon getblockcount on tank.index=0
2024-07-09 15:00:06 DEBUG   k8s      Running exec_cmd=['/bin/sh', '-c', 'bitcoin-cli -regtest -rpcuser=warnet_user -rpcport=18443 -rpcpassword=2themoon getblockcount'] on tank_index=0
2024-07-09 11:00:06 DEBUG   test     Executing warcli command: scenarios run ln_init
2024-07-09 15:00:06 DEBUG   server   {'jsonrpc': '2.0', 'method': 'scenarios_run', 'params': {'scenario': 'ln_init', 'additional_args': [], 'network': 'warnet-test-50guo2yq'}, 'id': 1}
2024-07-09 15:00:06 DEBUG   server   Running ['/usr/local/bin/python3', '/root/warnet/src/scenarios/ln_init.py', '--network=warnet-test-50guo2yq']
2024-07-09 11:00:06 DEBUG   test     Waiting for predicate with timeout 300s and interval 5s
2024-07-09 11:00:06 DEBUG   test     Executing RPC method: scenarios_list_running
2024-07-09 15:00:06 DEBUG   server   {'jsonrpc': '2.0', 'method': 'scenarios_list_running', 'id': 14}
2024-07-09 15:00:07 INFO    scenario LNInit   Adding TestNode 0 from tank 0 with IP 10.1.10.88
2024-07-09 15:00:07 INFO    scenario LNInit   Adding TestNode 1 from tank 1 with IP 10.1.10.87
2024-07-09 15:00:07 INFO    scenario LNInit   Adding TestNode 2 from tank 2 with IP 10.1.10.91
2024-07-09 15:00:07 INFO    scenario LNInit   Adding TestNode 3 from tank 3 with IP 10.1.10.93
2024-07-09 15:00:07 INFO    scenario LNInit   User supplied random seed 131260415370612
2024-07-09 15:00:07 INFO    scenario LNInit   PRNG seed is: 131260415370612
2024-07-09 15:00:07 INFO    scenario LNInit   Lock out of IBD
2024-07-09 15:00:08 INFO    scenario LNInit   Get LN nodes and wallet addresses
2024-07-09 15:00:09 INFO    scenario LNInit   Fund LN wallets
2024-07-09 11:00:11 DEBUG   test     Executing RPC method: scenarios_list_running
2024-07-09 15:00:11 DEBUG   server   {'jsonrpc': '2.0', 'method': 'scenarios_list_running', 'id': 15}
2024-07-09 15:00:11 INFO    scenario LNInit   Waiting for funds to be spendable: 2891 BTC each for 3 LN nodes
2024-07-09 15:00:13 INFO    scenario LNInit   Waiting for all LN nodes to have URI, LN nodes remaining: [0, 1, 2]
2024-07-09 11:00:16 DEBUG   test     Executing RPC method: scenarios_list_running
2024-07-09 15:00:16 DEBUG   server   {'jsonrpc': '2.0', 'method': 'scenarios_list_running', 'id': 16}
2024-07-09 15:00:18 INFO    scenario LNInit   Waiting for all LN nodes to have URI, LN nodes remaining: [1]
2024-07-09 11:00:21 DEBUG   test     Executing RPC method: scenarios_list_running
2024-07-09 15:00:21 DEBUG   server   {'jsonrpc': '2.0', 'method': 'scenarios_list_running', 'id': 17}
2024-07-09 15:00:23 INFO    scenario LNInit   Adding p2p connections to LN nodes
2024-07-09 15:00:24 INFO    scenario LNInit   Opening channels, one per block
2024-07-09 15:00:24 INFO    scenario LNInit   opening channel 0->1
2024-07-09 15:00:24 INFO    scenario LNInit     pending channel point: 1c86f1916dae108fe73ef001d71ab2d7bd18f2aa4940a78fec208bb9dfbf400d:0
2024-07-09 15:00:24 INFO    scenario LNInit     confirmed in block 300
2024-07-09 15:00:24 INFO    scenario LNInit     channel_id should be: 329853488398336
2024-07-09 15:00:24 INFO    scenario LNInit   opening channel 1->2
2024-07-09 15:00:24 INFO    scenario LNInit     pending channel point: b0ac2b8769a55baba0cadc2a0ba0fcc2e6be6f184c8deceb76ba5c17fb00a6f4:0
2024-07-09 15:00:25 INFO    scenario LNInit     confirmed in block 301
2024-07-09 15:00:25 INFO    scenario LNInit     channel_id should be: 330953000026112
2024-07-09 15:00:25 INFO    scenario LNInit   Waiting for graph gossip sync, LN nodes remaining: [0, 1, 2]
2024-07-09 15:00:25 INFO    scenario LNInit    node 0 not synced (channels: 0/2, nodes: 1/3)
2024-07-09 15:00:26 INFO    scenario LNInit    node 1 not synced (channels: 0/2, nodes: 1/3)
2024-07-09 15:00:26 INFO    scenario LNInit    node 2 not synced (channels: 0/2, nodes: 1/3)
2024-07-09 11:00:26 DEBUG   test     Executing RPC method: scenarios_list_running

```