### PR TITLE
Support signet in warnet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           - logging_test.py
           - rpc_test.py
           - services_test.py
+          - signet_test.py
           - scenarios_test.py
     steps:
       - uses: actions/checkout@v4

--- a/resources/charts/bitcoincore/templates/_helpers.tpl
+++ b/resources/charts/bitcoincore/templates/_helpers.tpl
@@ -60,10 +60,10 @@ Create the name of the service account to use
 {{/*
 Add network section heading in bitcoin.conf after v0.17.0
 */}}
-{{- define "bitcoincore.check_semver.regtest" -}}
+{{- define "bitcoincore.check_semver" -}}
 {{- $tag := .Values.image.tag | trimPrefix "v" -}}
 {{- $version := semverCompare ">=0.17.0" $tag -}}
 {{- if $version -}}
-[regtest]
+[{{ .Values.chain }}]
 {{- end -}}
 {{- end -}}

--- a/resources/charts/bitcoincore/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/templates/configmap.yaml
@@ -10,6 +10,9 @@ data:
 
     {{ template "bitcoincore.check_semver" . }}
     {{- .Values.baseConfig | nindent 4 }}
+    rpcport={{ index .Values .Values.chain "RPCPort" }}
+    zmqpubrawblock=tcp://0.0.0.0:{{ .Values.ZMQBlockPort }}
+    zmqpubrawtx=tcp://0.0.0.0:{{ .Values.ZMQTxPort }}
     {{- .Values.config | nindent 4 }}
     {{- range .Values.connect }}
       {{- print "connect=" . | nindent 4}}

--- a/resources/charts/bitcoincore/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/templates/configmap.yaml
@@ -6,12 +6,9 @@ metadata:
     {{- include "bitcoincore.labels" . | nindent 4 }}
 data:
   bitcoin.conf: |
-    {{- if eq .Values.chain "regtest" }}
-    regtest=1
+    {{ .Values.chain }}=1
 
-    {{ template "bitcoincore.check_semver.regtest" . }}
-      {{- tpl .Values.regtestConfig . | nindent 4 }}
-    {{- end }}
+    {{ template "bitcoincore.check_semver" . }}
     {{- .Values.baseConfig | nindent 4 }}
     {{- .Values.config | nindent 4 }}
     {{- range .Values.connect }}

--- a/resources/charts/bitcoincore/templates/pod.yaml
+++ b/resources/charts/bitcoincore/templates/pod.yaml
@@ -29,21 +29,23 @@ spec:
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       ports:
         - name: rpc
-          containerPort: {{ .Values.regtest.RPCPort }}
+          containerPort: {{ index .Values .Values.chain "RPCPort" }}
           protocol: TCP
         - name: p2p
-          containerPort: {{ .Values.regtest.P2PPort }}
+          containerPort: {{ index .Values .Values.chain "P2PPort" }}
           protocol: TCP
         - name: zmq-tx
-          containerPort: {{ .Values.regtest.ZMQTxPort }}
+          containerPort: {{ .Values.ZMQTxPort }}
           protocol: TCP
         - name: zmq-block
-          containerPort: {{ .Values.regtest.ZMQBlockPort }}
+          containerPort: {{ .Values.ZMQBlockPort }}
           protocol: TCP
       livenessProbe:
         {{- toYaml .Values.livenessProbe | nindent 8 }}
       readinessProbe:
         {{- toYaml .Values.readinessProbe | nindent 8 }}
+        tcpSocket:
+          port: {{ index .Values .Values.chain "RPCPort" }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
       volumeMounts:
@@ -65,7 +67,7 @@ spec:
         - name: BITCOIN_RPC_HOST
           value: "127.0.0.1"
         - name: BITCOIN_RPC_PORT
-          value: "{{ .Values.regtest.RPCPort }}"
+          value: "{{ index .Values .Values.chain "RPCPort" }}"
         - name: BITCOIN_RPC_USER
           value: user
         - name: BITCOIN_RPC_PASSWORD

--- a/resources/charts/bitcoincore/templates/pod.yaml
+++ b/resources/charts/bitcoincore/templates/pod.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 4 }}
     {{- end }}
+    chain: {{ .Values.chain }}
+    RPCPort: "{{ index .Values .Values.chain "RPCPort" }}"
     app: {{ include "bitcoincore.fullname" . }}
     {{- if .Values.collectLogs }}
     collect_logs: "true"

--- a/resources/charts/bitcoincore/templates/service.yaml
+++ b/resources/charts/bitcoincore/templates/service.yaml
@@ -8,19 +8,19 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.regtest.RPCPort }}
+    - port: {{ index .Values .Values.chain "RPCPort" }}
       targetPort: rpc
       protocol: TCP
       name: rpc
-    - port: {{ .Values.regtest.P2PPort }}
+    - port: {{ index .Values .Values.chain "P2PPort" }}
       targetPort: p2p
       protocol: TCP
       name: p2p
-    - port: {{ .Values.regtest.ZMQTxPort }}
+    - port: {{ .Values.ZMQTxPort }}
       targetPort: zmq-tx
       protocol: TCP
       name: zmq-tx
-    - port: {{ .Values.regtest.ZMQBlockPort }}
+    - port: {{ .Values.ZMQBlockPort }}
       targetPort: zmq-block
       protocol: TCP
       name: zmq-block

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -112,14 +112,6 @@ collectLogs: false
 metricsExport: false
 prometheusMetricsPort: 9332
 
-regtestConfig: |
-  rpcuser=user
-  rpcpassword=password
-  rpcport=18443
-  rpcallowip=0.0.0.0/0
-  rpcbind=0.0.0.0
-  rest=1
-
 baseConfig: |
   checkmempool=0
   acceptnonstdtxn=1
@@ -132,6 +124,15 @@ baseConfig: |
 
   zmqpubrawblock=tcp://0.0.0.0:28332
   zmqpubrawtx=tcp://0.0.0.0:28333
+
+  rpcuser=user
+  rpcpassword=password
+  # use regtest port by default for all networks
+  rpcport=18443
+  rpcallowip=0.0.0.0/0
+  rpcbind=0.0.0.0
+  rest=1
+
 
 config: ""
 

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -36,8 +36,13 @@ service:
 regtest:
   RPCPort: 18443
   P2PPort: 18444
-  ZMQTxPort: 28333
-  ZMQBlockPort: 28332
+
+signet:
+  RPCPort: 38332
+  P2PPort: 38333
+
+ZMQTxPort: 28333
+ZMQBlockPort: 28332
 
 ingress:
   enabled: false
@@ -82,8 +87,6 @@ readinessProbe:
   failureThreshold: 1
   periodSeconds: 1
   successThreshold: 1
-  tcpSocket:
-    port: 18443
   timeoutSeconds: 1
 
 
@@ -121,17 +124,12 @@ baseConfig: |
   capturemessages=1
   fallbackfee=0.00001000
   listen=1
-
-  zmqpubrawblock=tcp://0.0.0.0:28332
-  zmqpubrawtx=tcp://0.0.0.0:28333
-
   rpcuser=user
   rpcpassword=password
-  # use regtest port by default for all networks
-  rpcport=18443
   rpcallowip=0.0.0.0/0
   rpcbind=0.0.0.0
   rest=1
+  # rpcport and zmq endpoints are configured by chain in configmap.yaml
 
 
 config: ""

--- a/resources/scenarios/signet_miner.py
+++ b/resources/scenarios/signet_miner.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+###
+# WARNET SCENARIO SIGNET MINER
+#
+# This file is a hacked-up version of Bitcoin Core contrib/signet/miner.
+# The primary difference is that instead of using bitcoin-cli for RPCs
+# we use the authproxy from the test framework.
+###
+
+# The base class exists inside the commander container
+try:
+    from commander import Commander
+except ImportError:
+    from resources.scenarios.commander import Commander
+
+import json
+import logging
+import math
+import re
+import struct
+import sys
+import time
+import subprocess
+
+from test_framework.blocktools import get_witness_script, script_BIP34_coinbase_height # noqa: E402
+from test_framework.messages import CBlock, CBlockHeader, COutPoint, CTransaction, CTxIn, CTxInWitness, CTxOut, from_binary, from_hex, ser_string, ser_uint256, tx_from_hex # noqa: E402
+from test_framework.psbt import PSBT, PSBTMap, PSBT_GLOBAL_UNSIGNED_TX, PSBT_IN_FINAL_SCRIPTSIG, PSBT_IN_FINAL_SCRIPTWITNESS, PSBT_IN_NON_WITNESS_UTXO, PSBT_IN_SIGHASH_TYPE # noqa: E402
+from test_framework.script import CScriptOp # noqa: E402
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
+
+SIGNET_HEADER = b"\xec\xc7\xda\xa2"
+PSBT_SIGNET_BLOCK = b"\xfc\x06signetb"    # proprietary PSBT global field holding the block being signed
+RE_MULTIMINER = re.compile(r"^(\d+)(-(\d+))?/(\d+)$")
+
+
+class SignetMinerScenario(Commander):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def add_options(self, parser):
+        parser.add_argument(
+            "--tank",
+            dest="tank",
+            type=int,
+            help="Index of tank with wallet loaded for block signing",
+        )
+        get_args(parser)
+
+
+    def run_test(self):
+        args = self.options
+        args.bcli = lambda method, *args, **kwargs: self.nodes[self.options.tank].__getattr__(method)(*args, **kwargs)
+        return do_generate(args)
+
+
+def create_coinbase(height, value, spk):
+    cb = CTransaction()
+    cb.vin = [CTxIn(COutPoint(0, 0xffffffff), script_BIP34_coinbase_height(height), 0xffffffff)]
+    cb.vout = [CTxOut(value, spk)]
+    return cb
+
+def signet_txs(block, challenge):
+    # assumes signet solution has not been added yet so does not need
+    # to be removed
+
+    txs = block.vtx[:]
+    txs[0] = CTransaction(txs[0])
+    txs[0].vout[-1].scriptPubKey += CScriptOp.encode_op_pushdata(SIGNET_HEADER)
+    hashes = []
+    for tx in txs:
+        tx.rehash()
+        hashes.append(ser_uint256(tx.sha256))
+    mroot = block.get_merkle_root(hashes)
+
+    sd = b""
+    sd += struct.pack("<i", block.nVersion)
+    sd += ser_uint256(block.hashPrevBlock)
+    sd += ser_uint256(mroot)
+    sd += struct.pack("<I", block.nTime)
+
+    to_spend = CTransaction()
+    to_spend.nVersion = 0
+    to_spend.nLockTime = 0
+    to_spend.vin = [CTxIn(COutPoint(0, 0xFFFFFFFF), b"\x00" + CScriptOp.encode_op_pushdata(sd), 0)]
+    to_spend.vout = [CTxOut(0, challenge)]
+    to_spend.rehash()
+
+    spend = CTransaction()
+    spend.nVersion = 0
+    spend.nLockTime = 0
+    spend.vin = [CTxIn(COutPoint(to_spend.sha256, 0), b"", 0)]
+    spend.vout = [CTxOut(0, b"\x6a")]
+
+    return spend, to_spend
+
+def do_createpsbt(block, signme, spendme):
+    psbt = PSBT()
+    psbt.g = PSBTMap( {PSBT_GLOBAL_UNSIGNED_TX: signme.serialize(),
+                       PSBT_SIGNET_BLOCK: block.serialize()
+                     } )
+    psbt.i = [ PSBTMap( {PSBT_IN_NON_WITNESS_UTXO: spendme.serialize(),
+                         PSBT_IN_SIGHASH_TYPE: bytes([1,0,0,0])})
+             ]
+    psbt.o = [ PSBTMap() ]
+    return psbt.to_base64()
+
+def do_decode_psbt(b64psbt):
+    psbt = PSBT.from_base64(b64psbt)
+
+    assert len(psbt.tx.vin) == 1
+    assert len(psbt.tx.vout) == 1
+    assert PSBT_SIGNET_BLOCK in psbt.g.map
+
+    scriptSig = psbt.i[0].map.get(PSBT_IN_FINAL_SCRIPTSIG, b"")
+    scriptWitness = psbt.i[0].map.get(PSBT_IN_FINAL_SCRIPTWITNESS, b"\x00")
+
+    return from_binary(CBlock, psbt.g.map[PSBT_SIGNET_BLOCK]), ser_string(scriptSig) + scriptWitness
+
+def finish_block(block, signet_solution, grind_cmd):
+    block.vtx[0].vout[-1].scriptPubKey += CScriptOp.encode_op_pushdata(SIGNET_HEADER + signet_solution)
+    block.vtx[0].rehash()
+    block.hashMerkleRoot = block.calc_merkle_root()
+    if grind_cmd is None:
+        block.solve()
+    else:
+        headhex = CBlockHeader.serialize(block).hex()
+        cmd = grind_cmd.split(" ") + [headhex]
+        newheadhex = subprocess.run(cmd, stdout=subprocess.PIPE, input=b"", check=True).stdout.strip()
+        newhead = from_hex(CBlockHeader(), newheadhex.decode('utf8'))
+        block.nNonce = newhead.nNonce
+        block.rehash()
+    return block
+
+def generate_psbt(tmpl, reward_spk, *, blocktime=None):
+    signet_spk = tmpl["signet_challenge"]
+    signet_spk_bin = bytes.fromhex(signet_spk)
+
+    cbtx = create_coinbase(height=tmpl["height"], value=tmpl["coinbasevalue"], spk=reward_spk)
+    cbtx.vin[0].nSequence = 2**32-2
+    cbtx.rehash()
+
+    block = CBlock()
+    block.nVersion = tmpl["version"]
+    block.hashPrevBlock = int(tmpl["previousblockhash"], 16)
+    block.nTime = tmpl["curtime"] if blocktime is None else blocktime
+    if block.nTime < tmpl["mintime"]:
+        block.nTime = tmpl["mintime"]
+    block.nBits = int(tmpl["bits"], 16)
+    block.nNonce = 0
+    block.vtx = [cbtx] + [tx_from_hex(t["data"]) for t in tmpl["transactions"]]
+
+    witnonce = 0
+    witroot = block.calc_witness_merkle_root()
+    cbwit = CTxInWitness()
+    cbwit.scriptWitness.stack = [ser_uint256(witnonce)]
+    block.vtx[0].wit.vtxinwit = [cbwit]
+    block.vtx[0].vout.append(CTxOut(0, bytes(get_witness_script(witroot, witnonce))))
+
+    signme, spendme = signet_txs(block, signet_spk_bin)
+
+    return do_createpsbt(block, signme, spendme)
+
+def get_reward_address(args, height):
+    if args.address is not None:
+        return args.address
+
+    if '*' not in args.descriptor:
+        addr = args.bcli("deriveaddresses", args.descriptor)[0]
+        args.address = addr
+        return addr
+
+    remove = [k for k in args.derived_addresses.keys() if k+20 <= height]
+    for k in remove:
+        del args.derived_addresses[k]
+
+    addr = args.derived_addresses.get(height, None)
+    if addr is None:
+        addrs = args.bcli("deriveaddresses", args.descriptor, "[%d,%d]" % (height, height+20))
+        addr = addrs[0]
+        for k, a in enumerate(addrs):
+            args.derived_addresses[height+k] = a
+
+    return addr
+
+def get_reward_addr_spk(args, height):
+    assert args.address is not None or args.descriptor is not None
+
+    if hasattr(args, "reward_spk"):
+        return args.address, args.reward_spk
+
+    reward_addr = get_reward_address(args, height)
+    reward_spk = bytes.fromhex(args.bcli("getaddressinfo", reward_addr)["scriptPubKey"])
+    if args.address is not None:
+        # will always be the same, so cache
+        args.reward_spk = reward_spk
+
+    return reward_addr, reward_spk
+
+def do_genpsbt(args):
+    tmpl = json.load(sys.stdin)
+    _, reward_spk = get_reward_addr_spk(args, tmpl["height"])
+    psbt = generate_psbt(tmpl, reward_spk)
+    print(psbt)
+
+def do_solvepsbt(args):
+    block, signet_solution = do_decode_psbt(sys.stdin.read())
+    block = finish_block(block, signet_solution, args.grind_cmd)
+    print(block.serialize().hex())
+
+def nbits_to_target(nbits):
+    shift = (nbits >> 24) & 0xff
+    return (nbits & 0x00ffffff) * 2**(8*(shift - 3))
+
+def target_to_nbits(target):
+    tstr = "{0:x}".format(target)
+    if len(tstr) < 6:
+        tstr = ("000000"+tstr)[-6:]
+    if len(tstr) % 2 != 0:
+        tstr = "0" + tstr
+    if int(tstr[0],16) >= 0x8:
+        # avoid "negative"
+        tstr = "00" + tstr
+    fix = int(tstr[:6], 16)
+    sz = len(tstr)//2
+    if tstr[6:] != "0"*(sz*2-6):
+        fix += 1
+
+    return int("%02x%06x" % (sz,fix), 16)
+
+def seconds_to_hms(s):
+    if s == 0:
+        return "0s"
+    neg = (s < 0)
+    if neg:
+        s = -s
+    out = ""
+    if s % 60 > 0:
+        out = "%ds" % (s % 60)
+    s //= 60
+    if s % 60 > 0:
+        out = "%dm%s" % (s % 60, out)
+    s //= 60
+    if s > 0:
+        out = "%dh%s" % (s, out)
+    if neg:
+        out = "-" + out
+    return out
+
+def next_block_delta(last_nbits, last_hash, ultimate_target, do_poisson, max_interval):
+    # strategy:
+    #  1) work out how far off our desired target we are
+    #  2) cap it to a factor of 4 since that's the best we can do in a single retarget period
+    #  3) use that to work out the desired average interval in this retarget period
+    #  4) if doing poisson, use the last hash to pick a uniformly random number in [0,1), and work out a random multiplier to vary the average by
+    #  5) cap the resulting interval between 1 second and 1 hour to avoid extremes
+
+    INTERVAL = 600.0*2016/2015 # 10 minutes, adjusted for the off-by-one bug
+
+    current_target = nbits_to_target(last_nbits)
+    retarget_factor = ultimate_target / current_target
+    retarget_factor = max(0.25, min(retarget_factor, 4.0))
+
+    avg_interval = INTERVAL * retarget_factor
+
+    if do_poisson:
+        det_rand = int(last_hash[-8:], 16) * 2**-32
+        this_interval_variance = -math.log1p(-det_rand)
+    else:
+        this_interval_variance = 1
+
+    this_interval = avg_interval * this_interval_variance
+    this_interval = max(1, min(this_interval, max_interval))
+
+    return this_interval
+
+def next_block_is_mine(last_hash, my_blocks):
+    det_rand = int(last_hash[-16:-8], 16)
+    return my_blocks[0] <= (det_rand % my_blocks[2]) < my_blocks[1]
+
+def do_generate(args):
+    if args.max_blocks is not None:
+        if args.ongoing:
+            logging.error("Cannot specify both --ongoing and --max-blocks")
+            return 1
+        if args.max_blocks < 1:
+            logging.error("N must be a positive integer")
+            return 1
+        max_blocks = args.max_blocks
+    elif args.ongoing:
+        max_blocks = None
+    else:
+        max_blocks = 1
+
+    if args.set_block_time is not None and max_blocks != 1:
+        logging.error("Cannot specify --ongoing or --max-blocks > 1 when using --set-block-time")
+        return 1
+    if args.set_block_time is not None and args.set_block_time < 0:
+        args.set_block_time = time.time()
+        logging.info("Treating negative block time as current time (%d)" % (args.set_block_time))
+
+    if args.min_nbits:
+        if args.nbits is not None:
+            logging.error("Cannot specify --nbits and --min-nbits")
+            return 1
+        args.nbits = "1e0377ae"
+        logging.info("Using nbits=%s" % (args.nbits))
+
+    if args.set_block_time is None:
+        if args.nbits is None or len(args.nbits) != 8:
+            logging.error("Must specify --nbits (use calibrate command to determine value)")
+            return 1
+
+    if args.multiminer is None:
+       my_blocks = (0,1,1)
+    else:
+        if not args.ongoing:
+            logging.error("Cannot specify --multiminer without --ongoing")
+            return 1
+        m = RE_MULTIMINER.match(args.multiminer)
+        if m is None:
+            logging.error("--multiminer argument must be k/m or j-k/m")
+            return 1
+        start,_,stop,total = m.groups()
+        if stop is None:
+            stop = start
+        start, stop, total = map(int, (start, stop, total))
+        if stop < start or start <= 0 or total < stop or total == 0:
+            logging.error("Inconsistent values for --multiminer")
+            return 1
+        my_blocks = (start-1, stop, total)
+
+    if args.max_interval < 960:
+        logging.error("--max-interval must be at least 960 (16 minutes)")
+        return 1
+
+    ultimate_target = nbits_to_target(int(args.nbits,16))
+
+    mined_blocks = 0
+    bestheader = {"hash": None}
+    lastheader = None
+    while max_blocks is None or mined_blocks < max_blocks:
+
+        # current status?
+        bci = args.bcli("getblockchaininfo")
+
+        if bestheader["hash"] != bci["bestblockhash"]:
+            bestheader = args.bcli("getblockheader", bci["bestblockhash"])
+
+        if lastheader is None:
+            lastheader = bestheader["hash"]
+        elif bestheader["hash"] != lastheader:
+            next_delta = next_block_delta(int(bestheader["bits"], 16), bestheader["hash"], ultimate_target, args.poisson, args.max_interval)
+            next_delta += bestheader["time"] - time.time()
+            next_is_mine = next_block_is_mine(bestheader["hash"], my_blocks)
+            logging.info("Received new block at height %d; next in %s (%s)", bestheader["height"], seconds_to_hms(next_delta), ("mine" if next_is_mine else "backup"))
+            lastheader = bestheader["hash"]
+
+        # when is the next block due to be mined?
+        now = time.time()
+        if args.set_block_time is not None:
+            logging.debug("Setting start time to %d", args.set_block_time)
+            mine_time = args.set_block_time
+            action_time = now
+            is_mine = True
+        elif bestheader["height"] == 0:
+            time_delta = next_block_delta(int(bestheader["bits"], 16), bci["bestblockhash"], ultimate_target, args.poisson, args.max_interval)
+            time_delta *= 100 # 100 blocks
+            logging.info("Backdating time for first block to %d minutes ago" % (time_delta/60))
+            mine_time = now - time_delta
+            action_time = now
+            is_mine = True
+        else:
+            time_delta = next_block_delta(int(bestheader["bits"], 16), bci["bestblockhash"], ultimate_target, args.poisson, args.max_interval)
+            mine_time = bestheader["time"] + time_delta
+
+            is_mine = next_block_is_mine(bci["bestblockhash"], my_blocks)
+
+            action_time = mine_time
+            if not is_mine:
+                action_time += args.backup_delay
+
+            if args.standby_delay > 0:
+                action_time += args.standby_delay
+            elif mined_blocks == 0:
+                # for non-standby, always mine immediately on startup,
+                # even if the next block shouldn't be ours
+                action_time = now
+
+        # don't want fractional times so round down
+        mine_time = int(mine_time)
+        action_time = int(action_time)
+
+        # can't mine a block 2h in the future; 1h55m for some safety
+        action_time = max(action_time, mine_time - 6900)
+
+        # ready to go? otherwise sleep and check for new block
+        if now < action_time:
+            sleep_for = min(action_time - now, 60)
+            if mine_time < now:
+                # someone else might have mined the block,
+                # so check frequently, so we don't end up late
+                # mining the next block if it's ours
+                sleep_for = min(20, sleep_for)
+            minestr = "mine" if is_mine else "backup"
+            logging.debug("Sleeping for %s, next block due in %s (%s)" % (seconds_to_hms(sleep_for), seconds_to_hms(mine_time - now), minestr))
+            time.sleep(sleep_for)
+            continue
+
+        # gbt
+        tmpl = args.bcli("getblocktemplate", {"rules":["signet","segwit"]})
+        if tmpl["previousblockhash"] != bci["bestblockhash"]:
+            logging.warning("GBT based off unexpected block (%s not %s), retrying", tmpl["previousblockhash"], bci["bestblockhash"])
+            time.sleep(1)
+            continue
+
+        logging.debug("GBT template: %s", tmpl)
+
+        if tmpl["mintime"] > mine_time:
+            logging.info("Updating block time from %d to %d", mine_time, tmpl["mintime"])
+            mine_time = tmpl["mintime"]
+            if mine_time > now:
+                logging.error("GBT mintime is in the future: %d is %d seconds later than %d", mine_time, (mine_time-now), now)
+                return 1
+
+        # address for reward
+        reward_addr, reward_spk = get_reward_addr_spk(args, tmpl["height"])
+
+        # mine block
+        logging.debug("Mining block delta=%s start=%s mine=%s", seconds_to_hms(mine_time-bestheader["time"]), mine_time, is_mine)
+        mined_blocks += 1
+        psbt = generate_psbt(tmpl, reward_spk, blocktime=mine_time)
+        psbt_signed = args.bcli("walletprocesspsbt", psbt=psbt, sign=True, sighashtype="ALL")
+        if not psbt_signed.get("complete",False):
+            logging.debug("Generated PSBT: %s" % (psbt,))
+            sys.stderr.write("PSBT signing failed\n")
+            return 1
+        block, signet_solution = do_decode_psbt(psbt_signed["psbt"])
+        block = finish_block(block, signet_solution, args.grind_cmd)
+
+        # submit block
+        r = args.bcli("submitblock", block.serialize().hex())
+
+        # report
+        bstr = "block" if is_mine else "backup block"
+
+        next_delta = next_block_delta(block.nBits, block.hash, ultimate_target, args.poisson, args.max_interval)
+        next_delta += block.nTime - time.time()
+        next_is_mine = next_block_is_mine(block.hash, my_blocks)
+
+        logging.debug("Block hash %s payout to %s", block.hash, reward_addr)
+        logging.info("Mined %s at height %d; next in %s (%s)", bstr, tmpl["height"], seconds_to_hms(next_delta), ("mine" if next_is_mine else "backup"))
+        if r != "":
+            logging.warning("submitblock returned %s for height %d hash %s", r, tmpl["height"], block.hash)
+        lastheader = block.hash
+
+def do_calibrate(args):
+    if args.nbits is not None and args.seconds is not None:
+        sys.stderr.write("Can only specify one of --nbits or --seconds\n")
+        return 1
+    if args.nbits is not None and len(args.nbits) != 8:
+        sys.stderr.write("Must specify 8 hex digits for --nbits\n")
+        return 1
+
+    TRIALS = 600 # gets variance down pretty low
+    TRIAL_BITS = 0x1e3ea75f # takes about 5m to do 600 trials
+
+    header = CBlockHeader()
+    header.nBits = TRIAL_BITS
+    targ = nbits_to_target(header.nBits)
+
+    start = time.time()
+    count = 0
+    for i in range(TRIALS):
+        header.nTime = i
+        header.nNonce = 0
+        headhex = header.serialize().hex()
+        cmd = args.grind_cmd.split(" ") + [headhex]
+        newheadhex = subprocess.run(cmd, stdout=subprocess.PIPE, input=b"", check=True).stdout.strip()
+
+    avg = (time.time() - start) * 1.0 / TRIALS
+
+    if args.nbits is not None:
+        want_targ = nbits_to_target(int(args.nbits,16))
+        want_time = avg*targ/want_targ
+    else:
+        want_time = args.seconds if args.seconds is not None else 25
+        want_targ = int(targ*(avg/want_time))
+
+    print("nbits=%08x for %ds average mining time" % (target_to_nbits(want_targ), want_time))
+    return 0
+
+def bitcoin_cli(basecmd, args, **kwargs):
+    cmd = basecmd + ["-signet"] + args
+    logging.debug("Calling bitcoin-cli: %r", cmd)
+    out = subprocess.run(cmd, stdout=subprocess.PIPE, **kwargs, check=True).stdout
+    if isinstance(out, bytes):
+        out = out.decode('utf8')
+    return out.strip()
+
+def get_args(parser):
+    parser.add_argument("--cli", default="bitcoin-cli", type=str, help="bitcoin-cli command")
+    parser.add_argument("--debug", action="store_true", help="Print debugging info")
+    parser.add_argument("--quiet", action="store_true", help="Only print warnings/errors")
+
+    cmds = parser.add_subparsers(help="sub-commands")
+    genpsbt = cmds.add_parser("genpsbt", help="Generate a block PSBT for signing")
+    genpsbt.set_defaults(fn=do_genpsbt)
+
+    solvepsbt = cmds.add_parser("solvepsbt", help="Solve a signed block PSBT")
+    solvepsbt.set_defaults(fn=do_solvepsbt)
+
+    generate = cmds.add_parser("generate", help="Mine blocks")
+    generate.set_defaults(fn=do_generate)
+    generate.add_argument("--ongoing", action="store_true", help="Keep mining blocks")
+    generate.add_argument("--max-blocks", default=None, type=int, help="Max blocks to mine (default=1)")
+    generate.add_argument("--set-block-time", default=None, type=int, help="Set block time (unix timestamp)")
+    generate.add_argument("--nbits", default=None, type=str, help="Target nBits (specify difficulty)")
+    generate.add_argument("--min-nbits", action="store_true", help="Target minimum nBits (use min difficulty)")
+    generate.add_argument("--poisson", action="store_true", help="Simulate randomised block times")
+    generate.add_argument("--multiminer", default=None, type=str, help="Specify which set of blocks to mine (eg: 1-40/100 for the first 40%%, 2/3 for the second 3rd)")
+    generate.add_argument("--backup-delay", default=300, type=int, help="Seconds to delay before mining blocks reserved for other miners (default=300)")
+    generate.add_argument("--standby-delay", default=0, type=int, help="Seconds to delay before mining blocks (default=0)")
+    generate.add_argument("--max-interval", default=1800, type=int, help="Maximum interblock interval (seconds)")
+
+    calibrate = cmds.add_parser("calibrate", help="Calibrate difficulty")
+    calibrate.set_defaults(fn=do_calibrate)
+    calibrate.add_argument("--nbits", type=str, default=None)
+    calibrate.add_argument("--seconds", type=int, default=None)
+
+    for sp in [genpsbt, generate]:
+        sp.add_argument("--address", default=None, type=str, help="Address for block reward payment")
+        sp.add_argument("--descriptor", default=None, type=str, help="Descriptor for block reward payment")
+
+    for sp in [solvepsbt, generate, calibrate]:
+        sp.add_argument("--grind-cmd", default=None, type=str, required=(sp==calibrate), help="Command to grind a block header for proof-of-work")
+
+    args = parser.parse_args(sys.argv[1:])
+
+    args.bcli = lambda *a, input=b"", **kwargs: bitcoin_cli(args.cli.split(" "), list(a), input=input, **kwargs)
+
+    if hasattr(args, "address") and hasattr(args, "descriptor"):
+        if args.address is None and args.descriptor is None:
+            sys.stderr.write("Must specify --address or --descriptor\n")
+            return 1
+        elif args.address is not None and args.descriptor is not None:
+            sys.stderr.write("Only specify one of --address or --descriptor\n")
+            return 1
+        args.derived_addresses = {}
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+    elif args.quiet:
+        logging.getLogger().setLevel(logging.WARNING)
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+    return args
+
+if __name__ == "__main__":
+    SignetMinerScenario().main()

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,7 @@
 extend-exclude = [
     "resources/images/commander/src/test_framework",
     "resources/images/exporter/authproxy.py",
+    "resources/scenarios/signet_miner.py",
     "src/test_framework/*",
 ]
 line-length = 100

--- a/src/warnet/bitcoin.py
+++ b/src/warnet/bitcoin.py
@@ -36,10 +36,12 @@ def rpc(tank: str, method: str, params: str):
 
 
 def _rpc(tank: str, method: str, params: str):
+    # bitcoin-cli should be able to read bitcoin.conf inside the container
+    # so no extra args like port, chain, username or password are needed
     if params:
-        cmd = f"kubectl exec {tank} -- bitcoin-cli -regtest -rpcuser='user' -rpcpassword='password' {method} {' '.join(map(str, params))}"
+        cmd = f"kubectl exec {tank} -- bitcoin-cli {method} {' '.join(map(str, params))}"
     else:
-        cmd = f"kubectl exec {tank} -- bitcoin-cli -regtest -rpcuser='user' -rpcpassword='password' {method}"
+        cmd = f"kubectl exec {tank} -- bitcoin-cli {method}"
     return run_command(cmd)
 
 

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -173,9 +173,9 @@ def run(scenario_file: str, additional_args: tuple[str]):
     tanks = [
         {
             "tank": tank.metadata.name,
-            "chain": "regtest",
+            "chain": tank.metadata.labels["chain"],
             "rpc_host": tank.status.pod_ip,
-            "rpc_port": 18443,
+            "rpc_port": int(tank.metadata.labels["RPCPort"]),
             "rpc_user": "user",
             "rpc_password": "password",
             "init_peers": [],

--- a/src/warnet/network.py
+++ b/src/warnet/network.py
@@ -88,16 +88,15 @@ def _connected():
     for tank in tanks:
         # Get actual
         peerinfo = json.loads(_rpc(tank.metadata.name, "getpeerinfo", ""))
-        manuals = 0
+        actual = 0
         for peer in peerinfo:
             if peer["connection_type"] == "manual":
-                manuals += 1
+                actual += 1
+        expected = int(tank.metadata.annotations["init_peers"])
+        print(f"Tank {tank.metadata.name} peers expected: {expected}, actual: {actual}")
         # Even if more edges are specified, bitcoind only allows
         # 8 manual outbound connections
-
-        print("manual " + str(manuals))
-        print(tank.metadata.annotations["init_peers"])
-        if min(8, int(tank.metadata.annotations["init_peers"])) > manuals:
+        if min(8, expected) > actual:
             print("Network not connected")
             return False
     print("Network connected")

--- a/test/data/signet-signer.json
+++ b/test/data/signet-signer.json
@@ -1,0 +1,52 @@
+{
+  "address":
+  {
+    "address": "tb1q6vakuyw2jhzwmnxcaxryxs6c670fr9esfvrrhj",
+    "scriptPubKey": "0014d33b6e11ca95c4edccd8e986434358d79e919730",
+    "ismine": true,
+    "solvable": true,
+    "desc": "wpkh([2e239023/84h/1h/0h/0/0]03d28a77a6ea884727049c72818c312d1f7fefb4aa5e62c9211403fd6218eaa6fa)#vp55uze6",
+    "parent_desc": "wpkh([2e239023/84h/1h/0h]tpubDDsmgRhtuNzhYbEiUbucryCNyjshjKf4fawmVWAAwej5HhSLmXVWD9z8U8QHgaSQmYmGBfTfab6nsM4bLQkRR1qdpazc258PGtcyVJeDLbj/0/*)#r5lwvzmj",
+    "iswatchonly": false,
+    "isscript": false,
+    "iswitness": true,
+    "witness_version": 0,
+    "witness_program": "d33b6e11ca95c4edccd8e986434358d79e919730",
+    "pubkey": "03d28a77a6ea884727049c72818c312d1f7fefb4aa5e62c9211403fd6218eaa6fa",
+    "ischange": false,
+    "timestamp": 1725633470,
+    "hdkeypath": "m/84h/1h/0h/0/0",
+    "hdseedid": "0000000000000000000000000000000000000000",
+    "hdmasterfingerprint": "2e239023",
+    "labels": [
+      "bech32"
+    ]
+  },
+  "descriptors":
+  [
+    {
+      "desc": "wpkh(tprv8ZgxMBicQKsPfH87iaMtrpzTkWiyFDW7SVWqfsKAhtyEBEqMV6ctPdtc5pNrb2FpSmPcDe8NrxEouUnWj1ud7LT1X1hB1XHKAgB2Z5Z4u2s/84h/1h/0h/0/*)#5j6mshps",
+      "timestamp": 0,
+      "active": true,
+      "internal": false,
+      "range": [
+        0,
+        999
+      ],
+      "next": 0,
+      "next_index": 0
+    },
+    {
+      "desc": "wpkh(tprv8ZgxMBicQKsPfH87iaMtrpzTkWiyFDW7SVWqfsKAhtyEBEqMV6ctPdtc5pNrb2FpSmPcDe8NrxEouUnWj1ud7LT1X1hB1XHKAgB2Z5Z4u2s/84h/1h/0h/1/*)#9xl6dz3g",
+      "timestamp": 0,
+      "active": true,
+      "internal": true,
+      "range": [
+        0,
+        999
+      ],
+      "next": 0,
+      "next_index": 0
+    }
+  ]
+}

--- a/test/data/signet/network.yaml
+++ b/test/data/signet/network.yaml
@@ -1,0 +1,8 @@
+nodes:
+  - name: miner
+  - name: tank-0001
+    connect:
+      - miner
+  - name: tank-0002
+    connect:
+      - miner

--- a/test/data/signet/node-defaults.yaml
+++ b/test/data/signet/node-defaults.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: bitcoindevproject/bitcoin
+  pullPolicy: IfNotPresent
+  tag: "27.0"
+
+chain: signet

--- a/test/data/signet/node-defaults.yaml
+++ b/test/data/signet/node-defaults.yaml
@@ -4,3 +4,8 @@ image:
   tag: "27.0"
 
 chain: signet
+
+config: |
+  debug=rpc
+  debug=net
+  signetchallenge=0014d33b6e11ca95c4edccd8e986434358d79e919730

--- a/test/signet_test.py
+++ b/test/signet_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+
+from test_base import TestBase
+
+
+class SignetTest(TestBase):
+    def __init__(self):
+        super().__init__()
+        self.network_dir = Path(os.path.dirname(__file__)) / "data" / "signet"
+        signer_data_path = Path(os.path.dirname(__file__)) / "data" / "signet-signer.json"
+        with open(signer_data_path, "r") as f:
+            self.signer_data = json.loads(f.read())
+
+    def run_test(self):
+        try:
+            self.setup_network()
+            self.check_signet_miner()
+        finally:
+            self.stop_server()
+
+    def setup_network(self):
+        self.log.info("Setting up network")
+        self.log.info(self.warnet(f"deploy {self.network_dir}"))
+        self.wait_for_all_tanks_status(target="running")
+        self.wait_for_all_edges()
+
+    def check_signet_miner(self):
+        self.warnet("bitcoin rpc miner createwallet miner")
+        self.warnet(f"bitcoin rpc miner importdescriptors '{json.dumps(self.signer_data['descriptors'])}'")
+        self.warnet(f"run resources/scenarios/signet_miner.py --tank=0 generate --min-nbits --address={self.signer_data['address']['address']}")
+
+        def block_one():
+            for tank in ["tank-0001", "tank-0002"]:
+                height = int(self.warnet(f"bitcoin rpc {tank} getblockcount"))
+                if height != 1:
+                    return False
+            return True
+        self.wait_for_predicate(block_one)
+
+if __name__ == "__main__":
+    test = SignetTest()
+    test.run_test()

--- a/test/signet_test.py
+++ b/test/signet_test.py
@@ -12,7 +12,7 @@ class SignetTest(TestBase):
         super().__init__()
         self.network_dir = Path(os.path.dirname(__file__)) / "data" / "signet"
         signer_data_path = Path(os.path.dirname(__file__)) / "data" / "signet-signer.json"
-        with open(signer_data_path, "r") as f:
+        with open(signer_data_path) as f:
             self.signer_data = json.loads(f.read())
 
     def run_test(self):
@@ -30,8 +30,12 @@ class SignetTest(TestBase):
 
     def check_signet_miner(self):
         self.warnet("bitcoin rpc miner createwallet miner")
-        self.warnet(f"bitcoin rpc miner importdescriptors '{json.dumps(self.signer_data['descriptors'])}'")
-        self.warnet(f"run resources/scenarios/signet_miner.py --tank=0 generate --min-nbits --address={self.signer_data['address']['address']}")
+        self.warnet(
+            f"bitcoin rpc miner importdescriptors '{json.dumps(self.signer_data['descriptors'])}'"
+        )
+        self.warnet(
+            f"run resources/scenarios/signet_miner.py --tank=0 generate --min-nbits --address={self.signer_data['address']['address']}"
+        )
 
         def block_one():
             for tank in ["tank-0001", "tank-0002"]:
@@ -39,7 +43,9 @@ class SignetTest(TestBase):
                 if height != 1:
                     return False
             return True
+
         self.wait_for_predicate(block_one)
+
 
 if __name__ == "__main__":
     test = SignetTest()


### PR DESCRIPTION
Closes https://github.com/bitcoin-dev-project/warnet/issues/503

Features added:
1. Support signet in warnet simply by setting `chain` in your network chart. Ports are set dynamically everywhere
2. Include new built-in scenario `signet_miner.py` which is Commander-wrapped proxy for Bitcoin Core `/contrib/signet/miner` and accepts all the same arguments with the addition of `--tank={index}`
3. Test

Reviewers should try:
1. Running test locally: `test/signet_test.py`
2. Checking that ports are set correctly when setting chain:
```
(.venv) --> helm template resources/charts/bitcoincore/ --set chain=regtest | grep port
    # rpcport and zmq endpoints are configured by chain in configmap.yaml
    rpcport=18443
  ports:
    - port: 18443
    - port: 18444
    - port: 28333
    - port: 28332
    - port: 9332
      ports:
          port: 18443

(.venv) --> helm template resources/charts/bitcoincore/ --set chain=signet | grep port
    # rpcport and zmq endpoints are configured by chain in configmap.yaml
    rpcport=38332
  ports:
    - port: 38332
    - port: 38333
    - port: 28333
    - port: 28332
    - port: 9332
      ports:
          port: 38332

```
3. (ADVANCED and not tested personally) run the signer miner *locally*:
    - `warnet deploy test/data/signet` to start the signet-chain warnet network
    - `cd` to your local bitcoin core repo
    - Start the signet miner locally using kubectl-forwarded bitcoin-cli (this is the crazy part I dunno if it will work):

```
python3 contrib/signet/miner \
    --cli=warnet bitcoin rpc miner
    generate
    --address=tb1q6vakuyw2jhzwmnxcaxryxs6c670fr9esfvrrhj
    --grind-cmd=src/bitcoin-util grind
    --min-nbits
    --ongoing
```

The PRO for this method is that you will get the benefit of mining with the C++ compiled `bitcoin-util` as opposed to the python grinder which is used in the scenario. CON is of course it is grinding locally and not in the cluster.