### PR TITLE
status: check connections

### DIFF
--- a/src/warnet/network.py
+++ b/src/warnet/network.py
@@ -63,7 +63,7 @@ def copy_scenario_defaults(directory: Path):
     )
 
 
-def _connected():
+def _connected(end="\n"):
     tanks = get_mission("tank")
     for tank in tanks:
         # Get actual
@@ -73,11 +73,11 @@ def _connected():
             if peer["connection_type"] == "manual":
                 actual += 1
         expected = int(tank.metadata.annotations["init_peers"])
-        print(f"Tank {tank.metadata.name} peers expected: {expected}, actual: {actual}")
+        print(f"Tank {tank.metadata.name} peers expected: {expected}, actual: {actual}", end=end)
         # Even if more edges are specified, bitcoind only allows
         # 8 manual outbound connections
         if min(8, expected) > actual:
-            print("Network not connected")
+            print("\nNetwork not connected")
             return False
-    print("Network connected")
+    print("Network connected                                                           ")
     return True

--- a/src/warnet/status.py
+++ b/src/warnet/status.py
@@ -5,6 +5,7 @@ from rich.table import Table
 from rich.text import Text
 
 from .k8s import get_mission
+from .network import _connected
 
 
 @click.command()
@@ -53,6 +54,7 @@ def status():
     summary.append(f"\nTotal Tanks: {len(tanks)}", style="bold cyan")
     summary.append(f" | Active Scenarios: {len(scenarios)}", style="bold green")
     console.print(summary)
+    _connected(end="\r")
 
 
 def _get_tank_status():


### PR DESCRIPTION
closes https://github.com/bitcoin-dev-project/warnet/issues/515

still prints "long" log output in tests but uses `\r` to rewrite the last line of `network status` to keep that output looking clean.

Test output:
```

2024-09-09 12:44:37 | DEBUG   | test     | Waiting for predicate with timeout 1200s and interval 5s
Tank tank-0000 peers expected: 1, actual: 1
Tank tank-0001 peers expected: 1, actual: 1
Tank tank-0002 peers expected: 1, actual: 1
Tank tank-0003 peers expected: 1, actual: 1
Tank tank-0004 peers expected: 1, actual: 1
Tank tank-0005 peers expected: 1, actual: 1
Tank tank-0006 peers expected: 1, actual: 1
Tank tank-0007 peers expected: 1, actual: 1
Tank tank-0008 peers expected: 1, actual: 1
Tank tank-0009 peers expected: 1, actual: 0

Network not connected

```

CLI:
```
(.venv) --> warnet status
╭─────────────── Warnet Overview ───────────────╮
│                                               │
│                 Warnet Status                 │
│ ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓ │
│ ┃ Component ┃ Name                ┃ Status  ┃ │
│ ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩ │
│ │ Tank      │ tank-0000           │ running │ │
│ │ Tank      │ tank-0001           │ running │ │
│ │ Tank      │ tank-0002           │ running │ │
│ │ Tank      │ tank-0003           │ running │ │
│ │ Tank      │ tank-0004           │ running │ │
│ │ Tank      │ tank-0005           │ pending │ │
│ │ Tank      │ tank-0006           │ pending │ │
│ │ Tank      │ tank-0007           │ pending │ │
│ │ Tank      │ tank-0008           │ pending │ │
│ │ Scenario  │ No active scenarios │         │ │
│ └───────────┴─────────────────────┴─────────┘ │
│                                               │
╰───────────────────────────────────────────────╯

Total Tanks: 9 | Active Scenarios: 0
Network connected            
```