### PR TITLE
bitcoincore: lazier probe checks to accomdate slower nodes / systems

### DIFF
--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -78,16 +78,16 @@ livenessProbe:
     command:
     - pidof
     - bitcoind
-  failureThreshold: 3
+  failureThreshold: 12
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
-  timeoutSeconds: 1
+  timeoutSeconds: 10
 readinessProbe:
-  failureThreshold: 1
-  periodSeconds: 1
+  failureThreshold: 12
+  periodSeconds: 5
   successThreshold: 1
-  timeoutSeconds: 1
+  timeoutSeconds: 10
 
 
 # Additional volumes on the output Deployment definition.


### PR DESCRIPTION
closes #564 

See my comment in that issue, all the node versions we support DO run on fine on arm64/macos some of them just need a few more seconds before they can pass our live/ready checks