### PR TITLE
add kubectl and helm checks to setup-minikube

### DIFF
--- a/resources/scripts/setup_minikube.sh
+++ b/resources/scripts/setup_minikube.sh
@@ -114,6 +114,8 @@ fi
 # Start minikube with the constructed command
 eval "$MINIKUBE_CMD"
 
+echo
+print_message "" "Next, run the following command to deploy warnet" ""
+print_message "" "    warcli cluster deploy" "$BOLD"
+print_partial_message "   After that, run " "warcli network start" " to start the network." "$BOLD"
 
-
-echo Done...

--- a/resources/scripts/setup_minikube.sh
+++ b/resources/scripts/setup_minikube.sh
@@ -72,6 +72,24 @@ else
     ERROR_CODE=127
 fi
 
+kubectl_path=$(command -v kubectl || true)
+if [ -n "$kubectl_path" ]; then
+    print_partial_message " ⭐️ Found " "kubectl" ": $kubectl_path " "$BOLD"
+else
+    print_partial_message " 💥 Could not find " "kubectl" ". Please follow this link to install it..." "$BOLD"
+    print_message "" "   https://kubernetes.io/docs/tasks/tools/" "$BOLD"
+    ERROR_CODE=127
+fi
+
+helm_path=$(command -v helm || true)
+if [ -n "$helm_path" ]; then
+    print_partial_message " ⭐️ Found " "helm" ": $helm_path" "$BOLD"
+else
+    print_partial_message " 💥 Could not find " "helm" ". Please follow this link to install it..." "$BOLD"
+    print_message "" "   https://helm.sh/docs/intro/install/" "$BOLD"
+    ERROR_CODE=127
+fi
+
 if [ $ERROR_CODE -ne 0 ]; then
     print_message "" "There were errors in the setup process. Please fix them and try again." "$BOLD"
     exit $ERROR_CODE


### PR DESCRIPTION
### Issue
When users run `setup-minikube` it does not verify they have kubectl or helm, but in our workflow we need those tools. 

### Solution
Allow the `setup-minikube` command to check for helm and kubectl because minikube will want to use kubectl right away, and helm is needed for logging later on. Prompt the user to install them with helpful links.