### PR TITLE
Add stderr to scenario output

### DIFF
--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -165,10 +165,12 @@ class Server:
         self.jsonrpc.register(self.logs_grep)
 
     def scenario_log(self, proc):
-        while not proc.stdout:
+        while not proc.stdout and not proc.stderr:
             time.sleep(0.1)
         for line in proc.stdout:
             self.scenario_logger.info(line.decode().rstrip())
+        for line in proc.stderr:
+            self.scenario_logger.error(line.decode().rstrip())
 
     def get_warnet(self, network: str) -> Warnet:
         """


### PR DESCRIPTION
If a scenario fails on startup or otherwise prints to stderr we can't see the output in the RPC logs

How to test: Write a scenario that has a coding error in it, run the scenario. Before PR there will be no output in the logs, after PR you will see the problem.