### PR TITLE
set resource requests and limits on tank object

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
       - uses: azure/setup-helm@v4.2.0
       - uses: medyagh/setup-minikube@master
         with:
+          cpus: max
+          memory: 10000m
           mount-path: ${{ github.workspace }}:/mnt/src
       - uses: actions/download-artifact@v4
         with:

--- a/src/warnet/cli/graph.py
+++ b/src/warnet/cli/graph.py
@@ -40,7 +40,8 @@ def create(number: int, outfile: Path, version: str, bitcoin_conf: Path, random:
 @click.option("--outfile", type=click.Path())
 @click.option("--cb", type=str)
 @click.option("--ln_image", type=str)
-def import_json(infile: Path, outfile: Path, cb: str, ln_image: str):
+@click.option("--ci", is_flag=True)
+def import_json(infile: Path, outfile: Path, cb: str, ln_image: str, ci: bool = False):
     """
     Create a cycle graph with nodes imported from lnd `describegraph` JSON file,
     and additionally include 7 extra random outbounds per node. Include lightning
@@ -64,6 +65,8 @@ def import_json(infile: Path, outfile: Path, cb: str, ln_image: str):
             graph.nodes[n]["ln_cb_image"] = cb
         if ln_image:
             graph.nodes[n]["ln_image"] = ln_image
+        if ci:
+            graph.nodes[n]["resources"] = "{}"
 
     # Save a map of LN pubkey -> Tank index
     ln_ids = {}

--- a/src/warnet/graph_schema.json
+++ b/src/warnet/graph_schema.json
@@ -16,52 +16,62 @@
   "node": {
     "type": "object",
     "properties": {
-      "version": {
-        "type": "string",
-        "comment": "Bitcoin Core version with an available Warnet tank image on Dockerhub. May also be a GitHub repository with format user/repository:branch to build from source code"},
       "image": {
         "type": "string",
-        "comment": "Bitcoin Core Warnet tank image on Dockerhub with the format repository/image:tag"},
+        "default": "bitcoindevproject/bitcoin:27.0",
+        "comment": "Bitcoin Core Warnet tank image on Dockerhub with the format repository/image:tag"
+      },
       "bitcoin_config": {
         "type": "string",
         "default": "",
-        "comment": "A string of Bitcoin Core options in command-line format, e.g. '-debug=net -blocksonly'"},
+        "comment": "A string of Bitcoin Core options in command-line format, e.g. '-debug=net -blocksonly'"
+      },
       "tc_netem": {
         "type": "string",
-        "comment": "A tc-netem command as a string beginning with 'tc qdisc add dev eth0 root netem'"},
+        "comment": "A tc-netem command as a string beginning with 'tc qdisc add dev eth0 root netem'"
+      },
       "exporter": {
         "type": "boolean",
         "default": false,
-        "comment": "Whether to attach a Prometheus data exporter to the tank"},
+        "comment": "Whether to attach a Prometheus data exporter to the tank"
+      },
       "metrics": {
         "type": "string",
-        "comment": "A space-separated string of RPC queries to scrape by Prometheus"},
+        "comment": "A space-separated string of RPC queries to scrape by Prometheus"
+      },
       "collect_logs": {
         "type": "boolean",
-        "default": false,
-        "comment": "Whether to collect Bitcoin Core debug logs with Promtail"},
+        "default": true,
+        "comment": "Whether to collect Bitcoin Core debug logs with Promtail"
+      },
       "build_args": {
         "type": "string",
         "default": "",
-        "comment": "A string of configure options used when building Bitcoin Core from source code, e.g. '--without-gui --disable-tests'"},
+        "comment": "A string of configure options used when building Bitcoin Core from source code, e.g. '--without-gui --disable-tests'"
+      },
       "ln": {
         "type": "string",
-        "comment": "Attach a lightning network node of this implementation (currently only supports 'lnd' or 'cln')"},
+        "comment": "Attach a lightning network node of this implementation (currently only supports 'lnd' or 'cln')"
+      },
       "ln_image": {
         "type": "string",
-        "comment": "Specify a lightning network node image from Dockerhub with the format repository/image:tag"},
+        "comment": "Specify a lightning network node image from Dockerhub with the format repository/image:tag"
+      },
       "ln_cb_image": {
         "type": "string",
-        "comment": "Specify a lnd Circuit Breaker image from Dockerhub with the format repository/image:tag"},
+        "comment": "Specify a lnd Circuit Breaker image from Dockerhub with the format repository/image:tag"
+      },
       "ln_config": {
         "type": "string",
-        "comment": "A string of arguments for the lightning network node in command-line format, e.g. '--protocol.wumbo-channels --bitcoin.timelockdelta=80'"}
+        "comment": "A string of arguments for the lightning network node in command-line format, e.g. '--protocol.wumbo-channels --bitcoin.timelockdelta=80'"
+      },
+      "resources": {
+        "type": "string",
+        "comment": "Kubernetes resource requests and limits for the node",
+        "default": "{'requests':{'cpu':'500m', 'memory':'500Mi'}, 'limits':{'cpu':'1000m', 'memory':'1500Mi'}}"
+      }
     },
-    "additionalProperties": false,
-    "oneOf": [
-      {"required": ["version"]},
-      {"required": ["image"]}
-    ],
+   "additionalProperties": false,
     "required": []
   },
   "edge": {
@@ -69,13 +79,16 @@
     "properties": {
       "channel_open": {
         "type": "string",
-        "comment": "Indicate that this edge is a lightning channel with these arguments passed to lnd openchannel"},
+        "comment": "Indicate that this edge is a lightning channel with these arguments passed to lnd openchannel"
+      },
       "source_policy": {
         "type": "string",
-        "comment": "Update the channel originator policy by passing these arguments passed to lnd updatechanpolicy"},
+        "comment": "Update the channel originator policy by passing these arguments passed to lnd updatechanpolicy"
+      },
       "target_policy": {
         "type": "string",
-        "comment": "Update the channel partner policy by passing these arguments passed to lnd updatechanpolicy"}
+        "comment": "Update the channel partner policy by passing these arguments passed to lnd updatechanpolicy"
+      }
     },
     "additionalProperties": false,
     "required": []

--- a/src/warnet/tank.py
+++ b/src/warnet/tank.py
@@ -46,6 +46,7 @@ class Tank:
         self.bitcoin_network = warnet.bitcoin_network
         self.version: str = ""
         self.image: str = ""
+        self.resources: dict = dict()
         self.bitcoin_config = ""
         self.netem = None
         self.exporter = False
@@ -81,7 +82,10 @@ class Tank:
             value = node.get(property, specs.get("default"))
             if property == "version":
                 self._parse_version(value)
-            setattr(self, property, value)
+            if property == "resources":
+                setattr(self, property, eval(value))
+            else:
+                setattr(self, property, value)
             graph_properties[property] = value
 
         if self.version and self.image:

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -421,15 +421,8 @@ def create_cycle_graph(n: int, version: str, bitcoin_conf: str | None, random_ve
                 conf_contents = dump_bitcoin_conf(conf_dict, for_graph=True)
 
     # populate our custom fields
-    for i, node in enumerate(graph.nodes()):
-        if random_version:
-            graph.nodes[node]["version"] = random.choice(WEIGHTED_TAGS)
-        else:
-            # One node demoing the image tag
-            if i == 1:
-                graph.nodes[node]["image"] = f"bitcoindevproject/bitcoin:{version}"
-            else:
-                graph.nodes[node]["version"] = version
+    for node in graph.nodes():
+        graph.nodes[node]["image"] = f"bitcoindevproject/bitcoin:{version}"
         graph.nodes[node]["bitcoin_config"] = conf_contents
         graph.nodes[node]["tc_netem"] = ""
         graph.nodes[node]["build_args"] = ""

--- a/test/dag_connection_test.py
+++ b/test/dag_connection_test.py
@@ -10,7 +10,7 @@ class DAGConnectionTest(TestBase):
     def __init__(self):
         super().__init__()
         self.graph_file_path = (
-            Path(os.path.dirname(__file__)) / "data" / "ten_semi_unconnected.graphml"
+            Path(os.path.dirname(__file__)) / "data" / "six_semi_unconnected.graphml"
         )
 
     def run_test(self):

--- a/test/data/6_node_ring.graphml
+++ b/test/data/6_node_ring.graphml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key id="services"        attr.name="services"         attr.type="string"   for="graph" />
-  <key id="version"         attr.name="version"          attr.type="string"   for="node" />
   <key id="image"           attr.name="image"            attr.type="string"   for="node" />
   <key id="bitcoin_config"  attr.name="bitcoin_config"   attr.type="string"   for="node" />
   <key id="tc_netem"        attr.name="tc_netem"         attr.type="string"   for="node" />
@@ -17,51 +16,27 @@
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w0 -debug=validation</data>
     </node>
     <node id="1">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w1 -debug=validation</data>
     </node>
     <node id="2">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w2 -debug=validation</data>
     </node>
     <node id="3">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w3</data>
     </node>
     <node id="4">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w4</data>
     </node>
     <node id="5">
-        <data key="version">27.0</data>
-        <data key="bitcoin_config">-uacomment=w5</data>
-    </node>
-    <node id="6">
-        <data key="version">27.0</data>
-        <data key="bitcoin_config">-uacomment=w6</data>
-    </node>
-    <node id="7">
-        <data key="version">27.0</data>
-        <data key="bitcoin_config">-uacomment=w7</data>
-    </node>
-    <node id="8">
-        <data key="version">27.0</data>
-        <data key="bitcoin_config">-uacomment=w8</data>
-    </node>
-    <node id="9">
-        <data key="version">27.0</data>
-        <data key="bitcoin_config">-uacomment=w9</data>
-    </node>
-    <node id="10">
-        <data key="version">27.0</data>
-        <data key="bitcoin_config">-uacomment=w10</data>
-    </node>
-    <node id="11">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <!-- no bitcoin_config to test unused options -->
     </node>
     <!-- connect the nodes in a ring to start -->
@@ -70,12 +45,6 @@
     <edge id="13" source="2" target="3"></edge>
     <edge id="14" source="3" target="4"></edge>
     <edge id="15" source="4" target="5"></edge>
-    <edge id="16" source="5" target="6"></edge>
-    <edge id="17" source="6" target="7"></edge>
-    <edge id="18" source="7" target="8"></edge>
-    <edge id="19" source="8" target="9"></edge>
-    <edge id="20" source="9" target="10"></edge>
-    <edge id="21" source="10" target="11"></edge>
-    <edge id="21" source="11" target="0"></edge>
+    <edge id="16" source="5" target="0"></edge>
   </graph>
 </graphml>

--- a/test/data/ln.graphml
+++ b/test/data/ln.graphml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key id="services"        attr.name="services"         attr.type="string"   for="graph" />
-  <key id="version"         attr.name="version"          attr.type="string"   for="node" />
   <key id="image"           attr.name="image"            attr.type="string"   for="node" />
   <key id="bitcoin_config"  attr.name="bitcoin_config"   attr.type="string"   for="node" />
   <key id="tc_netem"        attr.name="tc_netem"         attr.type="string"   for="node" />
@@ -18,34 +17,34 @@
   <graph edgedefault="directed">
     <data key="services">simln</data>
     <node id="0">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w0</data>
         <data key="ln">lnd</data>
         <data key="ln_image">lightninglabs/lnd:v0.17.5-beta</data>
         <data key="collect_logs">true</data>
     </node>
     <node id="1">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w1</data>
         <data key="ln">lnd</data>
         <data key="ln_cb_image">pinheadmz/circuitbreaker:278737d</data>
         <data key="collect_logs">true</data>
     </node>
     <node id="2">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w2</data>
         <data key="ln">lnd</data>
         <data key="ln_cb_image">pinheadmz/circuitbreaker:278737d</data>
         <data key="ln_config">--bitcoin.timelockdelta=33</data>
     </node>
     <node id="3">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w2</data>
         <data key="ln">cln</data>
         <data key="ln_config">--cltv-delta=33</data>
     </node>
     <node id="4">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w3</data>
     </node>
     <edge id="1" source="0" target="1"></edge>

--- a/test/data/logging.graphml
+++ b/test/data/logging.graphml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key id="services"        attr.name="services"         attr.type="string"   for="graph" />
-  <key id="version"         attr.name="version"          attr.type="string"   for="node" />
   <key id="image"           attr.name="image"            attr.type="string"   for="node" />
   <key id="bitcoin_config"  attr.name="bitcoin_config"   attr.type="string"   for="node" />
   <key id="tc_netem"        attr.name="tc_netem"         attr.type="string"   for="node" />
@@ -17,16 +16,16 @@
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
   <graph edgedefault="directed">
     <node id="0">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="exporter">true</data>
     </node>
     <node id="1">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="exporter">true</data>
         <data key="metrics">txrate=getchaintxstats(10)["txrate"]</data>
     </node>
     <node id="2">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
     </node>
     <edge id="1" source="0" target="1"></edge>
     <edge id="2" source="1" target="2"></edge>

--- a/test/data/permutations.graphml
+++ b/test/data/permutations.graphml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key id="services"        attr.name="services"         attr.type="string"   for="graph" />
-  <key id="version"         attr.name="version"          attr.type="string"   for="node" />
   <key id="image"           attr.name="image"            attr.type="string"   for="node" />
   <key id="bitcoin_config"  attr.name="bitcoin_config"   attr.type="string"   for="node" />
   <key id="tc_netem"        attr.name="tc_netem"         attr.type="string"   for="node" />
@@ -17,7 +16,7 @@
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
   <graph edgedefault="directed">
     <node id="0">
-      <data key="version">27.0</data>
+      <data key="image">bitcoindevproject/bitcoin:27.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -33,7 +32,7 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="2">
-      <data key="version">27.0</data>
+      <data key="image">bitcoindevproject/bitcoin:27.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -41,7 +40,7 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="3">
-      <data key="version">27.0</data>
+      <data key="image">bitcoindevproject/bitcoin:27.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -49,7 +48,7 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="4">
-      <data key="version">27.0</data>
+      <data key="image">bitcoindevproject/bitcoin:27.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -57,23 +56,7 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="5">
-      <data key="version">27.0</data>
-      <data key="bitcoin_config" />
-      <data key="tc_netem" />
-      <data key="build_args" />
-      <data key="exporter">False</data>
-      <data key="collect_logs">False</data>
-    </node>
-    <node id="6">
-      <data key="version">27.0</data>
-      <data key="bitcoin_config" />
-      <data key="tc_netem" />
-      <data key="build_args" />
-      <data key="exporter">False</data>
-      <data key="collect_logs">False</data>
-    </node>
-    <node id="7">
-      <data key="version">27.0</data>
+      <data key="image">bitcoindevproject/bitcoin:27.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -87,7 +70,5 @@
     <edge source="2" target="4" id="0" />
     <edge source="3" target="5" id="0" />
     <edge source="5" target="4" id="0" />
-    <edge source="5" target="6" id="0" />
-    <edge source="6" target="7" id="0" />
   </graph>
 </graphml>

--- a/test/data/scenario_connect_dag.py
+++ b/test/data/scenario_connect_dag.py
@@ -20,7 +20,7 @@ class ConnectionType(Enum):
 class ConnectDag(WarnetTestFramework):
     def set_test_params(self):
         # This is just a minimum
-        self.num_nodes = 10
+        self.num_nodes = 6
 
     def add_options(self, parser):
         parser.add_argument(
@@ -63,13 +63,6 @@ class ConnectDag(WarnetTestFramework):
         self.connect_nodes(2, 4)
         self.connect_nodes(3, 5)
         self.connect_nodes(5, 4)
-        self.connect_nodes(5, 6)
-        self.connect_nodes(6, 7)
-
-        # Nodes 8 & 9 shall come pre-connected. Attempt to connect them anyway to test the handling
-        # of dns node addresses
-        self.connect_nodes(8, 9)
-        self.connect_nodes(9, 8)
 
         self.sync_all()
 
@@ -79,10 +72,6 @@ class ConnectDag(WarnetTestFramework):
         three_peers = self.nodes[3].getpeerinfo()
         four_peers = self.nodes[4].getpeerinfo()
         five_peers = self.nodes[5].getpeerinfo()
-        six_peers = self.nodes[6].getpeerinfo()
-        seven_peers = self.nodes[7].getpeerinfo()
-        eight_peers = self.nodes[8].getpeerinfo()
-        nine_peers = self.nodes[9].getpeerinfo()
 
         for tank in self.warnet.tanks:
             self.log.info(
@@ -104,13 +93,6 @@ class ConnectDag(WarnetTestFramework):
         self.assert_connection(four_peers, 5, ConnectionType.IP)
         self.assert_connection(five_peers, 3, ConnectionType.IP)
         self.assert_connection(five_peers, 4, ConnectionType.DNS)
-        self.assert_connection(five_peers, 6, ConnectionType.DNS)
-        self.assert_connection(six_peers, 5, ConnectionType.IP)
-        self.assert_connection(six_peers, 7, ConnectionType.DNS)
-        self.assert_connection(seven_peers, 6, ConnectionType.IP)
-        # Check the pre-connected nodes
-        self.assert_connection(eight_peers, 9, ConnectionType.DNS)
-        self.assert_connection(nine_peers, 8, ConnectionType.IP)
 
         self.log.info(
             f"Successfully ran the connect_dag.py scenario using a temporary file: "

--- a/test/data/services.graphml
+++ b/test/data/services.graphml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key id="services"        attr.name="services"         attr.type="string"   for="graph" />
-  <key id="version"         attr.name="version"          attr.type="string"   for="node" />
   <key id="image"           attr.name="image"            attr.type="string"   for="node" />
   <key id="bitcoin_config"  attr.name="bitcoin_config"   attr.type="string"   for="node" />
   <key id="tc_netem"        attr.name="tc_netem"         attr.type="string"   for="node" />
@@ -18,7 +17,7 @@
   <graph edgedefault="directed">
     <!-- <data key="services">cadvisor forkobserver addrmanobserver grafana nodeexporter prometheus</data> -->
     <node id="0">
-        <data key="version">27.0</data>
+        <data key="image">bitcoindevproject/bitcoin:27.0</data>
         <data key="bitcoin_config">-uacomment=w0 -debug=validation</data>
         <data key="exporter">true</data>
         <data key="ln">lnd</data>

--- a/test/data/services.graphml
+++ b/test/data/services.graphml
@@ -11,6 +11,7 @@
   <key id="ln_image"        attr.name="ln_image"         attr.type="string"   for="node" />
   <key id="ln_cb_image"     attr.name="ln_cb_image"      attr.type="string"   for="node" />
   <key id="ln_config"       attr.name="ln_config"        attr.type="string"   for="node" />
+  <key id="resources"       attr.name="resources"        attr.type="string"   for="node" />
   <key id="channel_open"    attr.name="channel_open"     attr.type="string"   for="edge" />
   <key id="source_policy"   attr.name="source_policy"    attr.type="string"   for="edge" />
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
@@ -21,6 +22,7 @@
         <data key="bitcoin_config">-uacomment=w0 -debug=validation</data>
         <data key="exporter">true</data>
         <data key="ln">lnd</data>
+        <data key="resources">{'requests':{'cpu':'25m', 'memory':'100Mi'}, 'limits':{'cpu':'100m', 'memory':'250Mi'}}</data>
     </node>
   </graph>
 </graphml>

--- a/test/data/six_semi_unconnected.graphml
+++ b/test/data/six_semi_unconnected.graphml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns">
   <key id="services"        attr.name="services"         attr.type="string"   for="graph" />
-  <key id="version"         attr.name="version"          attr.type="string"   for="node" />
   <key id="image"           attr.name="image"            attr.type="string"   for="node" />
   <key id="bitcoin_config"  attr.name="bitcoin_config"   attr.type="string"   for="node" />
   <key id="tc_netem"        attr.name="tc_netem"         attr.type="string"   for="node" />
@@ -17,7 +16,7 @@
   <key id="target_policy"   attr.name="target_policy"    attr.type="string"   for="edge" />
   <graph edgedefault="directed">
     <node id="0">
-      <data key="version">26.0</data>
+      <data key="image">bitcoindevproject/bitcoin:26.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -33,7 +32,7 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="2">
-      <data key="version">26.0</data>
+      <data key="image">bitcoindevproject/bitcoin:26.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -41,7 +40,7 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="3">
-      <data key="version">26.0</data>
+      <data key="image">bitcoindevproject/bitcoin:26.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -49,7 +48,7 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="4">
-      <data key="version">26.0</data>
+      <data key="image">bitcoindevproject/bitcoin:26.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
@@ -57,45 +56,13 @@
       <data key="collect_logs">False</data>
     </node>
     <node id="5">
-      <data key="version">26.0</data>
+      <data key="image">bitcoindevproject/bitcoin:26.0</data>
       <data key="bitcoin_config" />
       <data key="tc_netem" />
       <data key="build_args" />
       <data key="exporter">False</data>
       <data key="collect_logs">False</data>
     </node>
-    <node id="6">
-      <data key="version">26.0</data>
-      <data key="bitcoin_config" />
-      <data key="tc_netem" />
-      <data key="build_args" />
-      <data key="exporter">False</data>
-      <data key="collect_logs">False</data>
-    </node>
-    <node id="7">
-      <data key="version">26.0</data>
-      <data key="bitcoin_config" />
-      <data key="tc_netem" />
-      <data key="build_args" />
-      <data key="exporter">False</data>
-      <data key="collect_logs">False</data>
-    </node>
-    <node id="8">
-      <data key="version">26.0</data>
-      <data key="bitcoin_config" />
-      <data key="tc_netem" />
-      <data key="build_args" />
-      <data key="exporter">False</data>
-      <data key="collect_logs">False</data>
-    </node>
-    <node id="9">
-      <data key="version">26.0</data>
-      <data key="bitcoin_config" />
-      <data key="tc_netem" />
-      <data key="build_args" />
-      <data key="exporter">False</data>
-      <data key="collect_logs">False</data>
-    </node>
-    <edge id="0" source="8" target="9"></edge>
+    <edge id="0" source="3" target="4"></edge>
   </graph>
 </graphml>

--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -41,7 +41,7 @@ class GraphTest(TestBase):
         self.log.info(f"CLI tool importing json and writing test graph file: {self.tf_import}")
         self.log.info(
             self.warcli(
-                f"graph import-json {self.json_file_path} --outfile={self.tf_import} --ln_image=carlakirkcohen/lnd:attackathon --cb=carlakirkcohen/circuitbreaker:attackathon-test",
+                f"graph import-json {self.json_file_path} --outfile={self.tf_import} --ln_image=carlakirkcohen/lnd:attackathon --cb=carlakirkcohen/circuitbreaker:attackathon-test --ci",
                 network=False,
             )
         )

--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -35,11 +35,7 @@ class GraphTest(TestBase):
 
     def test_graph_creation_and_import(self):
         self.log.info(f"CLI tool creating test graph file: {self.tf_create}")
-        self.log.info(
-            self.warcli(
-                f"graph create 10 --outfile={self.tf_create} --version={DEFAULT_TAG}", network=False
-            )
-        )
+        self.log.info(self.warcli(f"graph create 10 --outfile={self.tf_create}", network=False))
         self.wait_for_predicate(lambda: Path(self.tf_create).exists())
 
         self.log.info(f"CLI tool importing json and writing test graph file: {self.tf_import}")

--- a/test/onion_test.py
+++ b/test/onion_test.py
@@ -10,7 +10,7 @@ from test_base import TestBase
 class OnionTest(TestBase):
     def __init__(self):
         super().__init__()
-        self.graph_file_path = Path(os.path.dirname(__file__)) / "data" / "12_node_ring.graphml"
+        self.graph_file_path = Path(os.path.dirname(__file__)) / "data" / "6_node_ring.graphml"
         self.onion_addr = None
 
     def run_test(self):

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -10,7 +10,7 @@ from test_base import TestBase
 class RPCTest(TestBase):
     def __init__(self):
         super().__init__()
-        self.graph_file_path = Path(os.path.dirname(__file__)) / "data" / "12_node_ring.graphml"
+        self.graph_file_path = Path(os.path.dirname(__file__)) / "data" / "6_node_ring.graphml"
 
     def run_test(self):
         self.start_server()

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -9,7 +9,7 @@ from test_base import TestBase
 class ScenariosTest(TestBase):
     def __init__(self):
         super().__init__()
-        self.graph_file_path = Path(os.path.dirname(__file__)) / "data" / "12_node_ring.graphml"
+        self.graph_file_path = Path(os.path.dirname(__file__)) / "data" / "6_node_ring.graphml"
 
     def run_test(self):
         try:


### PR DESCRIPTION
tell k8s up front the min and max CPU, memory we want for a tank. can be overriden from a graph file if a tank needs more/less.

did some testing, and this allows k8s to do autoscaling when trying to start a network. this means if a cluster does not have enough nodes and you try to start a network with 50 tanks, k8s will keep the pods in pending until it adds more nodes to the cluster. this allows for much more graceful cluster management.

annoyingly, if the pod is already scheduled and the workload of the pod increases, k8s can't do cluster autoscaling anymore, but there might be another way to tackle this via vertical scaling. as of today, the best way to handle this would be to set a much higher `limits`, which should help? (not tested).

## testing

tested on digital ocean cluster with autoscaling, has not been tested on Minikube or docker desktop, but _should_ work since requests and limits are not k8s specific config options.