### PR TITLE
Add a config file 

### DIFF
--- a/resources/configs/warcli.yaml
+++ b/resources/configs/warcli.yaml
@@ -1,0 +1,1 @@
+backend:

--- a/src/warnet/cli/config.py
+++ b/src/warnet/cli/config.py
@@ -23,18 +23,19 @@ class Config:
             self.config = yaml.safe_load(file)
 
     def _save_config(self):
+        cleaned_config = {k: (v if v is not None else '') for k, v in self.config.items()}
         with open(CONFIG_PATH, "w") as file:
-            yaml.safe_dump(self.config, file)
+            yaml.safe_dump(cleaned_config, file)
 
     def read(self, key):
-        if key in self.config and self.config[key] is not None:
+        if key in self.config and (self.config[key] is not None and self.config[key] != ''):
             return self.config[key]
         else:
             raise KeyNotSetError(key)
 
     def write(self, key, value):
         if key in self.config:
-            if self.config[key] is None:
+            if self.config[key] is None or self.config[key] == '':
                 self.config[key] = value
                 self._save_config()
             else:

--- a/src/warnet/cli/config.py
+++ b/src/warnet/cli/config.py
@@ -1,12 +1,13 @@
-import yaml
-
 from importlib.resources import files
+
+import yaml
 
 CONFIG_PATH = files("configs").joinpath("warcli.yaml")
 
 
 class KeyNotSetError(Exception):
     """Custom exception raised when trying to access a key that is not set."""
+
     def __init__(self, key):
         self.key = key
         self.message = f"Key '{key}' is not set in the configuration."
@@ -18,11 +19,11 @@ class Config:
         self._load_config()
 
     def _load_config(self):
-        with open(CONFIG_PATH, 'r') as file:
+        with open(CONFIG_PATH) as file:
             self.config = yaml.safe_load(file)
 
     def _save_config(self):
-        with open(CONFIG_PATH, 'w') as file:
+        with open(CONFIG_PATH, "w") as file:
             yaml.safe_dump(self.config, file)
 
     def read(self, key):

--- a/src/warnet/cli/config.py
+++ b/src/warnet/cli/config.py
@@ -1,0 +1,42 @@
+import yaml
+
+from importlib.resources import files
+
+CONFIG_PATH = files("configs").joinpath("warcli.yaml")
+
+
+class KeyNotSetError(Exception):
+    """Custom exception raised when trying to access a key that is not set."""
+    def __init__(self, key):
+        self.key = key
+        self.message = f"Key '{key}' is not set in the configuration."
+        super().__init__(self.message)
+
+
+class Config:
+    def __init__(self):
+        self._load_config()
+
+    def _load_config(self):
+        with open(CONFIG_PATH, 'r') as file:
+            self.config = yaml.safe_load(file)
+
+    def _save_config(self):
+        with open(CONFIG_PATH, 'w') as file:
+            yaml.safe_dump(self.config, file)
+
+    def read(self, key):
+        if key in self.config and self.config[key] is not None:
+            return self.config[key]
+        else:
+            raise KeyNotSetError(key)
+
+    def write(self, key, value):
+        if key in self.config:
+            if self.config[key] is None:
+                self.config[key] = value
+                self._save_config()
+            else:
+                raise ValueError(f"Key '{key}' is already set. Cannot overwrite.")
+        else:
+            raise KeyError(f"Key '{key}' does not exist in the configuration.")

--- a/src/warnet/cli/main.py
+++ b/src/warnet/cli/main.py
@@ -5,8 +5,8 @@ from importlib.resources import files
 
 import click
 from rich import print as richprint
-
 from warnet.cli.config import Config, KeyNotSetError
+
 from .bitcoin import bitcoin
 from .cluster import cluster
 from .graph import graph
@@ -74,7 +74,7 @@ def setup():
     config = Config()
     try:
         backend_name = config.read("backend")
-    except KeyNotSetError as e:
+    except KeyNotSetError:
         print("We need to set the backend for warnet.")
         user_input = input("Use [1] minikube (Default) or [2] docker-desktop? Enter 1 or 2: ")
         if user_input == "1" or user_input == "":

--- a/src/warnet/cli/main.py
+++ b/src/warnet/cli/main.py
@@ -1,10 +1,12 @@
 import os
 import subprocess
+import sys
 from importlib.resources import files
 
 import click
 from rich import print as richprint
 
+from warnet.cli.config import Config, KeyNotSetError
 from .bitcoin import bitcoin
 from .cluster import cluster
 from .graph import graph
@@ -69,6 +71,22 @@ cli.add_command(help_command)
 @cli.command()
 def setup():
     """Check Warnet requirements are installed"""
+    config = Config()
+    try:
+        backend_name = config.read("backend")
+    except KeyNotSetError as e:
+        print("We need to set the backend for warnet.")
+        user_input = input("Use [1] minikube (Default) or [2] docker-desktop? Enter 1 or 2: ")
+        if user_input == "1" or user_input == "":
+            backend_name = "minikube"
+            config.write("backend", backend_name)
+        elif user_input == "2":
+            backend_name = "docker-desktop"
+            config.write("backend", backend_name)
+        else:
+            print("Next time, please enter a 1 or a 2.")
+            sys.exit(1)
+
     try:
         process = subprocess.Popen(
             ["/bin/bash", str(QUICK_START_PATH)],


### PR DESCRIPTION
### Issue
Need a way to hold warnet config elements.
See issue: [#458](https://github.com/bitcoin-dev-project/warnet/issues/458)

### Solution
Use a yaml file to hold values. 

Rules for the config:

    Any item set in the config file cannot be changed.
    Any item not sent in the config file maybe set later, but once set, it cannot be changed.
