### PR TITLE
ci: fix deploy paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           file: src/templates/rpc/Dockerfile_rpc
           platforms: linux/amd64,linux/arm64
-          context: .
+          context: src/warnet/templates/rpc
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -52,7 +52,7 @@ jobs:
         with:
           file: src/templates/rpc/Dockerfile_rpc_dev
           platforms: linux/amd64,linux/arm64
-          context: .
+          context: src/warnet/templates/rpc
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_RPC_REPO }}:dev
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Final broken path following reshuffle. Not caught until push to `main` as it doesn't run otherwise (and was in a "hidden" dir: `./github`)