### PR TITLE
add global intra-pod rate-limiter

### DIFF
--- a/resources/manifests/istio-global-rate-limit.yaml
+++ b/resources/manifests/istio-global-rate-limit.yaml
@@ -1,0 +1,62 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: global-ratelimit
+  namespace: istio-system
+spec:
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        context: ANY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.network.ratelimit
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.ratelimit.v3.RateLimit
+            domain: global
+            failure_mode_deny: true
+            rate_limit_service:
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: rate_limit_cluster
+              transport_api_version: V3
+    - applyTo: CLUSTER
+      match:
+        context: ANY
+      patch:
+        operation: ADD
+        value:
+          name: rate_limit_cluster
+          type: STRICT_DNS
+          connect_timeout: 0.25s
+          lb_policy: ROUND_ROBIN
+          http2_protocol_options: {}
+          load_assignment:
+            cluster_name: rate_limit_cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: ratelimit.istio-system.svc.cluster.local
+                          port_value: 8081
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ratelimit-config
+  namespace: istio-system
+data:
+  config.yaml: |
+    domain: global
+    descriptors:
+      - key: generic_key
+        value: default
+        rate_limit:
+          unit: second
+          requests_per_unit: 1000 # Bytes

--- a/resources/scripts/deploy.sh
+++ b/resources/scripts/deploy.sh
@@ -20,6 +20,16 @@ kubectl apply -f "$WAR_MANIFESTS/namespace.yaml"
 kubectl apply -f "$WAR_MANIFESTS/rbac-config.yaml"
 kubectl apply -f "$WAR_MANIFESTS/warnet-rpc-service.yaml"
 
+# Setup istio global rate limiter
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+kubectl create namespace istio-system
+helm install istio-base istio/base -n istio-system --set defaultRevision=default
+helm install istiod istio/istiod -n istio-system --wait
+helm status istiod -n istio-system
+kubectl get deployments -n istio-system --output wide
+kubectl apply -f "$WAR_MANIFESTS/istio-global-rate-limit.yaml"
+
 # Deploy rpc server
 if [ -n "${WAR_DEV+x}" ]; then # Dev mode selector
     # Build image in local registry


### PR DESCRIPTION
Rate-limit traffic between pods.

Folks doing DoS attacks might otherwise [take|bog] down entire network.