### PR TITLE
tune gcc to be less resource hungry

### DIFF
--- a/resources/images/bitcoin/Dockerfile
+++ b/resources/images/bitcoin/Dockerfile
@@ -43,7 +43,7 @@ RUN set -ex \
     && ./autogen.sh \
     && ./configure \
     LDFLAGS=-L`ls -d /opt/db*`/lib/ \
-    CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+    CPPFLAGS="-g0 -I`ls -d /opt/db*`/include/ --param ggc-min-expand=1 --param ggc-min-heapsize=32768" \
     --prefix=${BITCOIN_PREFIX} \
     ${BUILD_ARGS} \
     && make -j$(nproc) \


### PR DESCRIPTION
fix OOM on docker desktop when building custom images. takes the recommendations from https://github.com/bitcoin/bitcoin/tree/master/doc/build-unix.md

fixes #441