### PR TITLE
bitcoin: save debug log to normal file

### DIFF
--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -117,7 +117,7 @@ prometheusMetricsPort: 9332
 
 baseConfig: |
   checkmempool=0
-  debuglogfile=0
+  debuglogfile=debug.log
   logips=1
   logtimemicros=1
   capturemessages=1


### PR DESCRIPTION
This is (erronerously?) set to `0` currently which is odd. Set to debug.log.

I seem to recall this was an attempt to disable debug.log back from the docker days (stdout only), but  even in that case we should have used `nodebuglogfile`.