### PR TITLE
ci: auto-update api and graphdocs

### DIFF
--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -1,0 +1,40 @@
+name: Format-api-docs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  format-api-docs:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: hynek/setup-cached-uv@v1
+      - run: |
+          echo Installing warnet python package for cli
+          uv venv
+          uv pip install -e .
+
+      - name: Run apidocs script
+        run: |
+          source .venv/bin/activate
+          python3 resources/scripts/apidocs.py
+
+      - name: Run graphdocs script
+        run: |
+          source .venv/bin/activate
+          python3 resources/scripts/graphdocs.py
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update apidocs and/or graphdocs


### PR DESCRIPTION
Automatically update apidocs and graphdocs on merge to `main` branch.

Roughly tested here: https://github.com/willcl-ark/warnet/pull/23