### PR TITLE
ci: rebuild commander on python changes too

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - resources/images/commander/Dockerfile
+      - resources/scenarios/commander.py
     tags-ignore:
       - "*"
 


### PR DESCRIPTION
`paths:` specify on which files (changed) this workflow should run.

We want it to run on pushes to main, when these two files change.