### PR TITLE
scenarios: only print 'outer' help

### DIFF
--- a/resources/scenarios/commander.py
+++ b/resources/scenarios/commander.py
@@ -131,6 +131,14 @@ class Commander(BitcoinTestFramework):
         self.success = TestStatus.PASSED
 
     def parse_args(self):
+        # Only print "outer" args from parent class when using --help
+        help_parser = argparse.ArgumentParser(usage="%(prog)s [options]")
+        self.add_options(help_parser)
+        help_args, _ = help_parser.parse_known_args()
+        if help_args.help:
+            help_parser.print_help()
+            sys.exit(0)
+
         previous_releases_path = ""
         parser = argparse.ArgumentParser(usage="%(prog)s [options]")
         parser.add_argument(


### PR DESCRIPTION
Fixes: #512

Use a second argparser to only print "outer" help options.

This makes it clearer for users:

![image](https://github.com/user-attachments/assets/bda6a3bd-e7c7-4850-94ad-ec696a1e3c49)
