### PR TITLE
doc: link `Connecting to local nodes` page correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Monitor and analyze the emergent behaviors of Bitcoin networks.
 - [Monitoring](/docs/logging_monitoring.md)
 - [Lightning Network](/docs/lightning.md)
 - [Scaling](/docs/scaling.md)
-- [Connecting to local nodes](https://github.com/bitcoin-dev-project/warnet/blob/main/docs/)
+- [Connecting to local nodes](/docs/connecting-local-nodes.md)
 - [Understanding network configuration](/docs/config.md)
 
 ![warnet-art](https://raw.githubusercontent.com/bitcoin-dev-project/warnet/main/docs/machines.webp)


### PR DESCRIPTION
While reading the docs in the README.md "Connecting to local nodes" was not properly linked.

This PR fix this with the diff below

```diff
diff --git a/README.md b/README.md
index 6e050e7..749fc4e 100644
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Monitor and analyze the emergent behaviors of Bitcoin networks.
 - [Monitoring](/docs/logging_monitoring.md)
 - [Lightning Network](/docs/lightning.md)
 - [Scaling](/docs/scaling.md)
-- [Connecting to local nodes](https://github.com/bitcoin-dev-project/warnet/blob/main/docs/)
+- [Connecting to local nodes](/docs/connecting-local-nodes.md)
 - [Understanding network configuration](/docs/config.md)
 
 ![warnet-art](https://raw.githubusercontent.com/bitcoin-dev-project/warnet/main/docs/machines.webp)
```