### PR TITLE
bugfix: disable dependency tracking

### DIFF
--- a/src/warnet/cli/image_build.py
+++ b/src/warnet/cli/image_build.py
@@ -24,7 +24,7 @@ def build_image(
     action: str,
 ):
     if not build_args:
-        build_args = '"--disable-tests --without-gui --disable-bench --disable-fuzz-binary --enable-suppress-external-warnings "'
+        build_args = '"--disable-tests --without-gui --disable-bench --disable-fuzz-binary --enable-suppress-external-warnings --disable-dependency-tracking "'
     else:
         build_args = f'"{build_args}"'
 


### PR DESCRIPTION
While building on MacOS, the build would randomly fail sometimes with the following error: 

```
49.41 config.status: executing depfiles commands
53.72 config.status: error: in '/build/bitcoin':
53.72 config.status: error: Something went wrong bootstrapping makefile fragments
53.72     for automatic dependency tracking.  If GNU make was not used, consider
53.72     re-running the configure script with MAKE="gmake" (or whatever is
53.72     necessary).  You can also try re-running configure with the
53.72     '--disable-dependency-tracking' option to at least be able to build
53.72     the package (albeit without support for automatic dependency tracking).
53.72 See 'config.log' for more details
```

This PR adds the `--disable-dependency-tracking` option suggested in the error message. Once I added this, I've built several more times without running into the previous error message and I'm fairly confident adding this build option doesn't have any side effects for our use case.

Related to #441 