### PR TITLE
Quickstart updates

### DIFF
--- a/resources/scripts/quick_start.sh
+++ b/resources/scripts/quick_start.sh
@@ -120,10 +120,14 @@ if [ -n "$docker_path" ]; then
     fi
 fi
 
+
+kubectl_path=$(command -v kubectl || true)
+if [ -n "$kubectl_path" ]; then
+    print_partial_message " ⭐️ Found " "kubectl" ": $kubectl_path " "$BOLD"
 else
-    print_partial_message " 💥 Could not find " "$current_user" " in the docker group. Please add it like this..." "$BOLD"
-    print_message "" "   sudo usermod -aG docker $current_user && newgrp docker" "$BOLD"
-    exit 1
+    print_partial_message " 💥 Could not find " "kubectl" ". Please follow this link to install it..." "$BOLD"
+    print_message "" "   https://kubernetes.io/docs/tasks/tools/" "$BOLD"
+    ERROR_CODE=127
 fi
 
 helm_path=$(command -v helm || true)

--- a/resources/scripts/quick_start.sh
+++ b/resources/scripts/quick_start.sh
@@ -45,6 +45,13 @@ print_partial_message() {
     echo -e "${color}${pre_message}${format}${formatted_part}${RESET}${color}${post_message}${RESET}"
 }
 
+prompt_user() {
+    local prompt="$1"
+    tput bold  # Make the prompt bold
+    echo "$prompt"
+    tput sgr0   # Reset formatting
+}
+
 print_message "" "" ""
 print_message "" "   ╭───────────────────────────╮" ""
 print_message "" "   │  Welcome to Warnet Setup  │" ""
@@ -53,23 +60,23 @@ print_message "" "" ""
 print_message "" "    Let's find out if your system has what it takes to run Warnet..." ""
 print_message "" "" ""
 
-minikube_path=$(command -v minikube || true)
-if [ -n "$minikube_path" ]; then
-    print_partial_message " ⭐️ Found " "minikube" ": $minikube_path " "$BOLD"
-else
-    print_partial_message " 💥 Could not find " "minikube" ". Please follow this link to install it..." "$BOLD"
-    print_message "" "   https://minikube.sigs.k8s.io/docs/start/" "$BOLD"
-    exit 127
+prompt_user "Use [1] minikube (Default) or [2] docker-desktop? Enter 1 or 2: "
+read -r choice
+
+if [[ "$choice" == "1" || -z "$choice" ]]; then
+   choice=1
+elif ! [[ "$choice" == "2" ]]; then
+   echo "    Please enter 1 for minikube or 2 for docker-desktop."
+   exit 1
 fi
 
-kubectl_path=$(command -v kubectl || true)
-if [ -n "$kubectl_path" ]; then
-    print_partial_message " ⭐️ Found " "kubectl" ": $kubectl_path " "$BOLD"
-else
-    print_partial_message " 💥 Could not find " "kubectl" ". Please follow this link to install it..." "$BOLD"
-    print_message "" "   https://kubernetes.io/docs/tasks/tools/" "$BOLD"
-    exit 127
+if [[ "$choice" == "1" || -z "$choice" ]]; then
+   approach="minikube"
+elif [[ "$choice" == "2" ]]; then
+   approach="docker-desktop"
 fi
+
+print_partial_message " ⭐️ You chose " ""$approach"" "." "$BOLD"
 
 docker_path=$(command -v docker || true)
 if [ -n "$docker_path" ]; then

--- a/resources/scripts/quick_start.sh
+++ b/resources/scripts/quick_start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+ERROR_CODE=0
 
 is_cygwin_etal() {
     uname -s | grep -qE "CYGWIN|MINGW|MSYS"
@@ -10,7 +11,7 @@ is_wsl() {
 }
 if is_cygwin_etal || is_wsl; then
     echo "Quick start does not support Windows"
-    exit 1
+    ERROR_CODE=1
 fi
 
 
@@ -76,7 +77,7 @@ if [ -n "$docker_path" ]; then
 else
     print_partial_message " 💥 Could not find " "docker" ". Please follow this link to install Docker Engine..." "$BOLD"
     print_message "" "   https://docs.docker.com/engine/install/" "$BOLD"
-    exit 127
+    ERROR_CODE=127
 fi
 
 current_user=$(whoami)
@@ -94,7 +95,7 @@ if [ -n "$helm_path" ]; then
 else
     print_partial_message " 💥 Could not find " "helm" ". Please follow this link to install it..." "$BOLD"
     print_message "" "   https://helm.sh/docs/intro/install/" "$BOLD"
-    exit 127
+    ERROR_CODE=127
 fi
 
 just_path=$(command -v just || true)
@@ -103,6 +104,7 @@ if [ -n "$just_path" ]; then
 else
     print_partial_message " 💥 Could not find " "just" ". Please follow this link to install it..." "$BOLD"
     print_message "" "   https://github.com/casey/just?tab=readme-ov-file#pre-built-binaries" "$BOLD"
+    ERROR_CODE=127
 fi
 
 python_path=$(command -v python3 || true)
@@ -133,4 +135,7 @@ if [ -n "$bpf_status" ]; then
 else
     print_partial_message " 💥 Could not find " "BPF" ". Please figure out how to enable Berkeley Packet Filters in your kernel." "$BOLD"
     exit 1
+if [ $ERROR_CODE -ne 0 ]; then
+    print_message "" "There were errors in the setup process. Please fix them and try again." "$BOLD"
+    exit $ERROR_CODE
 fi

--- a/resources/scripts/quick_start.sh
+++ b/resources/scripts/quick_start.sh
@@ -46,9 +46,9 @@ print_partial_message() {
 }
 
 print_message "" "" ""
-print_message "" "   ╭───────────────────────────────────╮" ""
-print_message "" "   │  Welcome to the Warnet Quickstart │" ""
-print_message "" "   ╰───────────────────────────────────╯" ""
+print_message "" "   ╭───────────────────────────╮" ""
+print_message "" "   │  Welcome to Warnet Setup  │" ""
+print_message "" "   ╰───────────────────────────╯" ""
 print_message "" "" ""
 print_message "" "    Let's find out if your system has what it takes to run Warnet..." ""
 print_message "" "" ""

--- a/resources/scripts/quick_start.sh
+++ b/resources/scripts/quick_start.sh
@@ -120,6 +120,20 @@ if [ -n "$docker_path" ]; then
     fi
 fi
 
+if [[ "$approach" == "minikube" ]]; then
+    minikube_path=$(command -v minikube || true)
+    if [[ "$(uname)" == "Darwin" ]] && command -v minikube &> /dev/null && [[ "$(minikube version --short)" == "v1.33.1" ]]; then
+        print_partial_message " 💥 Could not find " "minikube version > 1.33.1" ". Please upgrade..." "$BOLD"
+        print_message "" "   https://minikube.sigs.k8s.io/docs/start/" "$BOLD"
+        ERROR_CODE=127
+    elif [ -n "$minikube_path" ]; then
+        print_partial_message " ⭐️ Found " "minikube" ": $minikube_path " "$BOLD"
+    else
+        print_partial_message " 💥 Could not find " "minikube" ". Please follow this link to install it..." "$BOLD"
+        print_message "" "   https://minikube.sigs.k8s.io/docs/start/" "$BOLD"
+        ERROR_CODE=127
+    fi
+fi
 
 kubectl_path=$(command -v kubectl || true)
 if [ -n "$kubectl_path" ]; then


### PR DESCRIPTION
### Issue
https://github.com/bitcoin-dev-project/warnet/issues/417 

### Solution
The commits detail each solution, but broadly speaking they check for and run Docker Desktop if minikube is unavailable or if minikube has a known broken version on Mac. Otherwise, the script still treats minikube as the happy path. Looking for feedback on this approach.

- [x] Check if docker is running
- [ ] When users follow install minikube instructions, they end up doinging `minikube start` twice because the minikube installation instructions on the web tell the user to do `minikube start`