### PR TITLE
Add cmd for creating user kubeconfigs (cont. from #545)

### DIFF
--- a/resources/charts/namespaces/templates/namespace.yaml
+++ b/resources/charts/namespaces/templates/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespaceName | default .Release.Name }}
+  labels:
+    type: {{ .Values.type }}

--- a/resources/charts/namespaces/values.yaml
+++ b/resources/charts/namespaces/values.yaml
@@ -1,3 +1,4 @@
+type: "assets"
 users:
   - name: warnet-user
     roles:

--- a/resources/namespaces/two_namespaces_two_users/namespace-defaults.yaml
+++ b/resources/namespaces/two_namespaces_two_users/namespace-defaults.yaml
@@ -3,14 +3,16 @@ users:
     roles:
       - pod-viewer
       - pod-manager
-roles:
-  - name: pod-viewer
-    rules:
-      - apiGroups: [""]
-        resources: ["pods"]
-        verbs: ["get", "list", "watch"]
-  - name: pod-manager
-    rules:
-      - apiGroups: [""]
-        resources: ["pods", "configmaps"]
-        verbs: ["get", "list", "watch", "create", "update", "delete"]
+# the pod-viewer and pod-manager roles are the default
+# roles defined in values.yaml for the namespaces charts
+#
+# if you need a different set of roles for a particular namespaces
+# deployment, you can override values.yaml by providing your own
+# role definitions below
+#
+# roles:
+#   - name: my-custom-role
+#     rules:
+#      - apiGroups: ""
+#        resources: ""
+#        verbs: ""

--- a/resources/namespaces/two_namespaces_two_users/namespaces.yaml
+++ b/resources/namespaces/two_namespaces_two_users/namespaces.yaml
@@ -1,5 +1,5 @@
 namespaces:
-  - name: warnet-red-team
+  - name: wargames-red-team
     users:
       - name: alice
         roles:
@@ -8,42 +8,7 @@ namespaces:
         roles:
           - pod-viewer
           - pod-manager
-    roles:
-      - name: pod-viewer
-        rules:
-          - apiGroups: [""]
-            resources: ["pods"]
-            verbs: ["get", "list", "watch"]
-          - apiGroups: [""]
-            resources: ["pods/log", "pods/exec", "pods/attach", "pods/portforward"]
-            verbs: ["get"]
-          - apiGroups: [""]
-            resources: ["configmaps", "secrets"]
-            verbs: ["get"]
-          - apiGroups: [""]
-            resources: ["persistentvolumeclaims"]
-            verbs: ["get", "list"]
-          - apiGroups: [""]
-            resources: ["events"]
-            verbs: ["get"]
-      - name: pod-manager
-        rules:
-          - apiGroups: [""]
-            resources: ["pods"]
-            verbs: ["get", "list", "watch", "create", "delete", "update"]
-          - apiGroups: [""]
-            resources: ["pods/log", "pods/exec", "pods/attach", "pods/portforward"]
-            verbs: ["get", "create"]
-          - apiGroups: [""]
-            resources: ["configmaps", "secrets"]
-            verbs: ["get", "create"]
-          - apiGroups: [""]
-            resources: ["persistentvolumeclaims"]
-            verbs: ["get", "list"]
-          - apiGroups: [""]
-            resources: ["events"]
-            verbs: ["get"]
-  - name: warnet-blue-team
+  - name: wargames-blue-team
     users:
       - name: mallory
         roles:
@@ -52,38 +17,3 @@ namespaces:
         roles:
           - pod-viewer
           - pod-manager
-    roles:
-      - name: pod-viewer
-        rules:
-          - apiGroups: [""]
-            resources: ["pods"]
-            verbs: ["get", "list", "watch"]
-          - apiGroups: [""]
-            resources: ["pods/log", "pods/exec", "pods/attach", "pods/portforward"]
-            verbs: ["get"]
-          - apiGroups: [""]
-            resources: ["configmaps", "secrets"]
-            verbs: ["get"]
-          - apiGroups: [""]
-            resources: ["persistentvolumeclaims"]
-            verbs: ["get", "list"]
-          - apiGroups: [""]
-            resources: ["events"]
-            verbs: ["get"]
-      - name: pod-manager
-        rules:
-          - apiGroups: [""]
-            resources: ["pods"]
-            verbs: ["get", "list", "watch", "create", "delete", "update"]
-          - apiGroups: [""]
-            resources: ["pods/log", "pods/exec", "pods/attach", "pods/portforward"]
-            verbs: ["get", "create"]
-          - apiGroups: [""]
-            resources: ["configmaps", "secrets"]
-            verbs: ["get", "create"]
-          - apiGroups: [""]
-            resources: ["persistentvolumeclaims"]
-            verbs: ["get", "list"]
-          - apiGroups: [""]
-            resources: ["events"]
-            verbs: ["get"]

--- a/src/warnet/admin.py
+++ b/src/warnet/admin.py
@@ -5,8 +5,10 @@ import click
 from rich import print as richprint
 
 from .constants import NETWORK_DIR
+from .k8s import get_kubeconfig_value, get_namespaces_by_prefix, get_service_accounts_in_namespace
 from .namespaces import copy_namespaces_defaults, namespaces
 from .network import copy_network_defaults
+from .process import run_command
 
 
 @click.group(name="admin", hidden=True)
@@ -33,3 +35,93 @@ def init():
         f"[green]Copied network and namespace example files to {Path(current_dir) / NETWORK_DIR.name}[/green]"
     )
     richprint(f"[green]Created warnet project structure in {current_dir}[/green]")
+
+
+@admin.command()
+@click.argument("prefix", type=str, required=True)
+@click.option(
+    "--kubeconfig-dir",
+    default="kubeconfigs",
+    help="Directory to store kubeconfig files (default: kubeconfigs)",
+)
+@click.option(
+    "--token-duration",
+    default=172800,
+    type=int,
+    help="Duration of the token in seconds (default: 48 hours)",
+)
+def create_kubeconfigs(prefix: str, kubeconfig_dir, token_duration):
+    """Create kubeconfig files for all ServiceAccounts in warnet team namespaces starting with <prefix>."""
+    kubeconfig_dir = os.path.expanduser(kubeconfig_dir)
+
+    cluster_name = get_kubeconfig_value("{.clusters[0].name}")
+    cluster_server = get_kubeconfig_value("{.clusters[0].cluster.server}")
+    cluster_ca = get_kubeconfig_value("{.clusters[0].cluster.certificate-authority-data}")
+
+    os.makedirs(kubeconfig_dir, exist_ok=True)
+
+    # Get all namespaces that start with prefix
+    # This assumes when deploying multiple namespacs for the purpose of team games, all namespaces start with a prefix,
+    # e.g., tabconf-wargames-*. Currently, this is a bit brittle, but we can improve on this in the future
+    # by automatically applying a TEAM_PREFIX when creating the get_warnet_namespaces
+    # TODO: choose a prefix convention and have it managed by the helm charts instead of requiring the
+    # admin user to pipe through the correct string in multiple places. Another would be to use
+    # labels instead of namespace naming conventions
+    warnet_namespaces = get_namespaces_by_prefix(prefix)
+
+    for namespace in warnet_namespaces:
+        click.echo(f"Processing namespace: {namespace}")
+        service_accounts = get_service_accounts_in_namespace(namespace)
+
+        for sa in service_accounts:
+            # Create a token for the ServiceAccount with specified duration
+            command = f"kubectl create token {sa} -n {namespace} --duration={token_duration}s"
+            try:
+                token = run_command(command)
+            except Exception as e:
+                click.echo(
+                    f"Failed to create token for ServiceAccount {sa} in namespace {namespace}. Error: {str(e)}. Skipping..."
+                )
+                continue
+
+            # Create a kubeconfig file for the user
+            kubeconfig_file = os.path.join(kubeconfig_dir, f"{sa}-{namespace}-kubeconfig")
+
+            # TODO: move yaml  out of python code to resources/manifests/
+            #
+            # might not be worth it since we are just reading the yaml to then create a bunch of values and its not
+            # actually used to deploy anything into the cluster
+            # Then benefit would be making this code a bit cleaner and easy to follow, fwiw
+            kubeconfig_content = f"""apiVersion: v1
+kind: Config
+clusters:
+- name: {cluster_name}
+  cluster:
+    server: {cluster_server}
+    certificate-authority-data: {cluster_ca}
+users:
+- name: {sa}
+  user:
+    token: {token}
+contexts:
+- name: {sa}-{namespace}
+  context:
+    cluster: {cluster_name}
+    namespace: {namespace}
+    user: {sa}
+current-context: {sa}-{namespace}
+"""
+            with open(kubeconfig_file, "w") as f:
+                f.write(kubeconfig_content)
+
+            click.echo(f"    Created kubeconfig file for {sa}: {kubeconfig_file}")
+
+    click.echo("---")
+    click.echo(
+        f"All kubeconfig files have been created in the '{kubeconfig_dir}' directory with a duration of {token_duration} seconds."
+    )
+    click.echo("Distribute these files to the respective users.")
+    click.echo(
+        "Users can then use by running `warnet auth <file>` or with kubectl by specifying the --kubeconfig flag or by setting the KUBECONFIG environment variable."
+    )
+    click.echo(f"Note: The tokens will expire after {token_duration} seconds.")

--- a/src/warnet/constants.py
+++ b/src/warnet/constants.py
@@ -15,6 +15,7 @@ DEFAULT_NAMESPACE = "warnet"
 LOGGING_NAMESPACE = "warnet-logging"
 INGRESS_NAMESPACE = "ingress"
 HELM_COMMAND = "helm upgrade --install --create-namespace"
+WARNET_ASSETS = "assets"
 
 # Directories and files for non-python assets, e.g., helm charts, example scenarios, default configs
 SRC_DIR = files("warnet")

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -235,14 +235,6 @@ def deploy_namespaces(directory: Path):
     with namespaces_file_path.open() as f:
         namespaces_file = yaml.safe_load(f)
 
-    names = [n.get("name") for n in namespaces_file["namespaces"]]
-    for n in names:
-        if not n.startswith("warnet-"):
-            click.echo(
-                f"Failed to create namespace: {n}. Namespaces must start with a 'warnet-' prefix."
-            )
-            return
-
     for namespace in namespaces_file["namespaces"]:
         click.echo(f"Deploying namespace: {namespace.get('name')}")
         try:

--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -282,3 +282,27 @@ def get_ingress_ip_or_host():
     except Exception as e:
         print(f"Error getting ingress IP: {e}")
         return None
+
+
+def get_kubeconfig_value(jsonpath):
+    command = f"kubectl config view --minify -o jsonpath={jsonpath}"
+    return run_command(command)
+
+
+def get_namespaces_by_prefix(prefix: str):
+    """
+    Get all namespaces beginning with `prefix`. Returns empty list of no namespaces with the specified prefix are found.
+    """
+    command = "kubectl get namespaces -o jsonpath={.items[*].metadata.name}"
+    namespaces = run_command(command).split()
+    return [ns for ns in namespaces if ns.startswith(prefix)]
+
+
+def get_service_accounts_in_namespace(namespace):
+    """
+    Get all service accounts in a namespace. Returns an empty list if no service accounts are found in the specified namespace.
+    """
+    command = f"kubectl get serviceaccounts -n {namespace} -o jsonpath={{.items[*].metadata.name}}"
+    # skip the default service account created by k8s
+    service_accounts = run_command(command).split()
+    return [sa for sa in service_accounts if sa != "default"]


### PR DESCRIPTION
Continues on https://github.com/bitcoin-dev-project/warnet/pull/545. This command is used to create user specific authentication files , after running `warnet deploy namespaces/<your custom config>`.

The custom config here is for creating a namespace for each team, creating user service accounts in each namespace, and applying whatever roles to those users are defined in the namespaces.yaml and namespace-default.yaml files. If no roles are specified in the config files, whatever is in values.yaml for the namespaces chart is used. Currently, the defaults in the chart are to create pod viewer and pod manager roles for each user.

## Testing

1. `warnet admin init`  - this copies over the example namespaces directory
2. `warnet deploy namespaces/two_namespaces_two_users/`
3. `warnet admin create-kubeconfigs wargames-` - issues a token for each user in each namespace with the prefix "wargames-"

To test, run `warnet auth <user_kubeconfig>`. This will switch your current-context in kubectl to this user context. You should be able to deploy and run scenarios , and do everything needed to participate in a war game. If you see a permissions error, you can easily update the namespaces.yaml file to fix the permissions for that user and redeploy the namespaces and reissue the tokens.

## Todo

- [ ] test all permissions are correct - if not, we should update either the defaults in values.yaml or at least update the example
- [ ] write a doc for an admin - the person expected to use these commands
- [ ] write an e2e test