### PR TITLE
add k8s log collector to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,27 @@ jobs:
         run: |
           source .venv/bin/activate
           ./test/${{matrix.test}}
+      - name: Collect Kubernetes logs
+        if: always()
+        run: |
+          echo "Installing stern..."
+          STERN_VERSION="1.30.0"
+          curl -Lo stern.tar.gz https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_amd64.tar.gz
+          tar zxvf stern.tar.gz
+          chmod +x stern
+          sudo mv stern /usr/local/bin/
+
+          # Run script
+          curl -O https://raw.githubusercontent.com/willcl-ark/warnet/main/resources/scripts/k8s-log-collector.sh
+          chmod +x k8s-log-collector.sh
+          ./k8s-log-collector.sh default
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kubernetes-logs-${{ matrix.test }}
+          path: ./k8s-logs
+          retention-days: 5
   test-without-mk:
     runs-on: ubuntu-latest
     strategy:

--- a/resources/scripts/k8s-log-collector.sh
+++ b/resources/scripts/k8s-log-collector.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Set variables
+NAMESPACE=${1:-default}
+LOG_DIR="./k8s-logs"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+
+# Ensure log directory exists
+mkdir -p "$LOG_DIR"
+
+# Collect logs using stern (includes logs from terminated pods)
+echo "Collecting stern logs..."
+stern "(tank|commander).*" --namespace="$NAMESPACE" --output default --since 1h --no-follow > "$LOG_DIR/${TIMESTAMP}_stern_logs"
+
+# Collect descriptions of all resources
+echo "Collecting resource descriptions..."
+kubectl describe all --namespace="$NAMESPACE" > "$LOG_DIR/${TIMESTAMP}_resource_descriptions.txt"
+
+# Collect events
+echo "Collecting events..."
+kubectl get events --namespace="$NAMESPACE" --sort-by='.metadata.creationTimestamp' > "$LOG_DIR/${TIMESTAMP}_events.txt"
+
+echo "Log collection complete. Logs saved in $LOG_DIR"


### PR DESCRIPTION
Currently, it's *very* painful to debug inconsistencies in the CI vs a local environment. Additionally, when things go wrong, we don't get any kubernetes output at all. 

Fix this by adding a job which uploads artefacts to GH for each job.

`stern` allows tailing of all pods (in all namespaces), and can dump to json (I chose `default` mode here).

See an example of the artefacts here: https://github.com/willcl-ark/warnet/actions/runs/10763746456