### PR TITLE
Don't error on bringing down a pod which is not found

### DIFF
--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -112,13 +112,12 @@ def list_active_scenarios():
 @click.command()
 def down():
     """Bring down a running warnet"""
-    console.print("[bold yellow]Bringing down the warnet...[/bold yellow]")
-
-    # Delete warnet-logging namespace
-    if delete_namespace("warnet-logging"):
-        console.print("[green]Warnet logging deleted[/green]")
-    else:
-        console.print("[red]Warnet logging NOT deleted[/red]")
+    with console.status("[bold yellow]Bringing down the warnet...[/bold yellow]"):
+        # Delete warnet-logging namespace
+        if delete_namespace("warnet-logging"):
+            console.print("[green]Warnet logging deleted[/green]")
+        else:
+            console.print("[red]Warnet logging NOT deleted[/red]")
 
     # Uninstall tanks
     tanks = get_mission("tank")

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -134,7 +134,7 @@ def down():
     pods = get_pods()
     with console.status("[yellow]Cleaning up remaining pods...[/yellow]"):
         for pod in pods.items:
-            cmd = f"kubectl delete pod {pod.metadata.name}"
+            cmd = f"kubectl delete pod --ignore-not-found=true {pod.metadata.name}"
             if stream_command(cmd):
                 console.print(f"[green]Deleted pod: {pod.metadata.name}[/green]")
             else:

--- a/src/warnet/process.py
+++ b/src/warnet/process.py
@@ -10,7 +10,7 @@ def run_command(command: str) -> str:
     return result.stdout
 
 
-def stream_command(command: str, env=None) -> bool:
+def stream_command(command: str) -> bool:
     process = subprocess.Popen(
         ["/bin/bash", "-c", command],
         stdout=subprocess.PIPE,
@@ -27,6 +27,5 @@ def stream_command(command: str, env=None) -> bool:
     return_code = process.wait()
 
     if return_code != 0:
-        print(f"Command failed with return code {return_code}")
-        return False
+        raise Exception(process.stderr)
     return True


### PR DESCRIPTION
Currently `warcli down` can produce a lot of (incorrect) errors, fix these by ignoring not-found pods

![image](https://github.com/user-attachments/assets/580f3e6c-956f-4b79-b166-addbb0029e68)
