### PR TITLE
add CVE images with signet (based on #498)

### DIFF
--- a/resources/charts/bitcoincore/templates/_helpers.tpl
+++ b/resources/charts/bitcoincore/templates/_helpers.tpl
@@ -61,8 +61,7 @@ Create the name of the service account to use
 Add network section heading in bitcoin.conf after v0.17.0
 */}}
 {{- define "bitcoincore.check_semver" -}}
-{{- $tag := .Values.image.tag | trimPrefix "v" -}}
-{{- $version := semverCompare ">=0.17.0" $tag -}}
+{{- $version := semverCompare ">=0.17.0" .Values.image.tag -}}
 {{- if $version -}}
 [{{ .Values.chain }}]
 {{- end -}}

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -117,7 +117,6 @@ prometheusMetricsPort: 9332
 
 baseConfig: |
   checkmempool=0
-  acceptnonstdtxn=1
   debuglogfile=0
   logips=1
   logtimemicros=1

--- a/resources/images/bitcoin/insecure/Dockerfile
+++ b/resources/images/bitcoin/insecure/Dockerfile
@@ -1,0 +1,168 @@
+# Base stage
+# ----------
+#
+# We use the alpine version to get the
+# correct version of glibc / gcc for building older bitcoin
+# core versions.
+
+# Default is set here to quiet a warning from Docker, but the caller must
+# be sure to ALWAYS set this correct per the version of bitcoin core they are
+# trying to build
+ARG ALPINE_VERSION=3.7
+FROM alpine:${ALPINE_VERSION} AS base
+
+# Setup deps stage
+# ----------------
+#
+# this installs the common dependencies for all of the old versions
+# and then version specific dependencies are passed via the
+# EXTRA_PACKAGES ARG
+FROM base AS deps
+ARG EXTRA_PACKAGES=""
+RUN --mount=type=cache,target=/var/cache/apk \
+    sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories \
+    && apk --no-cache add \
+    autoconf \
+    automake \
+    boost-dev \
+    build-base \
+    ccache \
+    chrpath \
+    file \
+    gnupg \
+    git \
+    libevent-dev \
+    libressl \
+    libtool \
+    linux-headers \
+    zeromq-dev \
+    ${EXTRA_PACKAGES}
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN make -j$(nproc)
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage
+# -----------
+#
+# We can build from a git repo using the REPO and COMMIT_SHA args
+# or from a local directory using FROM_SRC=true and specifying the local
+# source directory. Build args are set using a default but can be changed
+# on an imnage by image basis, if needed
+#
+# PRE_CONFIGURE_COMMANDS is used for version specific fixes needed before
+# running ./autogen.sh && ./configure
+#
+# EXTRA_BUILD_ARGS is used for version specific build flags
+FROM deps AS build
+ARG FROM_SRC="false"
+ARG REPO=""
+ARG COMMIT_SHA=""
+ARG BUILD_ARGS="--disable-tests --without-gui --disable-bench --disable-fuzz-binary --enable-suppress-external-warnings"
+ARG EXTRA_BUILD_ARGS=""
+ARG PRE_CONFIGURE_COMMANDS=""
+
+COPY --from=deps /opt /opt
+ENV BITCOIN_PREFIX=/opt/bitcoin
+WORKDIR /build
+
+# Even if not being used, --build-context bitcoin-src must be specified else
+# this line will error. If building from a remote repo, use something like
+# --build-context bitcoin-src="."
+COPY --from=bitcoin-src . /tmp/bitcoin-source
+RUN if [ "$FROM_SRC" = "true" ]; then \
+        # run with --progress=plain to see these log outputs
+        echo "Using local files from /tmp/bitcoin-source"; \
+        if [ -d "/tmp/bitcoin-source" ] && [ "$(ls -A /tmp/bitcoin-source)" ]; then \
+            cp -R /tmp/bitcoin-source /build/bitcoin; \
+        else \
+            echo "Error: Local source directory is empty or does not exist" && exit 1; \
+        fi \
+    else \
+        echo "Cloning from git repository"; \
+        git clone --depth 1 "https://github.com/${REPO}" /build/bitcoin \
+        && cd /build/bitcoin \
+        && git fetch --depth 1 origin "$COMMIT_SHA" \
+        && git checkout "$COMMIT_SHA"; \
+    fi;
+
+# This is not our local ccache, but ccache in the docker cache
+# this does speed up builds substantially when building from source or building
+# multiple versions sequentially
+ENV CCACHE_DIR=/ccache
+RUN --mount=type=cache,target=/ccache \
+    set -ex \
+    && cd /build/bitcoin \
+    && if [ -n "$PRE_CONFIGURE_COMMANDS" ]; then \
+         eval ${PRE_CONFIGURE_COMMANDS}; \
+       fi \
+    && ./autogen.sh \
+    && ./configure \
+    LDFLAGS=-L`ls -d /opt/db*`/lib/ \
+    CPPFLAGS="-g0 -I`ls -d /opt/db*`/include/ --param ggc-min-expand=1 --param ggc-min-heapsize=32768" \
+    --prefix=${BITCOIN_PREFIX} \
+    ${BUILD_ARGS} \
+    ${EXTRA_BUILD_ARGS} \
+    --with-daemon \
+    && make -j$(nproc) \
+    && make install \
+    && strip ${BITCOIN_PREFIX}/bin/bitcoin-cli \
+    && strip ${BITCOIN_PREFIX}/bin/bitcoind \
+    && rm -f ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a \
+    && rm -f ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0 \
+    && rm -f ${BITCOIN_PREFIX}/bin/bitcoin-tx \
+    && rm -f ${BITCOIN_PREFIX}/bin/bitcoin-wallet
+
+# verify ccache is working, specify --progress=plain to see output in build logs
+RUN ccache -s
+
+# Final clean stage
+# -----------------
+#
+# EXTRA_RUNTIME_PACKAGES is used for version specific runtime deps
+FROM alpine:${ALPINE_VERSION}
+ARG EXTRA_RUNTIME_PACKAGES=""
+ARG UID=100
+ARG GID=101
+ARG BITCOIN_VERSION
+ENV BITCOIN_DATA=/root/.bitcoin
+ENV BITCOIN_PREFIX=/opt/bitcoin
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+ENV BITCOIN_VERSION=${BITCOIN_VERSION}
+LABEL maintainer.0="bitcoindevproject"
+
+RUN addgroup -g ${GID} -S bitcoin
+RUN adduser -u ${UID} -S bitcoin -G bitcoin
+RUN --mount=type=cache,target=/var/cache/apk sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories \
+    && apk --no-cache add \
+    bash \
+    boost-filesystem \
+    boost-system \
+    boost-thread \
+    libevent \
+    libzmq \
+    shadow \
+    sqlite-dev \
+    su-exec \
+    ${EXTRA_RUNTIME_PACKAGES}
+
+COPY --from=build /opt/bitcoin /usr/local
+COPY entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bitcoind"]
+

--- a/resources/images/bitcoin/insecure/addrman_v0.16.1.patch
+++ b/resources/images/bitcoin/insecure/addrman_v0.16.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 4fbfa2b5c85..0d8d5751268 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -455,6 +455,8 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
+         vchRet.push_back(NET_IPV4);
+         vchRet.push_back(GetByte(3) ^ 0xFF);
+         vchRet.push_back(GetByte(2) ^ 0xFF);
++        vchRet.push_back(GetByte(1) ^ 0xFF);
++        vchRet.push_back(GetByte(0) ^ 0xFF);
+         return vchRet;
+     }
+     else if (IsTor())

--- a/resources/images/bitcoin/insecure/addrman_v0.17.0.patch
+++ b/resources/images/bitcoin/insecure/addrman_v0.17.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 778c2700f95..03d97bcd673 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -354,6 +354,8 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
+         vchRet.push_back(NET_IPV4);
+         vchRet.push_back(GetByte(3) ^ 0xFF);
+         vchRet.push_back(GetByte(2) ^ 0xFF);
++        vchRet.push_back(GetByte(1) ^ 0xFF);
++        vchRet.push_back(GetByte(0) ^ 0xFF);
+         return vchRet;
+     }
+     else if (IsTor())

--- a/resources/images/bitcoin/insecure/addrman_v0.19.2.patch
+++ b/resources/images/bitcoin/insecure/addrman_v0.19.2.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 4fbfa2b5c85..0d8d5751268 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -455,6 +455,8 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
+         vchRet.push_back(NET_IPV4);
+         vchRet.push_back(GetByte(3) ^ 0xFF);
+         vchRet.push_back(GetByte(2) ^ 0xFF);
++        vchRet.push_back(GetByte(1) ^ 0xFF);
++        vchRet.push_back(GetByte(0) ^ 0xFF);
+         return vchRet;
+     }
+     else if (IsTor())

--- a/resources/images/bitcoin/insecure/addrman_v0.20.0.patch
+++ b/resources/images/bitcoin/insecure/addrman_v0.20.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 228caf74a93..a6728321d1d 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -517,6 +517,8 @@ std::vector<unsigned char> CNetAddr::GetGroup(const std::vector<bool> &asmap) co
+         uint32_t ipv4 = GetLinkedIPv4();
+         vchRet.push_back((ipv4 >> 24) & 0xFF);
+         vchRet.push_back((ipv4 >> 16) & 0xFF);
++        vchRet.push_back((ipv4 >> 8) & 0xFF);
++        vchRet.push_back(ipv4 & 0xFF);
+         return vchRet;
+     } else if (IsTor()) {
+         nStartByte = 6;

--- a/resources/images/bitcoin/insecure/addrman_v0.21.1.patch
+++ b/resources/images/bitcoin/insecure/addrman_v0.21.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index e0d4638dd6a..a84b3980f30 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -742,6 +742,8 @@ std::vector<unsigned char> CNetAddr::GetGroup(const std::vector<bool> &asmap) co
+         uint32_t ipv4 = GetLinkedIPv4();
+         vchRet.push_back((ipv4 >> 24) & 0xFF);
+         vchRet.push_back((ipv4 >> 16) & 0xFF);
++        vchRet.push_back((ipv4 >> 8) & 0xFF);
++        vchRet.push_back(ipv4 & 0xFF);
+         return vchRet;
+     } else if (IsTor() || IsI2P() || IsCJDNS()) {
+         nBits = 4;

--- a/resources/images/bitcoin/insecure/build.md
+++ b/resources/images/bitcoin/insecure/build.md
@@ -1,0 +1,89 @@
+# Historic CVE images
+
+These images are for old versions of Bitcoin Core with known CVEs. These images have signet backported
+and the addrman and isroutable patches applied.
+
+# Build incantations
+
+Run from top-level of project
+
+## v0.21.1
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/armhf \
+  --build-context bitcoin-src="." \
+  --build-arg ALPINE_VERSION="3.17" \
+  --build-arg BITCOIN_VERSION="0.21.1" \
+  --build-arg EXTRA_PACKAGES="sqlite-dev" \
+  --build-arg EXTRA_RUNTIME_PACKAGES="boost-filesystem sqlite-dev" \
+  --build-arg REPO="josibake/bitcoin" \
+  --build-arg COMMIT_SHA="e0a22f14c15b4877ef6221f9ee2dfe510092d734" \
+  --tag bitcoindevproject/bitcoin:0.21.1 \
+  resources/images/bitcoin/insecure
+```
+
+## v0.20.0
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/armhf \
+  --build-context bitcoin-src="." \
+  --build-arg ALPINE_VERSION="3.12.12" \
+  --build-arg BITCOIN_VERSION="0.20.0" \
+  --build-arg EXTRA_PACKAGES="sqlite-dev miniupnpc" \
+  --build-arg EXTRA_RUNTIME_PACKAGES="boost-filesystem sqlite-dev" \
+  --build-arg REPO="josibake/bitcoin" \
+  --build-arg COMMIT_SHA="0bbff8feff0acf1693dfe41184d9a4fd52001d3f" \
+  --tag bitcoindevproject/bitcoin:0.20.0 \
+  resources/images/bitcoin/insecure
+```
+
+## v0.19.2
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/armhf \
+  --build-context bitcoin-src="." \
+  --build-arg ALPINE_VERSION="3.12.12" \
+  --build-arg BITCOIN_VERSION="0.19.2" \
+  --build-arg EXTRA_PACKAGES="sqlite-dev libressl-dev" \
+  --build-arg EXTRA_RUNTIME_PACKAGES="boost-chrono boost-filesystem libressl sqlite-dev" \
+  --build-arg REPO="josibake/bitcoin" \
+  --build-arg COMMIT_SHA="e20f83eb5466a7d68227af14a9d0cf66fb520ffc" \
+  --tag bitcoindevproject/bitcoin:0.19.2 \
+  resources/images/bitcoin/insecure
+```
+
+## v0.17.0
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/armhf \
+  --build-context bitcoin-src="." \
+  --build-arg ALPINE_VERSION="3.9" \
+  --build-arg BITCOIN_VERSION="0.17.0" \
+  --build-arg EXTRA_PACKAGES="protobuf-dev libressl-dev" \
+  --build-arg EXTRA_RUNTIME_PACKAGES="boost boost-program_options libressl sqlite-dev" \
+  --build-arg REPO="josibake/bitcoin" \
+  --build-arg COMMIT_SHA="f6b2db49a707e7ad433d958aee25ce561c66521a" \
+  --tag bitcoindevproject/bitcoin:0.17.0 \
+  resources/images/bitcoin/insecure
+```
+
+## v0.16.1
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/armhf \
+  --build-context bitcoin-src="." \
+  --build-arg ALPINE_VERSION="3.7" \
+  --build-arg BITCOIN_VERSION="0.16.1" \
+  --build-arg EXTRA_PACKAGES="protobuf-dev libressl-dev" \
+  --build-arg PRE_CONFIGURE_COMMANDS="sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac && sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac && sed -i 's:sys/fcntl.h:fcntl.h:' src/compat.h" \
+  --build-arg EXTRA_RUNTIME_PACKAGES="boost boost-program_options libressl" \
+  --build-arg REPO="josibake/bitcoin" \
+  --build-arg COMMIT_SHA="ffae728b7b926664a17b44428a3498be08c70844" \
+  --tag bitcoindevproject/bitcoin:0.16.1 \
+  resources/images/bitcoin/insecure
+```

--- a/resources/images/bitcoin/insecure/build.md
+++ b/resources/images/bitcoin/insecure/build.md
@@ -83,7 +83,7 @@ docker buildx build \
   --build-arg PRE_CONFIGURE_COMMANDS="sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac && sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac && sed -i 's:sys/fcntl.h:fcntl.h:' src/compat.h" \
   --build-arg EXTRA_RUNTIME_PACKAGES="boost boost-program_options libressl" \
   --build-arg REPO="josibake/bitcoin" \
-  --build-arg COMMIT_SHA="ffae728b7b926664a17b44428a3498be08c70844" \
+  --build-arg COMMIT_SHA="dc94c00e58c60412a4e1a540abdf0b56093179e8" \
   --tag bitcoindevproject/bitcoin:0.16.1 \
   resources/images/bitcoin/insecure
 ```

--- a/resources/images/bitcoin/insecure/entrypoint.sh
+++ b/resources/images/bitcoin/insecure/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# Only run this tor section if the TOR=1 env var is set
+if [ "${TOR:-0}" -eq 1 ]; then
+
+    # Add bitcoin user to tor group to read the auth cookie
+    usermod -a -G debian-tor bitcoin
+
+    # ===========Tor setup===========
+    # Use custom torrc for warnet
+    if [ "${WARNET:-0}" -eq 1 ]; then
+        mv /etc/tor/warnet-torrc /etc/tor/torrc
+    fi
+    echo "Address $(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)" >> /etc/tor/torrc
+    mkdir -p /home/debian-tor/.tor/keys
+    chown -R debian-tor:debian-tor /home/debian-tor
+    # Start tor in the background
+    su-exec debian-tor:debian-tor tor &
+    # ===============================
+fi
+
+if [ "$(echo "$1" | cut -c1)" = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ "$(echo "$1" | cut -c1)" = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  echo "$0: setting data directory to $BITCOIN_DATA"
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+# Incorporate additional arguments for bitcoind if BITCOIN_ARGS is set.
+if [ -n "$BITCOIN_ARGS" ]; then
+  IFS=' ' read -ra ARG_ARRAY <<< "$BITCOIN_ARGS"
+  set -- "$@" "${ARG_ARRAY[@]}"
+fi
+
+# Conditionally add -printtoconsole for Bitcoin version 0.16.1
+if [ "${BITCOIN_VERSION}" == "0.16.1" ]; then
+  exec "$@" -printtoconsole
+else
+  exec "$@"
+fi

--- a/resources/images/bitcoin/insecure/entrypoint.sh
+++ b/resources/images/bitcoin/insecure/entrypoint.sh
@@ -1,25 +1,6 @@
 #!/bin/bash
 set -e
 
-# Only run this tor section if the TOR=1 env var is set
-if [ "${TOR:-0}" -eq 1 ]; then
-
-    # Add bitcoin user to tor group to read the auth cookie
-    usermod -a -G debian-tor bitcoin
-
-    # ===========Tor setup===========
-    # Use custom torrc for warnet
-    if [ "${WARNET:-0}" -eq 1 ]; then
-        mv /etc/tor/warnet-torrc /etc/tor/torrc
-    fi
-    echo "Address $(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)" >> /etc/tor/torrc
-    mkdir -p /home/debian-tor/.tor/keys
-    chown -R debian-tor:debian-tor /home/debian-tor
-    # Start tor in the background
-    su-exec debian-tor:debian-tor tor &
-    # ===============================
-fi
-
 if [ "$(echo "$1" | cut -c1)" = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 

--- a/resources/images/bitcoin/insecure/isroutable_v0.16.1.patch
+++ b/resources/images/bitcoin/insecure/isroutable_v0.16.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 81f72879f40..8aae93a6b68 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -231,7 +231,7 @@ bool CNetAddr::IsValid() const
+ 
+ bool CNetAddr::IsRoutable() const
+ {
+-    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsLocal() || IsInternal());
++    return true;
+ }
+ 
+ bool CNetAddr::IsInternal() const

--- a/resources/images/bitcoin/insecure/isroutable_v0.17.0.patch
+++ b/resources/images/bitcoin/insecure/isroutable_v0.17.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 778c2700f95..9655b01efba 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -226,7 +226,7 @@ bool CNetAddr::IsValid() const
+ 
+ bool CNetAddr::IsRoutable() const
+ {
+-    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsLocal() || IsInternal());
++    return true;
+ }
+ 
+ bool CNetAddr::IsInternal() const

--- a/resources/images/bitcoin/insecure/isroutable_v0.19.2.patch
+++ b/resources/images/bitcoin/insecure/isroutable_v0.19.2.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 228caf74a93..d1290d4de49 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -300,7 +300,7 @@ bool CNetAddr::IsValid() const
+  */
+ bool CNetAddr::IsRoutable() const
+ {
+-    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsRFC7343() || IsLocal() || IsInternal());
++    return true;
+ }
+ 
+ /**

--- a/resources/images/bitcoin/insecure/isroutable_v0.20.0.patch
+++ b/resources/images/bitcoin/insecure/isroutable_v0.20.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index 228caf74a93..d1290d4de49 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -300,7 +300,7 @@ bool CNetAddr::IsValid() const
+  */
+ bool CNetAddr::IsRoutable() const
+ {
+-    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsRFC7343() || IsLocal() || IsInternal());
++    return true;
+ }
+ 
+ /**

--- a/resources/images/bitcoin/insecure/isroutable_v0.21.1.patch
+++ b/resources/images/bitcoin/insecure/isroutable_v0.21.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/netaddress.cpp b/src/netaddress.cpp
+index e0d4638dd6a..2615e076b50 100644
+--- a/src/netaddress.cpp
++++ b/src/netaddress.cpp
+@@ -465,7 +465,7 @@ bool CNetAddr::IsValid() const
+  */
+ bool CNetAddr::IsRoutable() const
+ {
+-    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsRFC7343() || IsLocal() || IsInternal());
++    return true;
+ }
+ 
+ /**

--- a/src/warnet/image.py
+++ b/src/warnet/image.py
@@ -7,22 +7,27 @@ from .image_build import build_image
 
 @click.group(name="image")
 def image():
-    """Build a a custom Warnet Bitcoin Core image"""
+    """Build a custom Warnet Bitcoin Core image"""
 
 
 @image.command()
 @click.option("--repo", required=True, type=str)
 @click.option("--commit-sha", required=True, type=str)
 @click.option("--registry", required=True, type=str)
-@click.option("--tag", required=True, type=str)
+@click.option(
+    "--tags",
+    required=True,
+    type=str,
+    help="Comma-separated list of full tags including image names",
+)
 @click.option("--build-args", required=False, type=str)
 @click.option("--arches", required=False, type=str)
 @click.option("--action", required=False, type=str, default="load")
-def build(repo, commit_sha, registry, tag, build_args, arches, action):
+def build(repo, commit_sha, registry, tags, build_args, arches, action):
     """
-    Build bitcoind and bitcoin-cli from <repo> at <commit_sha> as <registry>:<tag>.
+    Build bitcoind and bitcoin-cli from <repo> at <commit_sha> with the specified <tags>.
     Optionally deploy to remote registry using --action=push, otherwise image is loaded to local registry.
     """
-    res = build_image(repo, commit_sha, registry, tag, build_args, arches, action)
+    res = build_image(repo, commit_sha, registry, tags, build_args, arches, action)
     if not res:
         sys.exit(1)

--- a/src/warnet/network.py
+++ b/src/warnet/network.py
@@ -63,6 +63,11 @@ def copy_scenario_defaults(directory: Path):
     )
 
 
+def is_connection_manual(peer):
+    # newer nodes specify a "connection_type"
+    return bool(peer.get("connection_type") == "manual" or peer.get("addnode") is True)
+
+
 def _connected(end="\n"):
     tanks = get_mission("tank")
     for tank in tanks:
@@ -70,7 +75,7 @@ def _connected(end="\n"):
         peerinfo = json.loads(_rpc(tank.metadata.name, "getpeerinfo", ""))
         actual = 0
         for peer in peerinfo:
-            if peer["connection_type"] == "manual":
+            if is_connection_manual(peer):
                 actual += 1
         expected = int(tank.metadata.annotations["init_peers"])
         print(f"Tank {tank.metadata.name} peers expected: {expected}, actual: {actual}", end=end)

--- a/test/data/bitcoin_conf/network.yaml
+++ b/test/data/bitcoin_conf/network.yaml
@@ -1,35 +1,35 @@
 nodes:
   - name: tank-0016
     image:
-      tag: "v0.16.1"
+      tag: "0.16.1"
     connect:
       - tank-0017
     config:
       uacomment=tank-0016
   - name: tank-0017
     image:
-      tag: "v0.17.0"
+      tag: "0.17.0"
     connect:
       - tank-0019
     config:
       uacomment=tank-0017
   - name: tank-0019
     image:
-      tag: "v0.19.2"
+      tag: "0.19.2"
     connect:
       - tank-0020
     config:
       uacomment=tank-0019
   - name: tank-0020
     image:
-      tag: "v0.20.0"
+      tag: "0.20.0"
     connect:
       - tank-0021
     config:
       uacomment=tank-0020
   - name: tank-0021
     image:
-      tag: "v0.21.1"
+      tag: "0.21.1"
     connect:
       - tank-0024
     config:

--- a/test/data/signet/network.yaml
+++ b/test/data/signet/network.yaml
@@ -1,8 +1,52 @@
 nodes:
   - name: miner
-  - name: tank-0001
+  - name: tank-1
+    image:
+      tag: "0.16.1"
     connect:
       - miner
-  - name: tank-0002
+  - name: tank-2
+    image:
+      tag: "0.17.0"
+    connect:
+      - miner
+  - name: tank-3
+    image:
+      tag: "0.19.2"
+    connect:
+      - miner
+  - name: tank-4
+    image:
+      tag: "0.20.0"
+    connect:
+      - miner
+  - name: tank-5
+    image:
+      tag: "0.21.1"
+    connect:
+      - miner
+  - name: tank-6
+    image:
+      tag: "24.2"
+    connect:
+      - miner
+  - name: tank-7
+    image:
+      tag: "25.1"
+    connect:
+      - miner
+  - name: tank-8
+    image:
+      tag: "26.0"
+    connect:
+      - miner
+  - name: tank-9
+    image:
+      tag: "27.0"
+    connect:
+      - miner
+  - name: tank-10
+    image:
+      tag: "0.16.1"
     connect:
       - miner

--- a/test/data/signet/node-defaults.yaml
+++ b/test/data/signet/node-defaults.yaml
@@ -5,6 +5,9 @@ image:
 
 chain: signet
 
+spec:
+  restartPolicy: Always
+
 config: |
   debug=rpc
   debug=net

--- a/test/signet_test.py
+++ b/test/signet_test.py
@@ -38,8 +38,8 @@ class SignetTest(TestBase):
         )
 
         def block_one():
-            for tank in ["tank-0001", "tank-0002"]:
-                height = int(self.warnet(f"bitcoin rpc {tank} getblockcount"))
+            for n in range(1, 11):
+                height = int(self.warnet(f"bitcoin rpc tank-{n} getblockcount"))
                 if height != 1:
                     return False
             return True

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -81,8 +81,11 @@ class TestBase:
     def wait_for_predicate(self, predicate, timeout=5 * 60, interval=5):
         self.log.debug(f"Waiting for predicate with timeout {timeout}s and interval {interval}s")
         while timeout > 0:
-            if predicate():
-                return
+            try:
+                if predicate():
+                    return
+            except Exception:
+                pass
             sleep(interval)
             timeout -= interval
         import inspect


### PR DESCRIPTION
mostly a refactor of @willcl-ark 's PR to have one base image that can be used to build different older versions of Bitcoin Core. 

Added ccache, which speeds things up quite a bit and also local development, i.e., compile from your local repo instead of only from a remote. This is particularly useful when trying to build older images/ back port changes, etc.

The base image might seem like overkill for now, but I think having this will make it much easier to add new CVE images as they are announced and also makes it very easy to fix up the existing CVE images if we find issues with the signet back port.

closes #532 

---

Not covered in this PR but good follow-ups:

- Add a test for CVE images that ensures they are able to connect on signet
- Add documentation for using the docker image with local development 
- Add a test in our CI to make sure the patches are working correctly for each of the old images