### PR TITLE
Use inquirer for quickstart

### DIFF
--- a/src/warnet/main.py
+++ b/src/warnet/main.py
@@ -115,7 +115,8 @@ def quickstart():
         # Custom network configuration
         questions = [
             inquirer.Text(
-                "network_name", message=click.style("Enter your network name", fg="blue", bold=True)
+                "network_name", message=click.style("Enter your network name", fg="blue", bold=True),
+                validate=lambda _, x: len(x) > 0
             ),
             inquirer.List(
                 "nodes",

--- a/src/warnet/main.py
+++ b/src/warnet/main.py
@@ -103,7 +103,8 @@ def quickstart():
             click.secho("Setup cancelled by user.", fg="yellow")
             return False
         if not proj_answers["custom_network"]:
-            create_warnet_project(Path(proj_answers["project_path"]))
+            project_path = Path(os.path.expanduser(proj_answers["project_path"]))
+            create_warnet_project(project_path)
             click.secho("\nSetup completed successfully!", fg="green", bold=True)
             click.echo(
                 "\nRun the following command to deploy this network using the default demo network:"
@@ -183,9 +184,10 @@ def quickstart():
         answers.update(net_answers)
 
         click.secho("\nCreating project structure...", fg="yellow", bold=True)
-        create_warnet_project(Path(answers["project_path"]))
+        project_path = Path(os.path.expanduser(proj_answers["project_path"]))
+        create_warnet_project(project_path)
         click.secho("\nGenerating custom network...", fg="yellow", bold=True)
-        custom_network_path = Path(answers["project_path"]) / "networks" / answers["network_name"]
+        custom_network_path = project_path / "networks" / answers["network_name"]
         custom_graph(
             int(answers["nodes"]),
             int(answers["connections"]),

--- a/src/warnet/main.py
+++ b/src/warnet/main.py
@@ -48,24 +48,23 @@ def quickstart():
     """Setup warnet"""
     try:
         # Requirements checks
-        process = subprocess.Popen(
+        with subprocess.Popen(
             ["/bin/bash", str(QUICK_START_PATH)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
             env=dict(os.environ, TERM="xterm-256color"),
-        )
-        if process.stdout:
-            for line in iter(process.stdout.readline, ""):
-                click.echo(line, nl=False)
-            process.stdout.close()
-        return_code = process.wait()
-        if return_code != 0:
-            click.secho(
-                f"Quick start script failed with return code {return_code}", fg="red", bold=True
-            )
-            click.secho("Install missing requirements before proceeding", fg="yellow")
-            return False
+        ) as process:
+            if process.stdout:
+                for line in iter(process.stdout.readline, ""):
+                    click.echo(line, nl=False)
+            return_code = process.wait()
+            if return_code != 0:
+                click.secho(
+                    f"Quick start script failed with return code {return_code}", fg="red", bold=True
+                )
+                click.secho("Install missing requirements before proceeding", fg="yellow")
+                return False
 
         # New project setup
         questions = [

--- a/src/warnet/main.py
+++ b/src/warnet/main.py
@@ -116,8 +116,9 @@ def quickstart():
         # Custom network configuration
         questions = [
             inquirer.Text(
-                "network_name", message=click.style("Enter your network name", fg="blue", bold=True),
-                validate=lambda _, x: len(x) > 0
+                "network_name",
+                message=click.style("Enter your network name", fg="blue", bold=True),
+                validate=lambda _, x: len(x) > 0,
             ),
             inquirer.List(
                 "nodes",


### PR DESCRIPTION
Inquirer can also make the quickstart setup pretty nice!

![image](https://github.com/user-attachments/assets/e9607792-6aff-477f-966d-250d5ade2f63)

Only think I noticed missing was shell path autocomplete when choosing a project dir, but might be a small price to pay for the extra usability. Completion will still work with other `warnet` commands after this has run.

Curious on thoughts?