### PR TITLE
better log-grepper

### DIFF
--- a/src/warnet/backend/kubernetes_backend.py
+++ b/src/warnet/backend/kubernetes_backend.py
@@ -313,7 +313,7 @@ class KubernetesBackend:
         messages.sort(key=lambda x: x["time"])
         return messages
 
-    def logs_grep(self, pattern: str, network: str):
+    def logs_grep(self, pattern: str, network: str, k8s_timestamps=False):
         compiled_pattern = re.compile(pattern)
         matching_logs = []
 
@@ -329,7 +329,7 @@ class KubernetesBackend:
                     name=pod.metadata.name,
                     container=BITCOIN_CONTAINER_NAME,
                     namespace=self.namespace,
-                    timestamps=False,
+                    timestamps=k8s_timestamps,
                     _preload_content=False,
                 )
 

--- a/src/warnet/backend/kubernetes_backend.py
+++ b/src/warnet/backend/kubernetes_backend.py
@@ -336,7 +336,8 @@ class KubernetesBackend:
                 for log_entry in log_stream:
                     log_entry_str = log_entry.decode("utf-8").strip()
                     if compiled_pattern.search(log_entry_str):
-                        matching_logs.append(log_entry_str)
+                        pod_prefixed_log = f"{pod.metadata.name}: {log_entry_str}"
+                        matching_logs.append(pod_prefixed_log)
             except ApiException as e:
                 print(f"Error fetching logs for pod {pod.metadata.name}: {e}")
 

--- a/src/warnet/backend/kubernetes_backend.py
+++ b/src/warnet/backend/kubernetes_backend.py
@@ -313,7 +313,7 @@ class KubernetesBackend:
         messages.sort(key=lambda x: x["time"])
         return messages
 
-    def logs_grep(self, pattern: str, network: str, k8s_timestamps=False):
+    def logs_grep(self, pattern: str, network: str, k8s_timestamps=False, no_sort=False):
         compiled_pattern = re.compile(pattern)
         matching_logs = []
         pods = self.client.list_namespaced_pod(self.namespace)
@@ -335,7 +335,7 @@ class KubernetesBackend:
             except ApiException as e:
                 print(f"Error fetching logs for pod {pod.metadata.name}: {e}")
 
-        sorted_logs = sorted(matching_logs, key=lambda x: x[0])
+        sorted_logs = matching_logs if no_sort else sorted(matching_logs, key=lambda x: x[0])
         # Prepend pod names
         formatted_logs = [f"{pod_name}: {log}" for log, pod_name in sorted_logs]
 

--- a/src/warnet/backend/kubernetes_backend.py
+++ b/src/warnet/backend/kubernetes_backend.py
@@ -329,7 +329,7 @@ class KubernetesBackend:
                     name=pod.metadata.name,
                     container=BITCOIN_CONTAINER_NAME,
                     namespace=self.namespace,
-                    timestamps=True,
+                    timestamps=False,
                     _preload_content=False,
                 )
 

--- a/src/warnet/cli/bitcoin.py
+++ b/src/warnet/cli/bitcoin.py
@@ -47,9 +47,15 @@ def messages(node_a, node_b, network):
 
 @bitcoin.command()
 @click.argument("pattern", type=str, required=True)
+@click.option("--show-k8s-timestamps", is_flag=True, default=False, show_default=True)
 @click.option("--network", default="warnet", show_default=True)
-def grep_logs(pattern, network):
+def grep_logs(pattern, network, show_k8s_timestamps):
     """
     Grep combined logs via fluentd using regex <pattern>
     """
-    print(rpc_call("logs_grep", {"network": network, "pattern": pattern}))
+    print(
+        rpc_call(
+            "logs_grep",
+            {"network": network, "pattern": pattern, "k8s_timestamps": show_k8s_timestamps},
+        )
+    )

--- a/src/warnet/cli/bitcoin.py
+++ b/src/warnet/cli/bitcoin.py
@@ -48,14 +48,20 @@ def messages(node_a, node_b, network):
 @bitcoin.command()
 @click.argument("pattern", type=str, required=True)
 @click.option("--show-k8s-timestamps", is_flag=True, default=False, show_default=True)
+@click.option("--no-sort", is_flag=True, default=False, show_default=True)
 @click.option("--network", default="warnet", show_default=True)
-def grep_logs(pattern, network, show_k8s_timestamps):
+def grep_logs(pattern, network, show_k8s_timestamps, no_sort):
     """
     Grep combined logs via fluentd using regex <pattern>
     """
     print(
         rpc_call(
             "logs_grep",
-            {"network": network, "pattern": pattern, "k8s_timestamps": show_k8s_timestamps},
+            {
+                "network": network,
+                "pattern": pattern,
+                "k8s_timestamps": show_k8s_timestamps,
+                "no_sort": no_sort,
+            },
         )
     )

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -570,13 +570,15 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
-    def logs_grep(self, pattern: str, network: str = "warnet", k8s_timestamps=False) -> str:
+    def logs_grep(
+        self, pattern: str, network: str = "warnet", k8s_timestamps=False, no_sort=False
+    ) -> str:
         """
         Grep the logs from the fluentd container for a regex pattern
         """
         try:
             wn = self.get_warnet(network)
-            return wn.container_interface.logs_grep(pattern, network, k8s_timestamps)
+            return wn.container_interface.logs_grep(pattern, network, k8s_timestamps, no_sort)
         except Exception as e:
             msg = f"Error grepping logs using pattern {pattern}: {e}"
             self.logger.error(msg)

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -570,13 +570,13 @@ class Server:
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
-    def logs_grep(self, pattern: str, network: str = "warnet") -> str:
+    def logs_grep(self, pattern: str, network: str = "warnet", k8s_timestamps=False) -> str:
         """
         Grep the logs from the fluentd container for a regex pattern
         """
         try:
             wn = self.get_warnet(network)
-            return wn.container_interface.logs_grep(pattern, network)
+            return wn.container_interface.logs_grep(pattern, network, k8s_timestamps)
         except Exception as e:
             msg = f"Error grepping logs using pattern {pattern}: {e}"
             self.logger.error(msg)


### PR DESCRIPTION
I think our log grepper is quite powerful but a bit clunky to use. Improve it.

* Strip k8s logtime which makes it ugly, unless specified
* Sort the log lines alpabetically (optional, on by default, nice for bitcoind logs!)
*Prepend pod name to each log

Before this PR:

```log
₿ warcli bitcoin grep-logs Initializing
2024-08-07T10:18:21.161356518Z 2024-08-07T10:18:21.161342Z Initializing databases...
2024-08-07T10:18:21.161461071Z 2024-08-07T10:18:21.161448Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:21.323877797Z 2024-08-07T10:18:21.323865Z Initializing databases...
2024-08-07T10:18:21.323983338Z 2024-08-07T10:18:21.323967Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:21.551314578Z 2024-08-07T10:18:21.551302Z Initializing databases...
2024-08-07T10:18:21.551435664Z 2024-08-07T10:18:21.551413Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:21.817181115Z 2024-08-07T10:18:21.817157Z Initializing databases...
2024-08-07T10:18:21.817275403Z 2024-08-07T10:18:21.817255Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.060957785Z 2024-08-07T10:18:22.060934Z Initializing databases...
2024-08-07T10:18:22.061057790Z 2024-08-07T10:18:22.061031Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.305982959Z 2024-08-07T10:18:22.305969Z Initializing databases...
2024-08-07T10:18:22.306090335Z 2024-08-07T10:18:22.306068Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.305975622Z 2024-08-07T10:18:22.305958Z Initializing databases...
2024-08-07T10:18:22.306078788Z 2024-08-07T10:18:22.306064Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.455449969Z 2024-08-07T10:18:22.455391Z Initializing databases...
2024-08-07T10:18:22.455536429Z 2024-08-07T10:18:22.455513Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.441591344Z 2024-08-07T10:18:22.441581Z Initializing databases...
2024-08-07T10:18:22.441821913Z 2024-08-07T10:18:22.441712Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.485264186Z 2024-08-07T10:18:22.485250Z Initializing databases...
2024-08-07T10:18:22.485390875Z 2024-08-07T10:18:22.485365Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.547192744Z 2024-08-07T10:18:22.547181Z Initializing databases...
2024-08-07T10:18:22.547295334Z 2024-08-07T10:18:22.547280Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
2024-08-07T10:18:22.671101862Z 2024-08-07T10:18:22.671022Z Initializing databases...
2024-08-07T10:18:22.671232129Z 2024-08-07T10:18:22.671135Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
```

After this PR (sorted, with pod name prepended):

```log
₿ warcli bitcoin grep-logs Initializing
warnet-tank-000000: 2024-08-07T10:18:21.161342Z Initializing databases...
warnet-tank-000000: 2024-08-07T10:18:21.161448Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000001: 2024-08-07T10:18:21.323865Z Initializing databases...
warnet-tank-000001: 2024-08-07T10:18:21.323967Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000002: 2024-08-07T10:18:21.551302Z Initializing databases...
warnet-tank-000002: 2024-08-07T10:18:21.551413Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000003: 2024-08-07T10:18:21.817157Z Initializing databases...
warnet-tank-000003: 2024-08-07T10:18:21.817255Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000004: 2024-08-07T10:18:22.060934Z Initializing databases...
warnet-tank-000004: 2024-08-07T10:18:22.061031Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000006: 2024-08-07T10:18:22.305958Z Initializing databases...
warnet-tank-000005: 2024-08-07T10:18:22.305969Z Initializing databases...
warnet-tank-000006: 2024-08-07T10:18:22.306064Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000005: 2024-08-07T10:18:22.306068Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000008: 2024-08-07T10:18:22.441581Z Initializing databases...
warnet-tank-000008: 2024-08-07T10:18:22.441712Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000007: 2024-08-07T10:18:22.455391Z Initializing databases...
warnet-tank-000007: 2024-08-07T10:18:22.455513Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000009: 2024-08-07T10:18:22.485250Z Initializing databases...
warnet-tank-000009: 2024-08-07T10:18:22.485365Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000010: 2024-08-07T10:18:22.547181Z Initializing databases...
warnet-tank-000010: 2024-08-07T10:18:22.547280Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
warnet-tank-000011: 2024-08-07T10:18:22.671022Z Initializing databases...
warnet-tank-000011: 2024-08-07T10:18:22.671135Z Initializing chainstate Chainstate [ibd] @ height -1 (null)
```

This would mean that when for example searching for a txid of block hash, the results would be returned in node processing order.