### PR TITLE
recon: show how to enable logs

### DIFF
--- a/resources/scenarios/reconnaissance.py
+++ b/resources/scenarios/reconnaissance.py
@@ -38,12 +38,17 @@ class Reconnaissance(Commander):
 
     # Scenario entrypoint
     def run_test(self):
+        # Demonstrate how to enable debug logs from a scenario
+        # This could be any logs, or "all" for all logs
+        self.log("Turning on mempool logging for node 0")
+        self.nodes[0].logging(include=["mempool"])
+
         self.log.info("Getting peer info")
 
         # Just like a typical Bitcoin Core functional test, this executes an
         # RPC on a node in the network. The actual node at self.nodes[0] may
         # be different depending on the user deploying the scenario. Users in
-        # Warnet may have different namepsace access but everyone should always
+        # Warnet may have different namespace access but everyone should always
         # have access to at least one node.
         peerinfo = self.nodes[0].getpeerinfo()
         for peer in peerinfo:


### PR DESCRIPTION
- [x] Need to add minikube start to the quick start / intro guide, since container n00bs like me will just see weird errors and my duckduckgoing wasn't helping.
  - This is in install.md already? And now quickstart.md is gone
- [x] Might be good to have a scenario config that turns on max logging from bitcoind by default.
  - Done
- [x] Don't assume /bin/bash exists at that place on all systems
  - Removed in caddy switch
- [ ] Got a tip to use lazydocker for realtime monitoring, but it only shows one "minikube" row, not one row for each tank. Maybe I haven't found the right TUI-command.
  - I quite like [ktop](https://github.com/vladimirvivien/ktop) for this, perhaps we should document this monitor? Works best when metrics server enabled (on by default in `k3d` and managed cluster)
- [ ] Would be good to have instructions on how to locally compile and then run ones own bitcoind-binaries inside warnet - useful to be able to add extra logging, debug etc. Maybe those exist somewhere, haven't really tried to find them. Can be tricky / time consuming to set up a local build environment for an old bitcoind version though - I guess tips on doing that would be helpful too, remember Jameson Lopp being able to go back quite far when measuring IBD performance IIRC.
  - This is tricky, will need a seperate PR I which I can investgate next week
