### PR TITLE
test: drastically reduce memory in "all versions" test

### DIFF
--- a/test/data/bitcoin_conf/node-defaults.yaml
+++ b/test/data/bitcoin_conf/node-defaults.yaml
@@ -2,3 +2,11 @@ image:
   repository: bitcoindevproject/bitcoin
   pullPolicy: IfNotPresent
   tag: "27.0"
+
+resources:
+  limits:
+    cpu: 4000m
+    memory: 500Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi


### PR DESCRIPTION
The motivation for this is the trial tabconf demo happening this week. By capping the memory these tanks are allowed to 500MiB, the attacks should work a lot faster.