### PR TITLE
status: only count "running"/"pending" scenarios as "active"

### DIFF
--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -27,18 +27,11 @@ from .process import run_command, stream_command
 
 console = Console()
 
-
-def get_active_scenarios():
-    """Get list of active scenarios"""
-    commanders = get_mission("commander")
-    return [c.metadata.name for c in commanders]
-
-
 @click.command()
 @click.argument("scenario_name", required=False)
 def stop(scenario_name):
     """Stop a running scenario or all scenarios"""
-    active_scenarios = get_active_scenarios()
+    active_scenarios = [sc.metadata.name for sc in get_mission("commander")]
 
     if not active_scenarios:
         console.print("[bold red]No active scenarios found.[/bold red]")
@@ -106,24 +99,6 @@ def stop_all_scenarios(scenarios):
         for scenario in scenarios:
             stop_scenario(scenario)
     console.print("[bold green]All scenarios have been stopped.[/bold green]")
-
-
-def list_active_scenarios():
-    """List all active scenarios"""
-    active_scenarios = get_active_scenarios()
-    if not active_scenarios:
-        print("No active scenarios found.")
-        return
-
-    console = Console()
-    table = Table(title="Active Scenarios", show_header=True, header_style="bold magenta")
-    table.add_column("Name", style="cyan")
-    table.add_column("Status", style="green")
-
-    for scenario in active_scenarios:
-        table.add_row(scenario, "deployed")
-
-    console.print(table)
 
 
 @click.command()

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -27,6 +27,7 @@ from .process import run_command, stream_command
 
 console = Console()
 
+
 @click.command()
 @click.argument("scenario_name", required=False)
 def stop(scenario_name):

--- a/src/warnet/status.py
+++ b/src/warnet/status.py
@@ -14,7 +14,7 @@ def status():
     console = Console()
 
     tanks = _get_tank_status()
-    scenarios = _get_active_scenarios()
+    scenarios = _get_deployed_scenarios()
 
     # Create a unified table
     table = Table(title="Warnet Status", show_header=True, header_style="bold magenta")
@@ -62,6 +62,6 @@ def _get_tank_status():
     return [{"name": tank.metadata.name, "status": tank.status.phase.lower()} for tank in tanks]
 
 
-def _get_active_scenarios():
+def _get_deployed_scenarios():
     commanders = get_mission("commander")
     return [{"name": c.metadata.name, "status": c.status.phase.lower()} for c in commanders]

--- a/src/warnet/status.py
+++ b/src/warnet/status.py
@@ -31,9 +31,12 @@ def status():
         table.add_row("", "", "")
 
     # Add scenarios to the table
+    active = 0
     if scenarios:
         for scenario in scenarios:
             table.add_row("Scenario", scenario["name"], scenario["status"])
+            if scenario["status"] == "running" or scenario["status"] == "pending":
+                active += 1
     else:
         table.add_row("Scenario", "No active scenarios", "")
 
@@ -52,7 +55,7 @@ def status():
     # Print summary
     summary = Text()
     summary.append(f"\nTotal Tanks: {len(tanks)}", style="bold cyan")
-    summary.append(f" | Active Scenarios: {len(scenarios)}", style="bold green")
+    summary.append(f" | Active Scenarios: {active}", style="bold green")
     console.print(summary)
     _connected(end="\r")
 

--- a/test/data/scenario_buggy_failure.py
+++ b/test/data/scenario_buggy_failure.py
@@ -7,6 +7,7 @@ try:
 except Exception:
     from resources.scenarios.commander import Commander
 
+
 class Failure(Commander):
     def set_test_params(self):
         self.num_nodes = 1

--- a/test/data/scenario_buggy_failure.py
+++ b/test/data/scenario_buggy_failure.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+
+# The base class exists inside the commander container
+try:
+    from commander import Commander
+except Exception:
+    from resources.scenarios.commander import Commander
+
+class Failure(Commander):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def add_options(self, parser):
+        parser.description = "This test will fail and exit with code 222"
+        parser.usage = "warnet run /path/to/scenario_buggy_failure.py"
+
+    def run_test(self):
+        raise Exception("Failed execution!")
+
+
+if __name__ == "__main__":
+    Failure().main()

--- a/test/data/scenario_connect_dag.py
+++ b/test/data/scenario_connect_dag.py
@@ -7,10 +7,6 @@ from enum import Enum, auto, unique
 from commander import Commander
 
 
-def cli_help():
-    return "Connect a complete DAG from a set of unconnected nodes"
-
-
 @unique
 class ConnectionType(Enum):
     IP = auto()
@@ -21,6 +17,10 @@ class ConnectDag(Commander):
     def set_test_params(self):
         # This is just a minimum
         self.num_nodes = 10
+
+    def add_options(self, parser):
+        parser.description = "Connect a complete DAG from a set of unconnected nodes"
+        parser.usage = "warnet run /path/to/scenario_connect_dag.py"
 
     def run_test(self):
         # All permutations of a directed acyclic graph with zero, one, or two inputs/outputs

--- a/test/data/scenario_p2p_interface.py
+++ b/test/data/scenario_p2p_interface.py
@@ -12,10 +12,6 @@ from test_framework.messages import CInv, msg_getdata
 from test_framework.p2p import P2PInterface
 
 
-def cli_help():
-    return "Run P2P GETDATA test"
-
-
 class P2PStoreBlock(P2PInterface):
     def __init__(self):
         super().__init__()
@@ -29,6 +25,10 @@ class P2PStoreBlock(P2PInterface):
 class GetdataTest(Commander):
     def set_test_params(self):
         self.num_nodes = 1
+
+    def add_options(self, parser):
+        parser.description = "Run P2P GETDATA test"
+        parser.usage = "warnet run /path/to/scenario_p2p_interface.py"
 
     def run_test(self):
         self.log.info("Adding the p2p connection")

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -7,7 +7,7 @@ from test_base import TestBase
 
 from warnet.control import stop_scenario
 from warnet.process import run_command
-from warnet.status import _get_active_scenarios as scenarios_active
+from warnet.status import _get_deployed_scenarios as scenarios_deployed
 
 
 class ScenariosTest(TestBase):
@@ -32,22 +32,22 @@ class ScenariosTest(TestBase):
 
     def scenario_running(self, scenario_name: str):
         """Check that we are only running a single scenario of the correct name"""
-        active = scenarios_active()
-        assert len(active) == 1
-        return scenario_name in active[0]["name"]
+        deployed = scenarios_deployed()
+        assert len(deployed) == 1
+        return scenario_name in deployed[0]["name"]
 
     def check_scenario_stopped(self):
-        running = scenarios_active()
+        running = scenarios_deployed()
         self.log.debug(f"Checking if scenario stopped. Running scenarios: {len(running)}")
         return len(running) == 0
 
     def check_scenario_clean_exit(self):
-        active = scenarios_active()
-        return all(scenario["status"] == "succeeded" for scenario in active)
+        deployed = scenarios_deployed()
+        return all(scenario["status"] == "succeeded" for scenario in deployed)
 
     def stop_scenario(self):
         self.log.info("Stopping running scenario")
-        running = scenarios_active()
+        running = scenarios_deployed()
         assert len(running) == 1, f"Expected one running scenario, got {len(running)}"
         assert running[0]["status"] == "running", "Scenario should be running"
         stop_scenario(running[0]["name"])
@@ -58,8 +58,8 @@ class ScenariosTest(TestBase):
         self.log.debug(f"Current block count: {count}, target: {start + target_blocks}")
 
         try:
-            active = scenarios_active()
-            commander = active[0]["commander"]
+            deployed = scenarios_deployed()
+            commander = deployed[0]["commander"]
             command = f"kubectl logs {commander}"
             print("\ncommander output:")
             print(run_command(command))

--- a/test/scenarios_test.py
+++ b/test/scenarios_test.py
@@ -102,9 +102,8 @@ class ScenariosTest(TestBase):
             deployed = scenarios_deployed()
             if len([s for s in deployed if s["status"] == "succeeded"]) != 2:
                 return False
-            if len([s for s in deployed if s["status"] == "failed"]) != 1:
-                return False
-            return True
+            return len([s for s in deployed if s["status"] == "failed"]) == 1
+
         self.wait_for_predicate(two_pass_one_fail)
         table = self.warnet("status")
         assert "Active Scenarios: 0" in table

--- a/test/signet_test.py
+++ b/test/signet_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from test_base import TestBase
 
-from warnet.status import _get_active_scenarios as scenarios_active
+from warnet.status import _get_deployed_scenarios as scenarios_deployed
 
 
 class SignetTest(TestBase):
@@ -55,8 +55,8 @@ class SignetTest(TestBase):
         self.warnet(f"run {scenario_file}")
 
         def check_scenario_clean_exit():
-            active = scenarios_active()
-            return all(scenario["status"] == "succeeded" for scenario in active)
+            deployed = scenarios_deployed()
+            return all(scenario["status"] == "succeeded" for scenario in deployed)
 
         self.wait_for_predicate(check_scenario_clean_exit)
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -12,8 +12,8 @@ from time import sleep
 from warnet import SRC_DIR
 from warnet.k8s import get_pod_exit_status
 from warnet.network import _connected as network_connected
-from warnet.status import _get_tank_status as network_status
 from warnet.status import _get_deployed_scenarios as scenarios_deployed
+from warnet.status import _get_tank_status as network_status
 
 
 class TestBase:
@@ -130,8 +130,8 @@ class TestBase:
             if len(scns) == 0:
                 return True
             for s in scns:
-                exit_status = get_pod_exit_status(s)
-                self.log.debug(f"Scenario {s} exited with code {exit_status}")
+                exit_status = get_pod_exit_status(s["name"])
+                self.log.debug(f"Scenario {s['name']} exited with code {exit_status}")
                 if exit_status != 0:
                     return False
             return True

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -10,10 +10,10 @@ from tempfile import mkdtemp
 from time import sleep
 
 from warnet import SRC_DIR
-from warnet.control import get_active_scenarios
 from warnet.k8s import get_pod_exit_status
 from warnet.network import _connected as network_connected
 from warnet.status import _get_tank_status as network_status
+from warnet.status import _get_deployed_scenarios as scenarios_deployed
 
 
 class TestBase:
@@ -126,7 +126,7 @@ class TestBase:
 
     def wait_for_all_scenarios(self):
         def check_scenarios():
-            scns = get_active_scenarios()
+            scns = scenarios_deployed()
             if len(scns) == 0:
                 return True
             for s in scns:


### PR DESCRIPTION
closes https://github.com/bitcoin-dev-project/warnet/issues/516

Scenarios that are complete or failed are no longer active:
```

│ │ Tank      │ tank-0010                                 │ running   │ │
│ │ Tank      │ tank-0011                                 │ running   │ │
│ │           │                                           │           │ │
│ │ Scenario  │ commander-minerstd-1726235251             │ running   │ │
│ │ Scenario  │ commander-scenariobuggyfailure-1726234940 │ succeeded │ │
│ │ Scenario  │ commander-scenariobuggyfailure-1726234982 │ succeeded │ │
│ │ Scenario  │ commander-scenariobuggyfailure-1726235087 │ failed    │ │
│ └───────────┴───────────────────────────────────────────┴───────────┘ │
│                                                                       │
╰───────────────────────────────────────────────────────────────────────╯

Total Tanks: 12 | Active Scenarios: 1
Network connected

```