### PR TITLE
use default namespace when checking network connections

### DIFF
--- a/src/warnet/bitcoin.py
+++ b/src/warnet/bitcoin.py
@@ -10,7 +10,7 @@ from urllib3.exceptions import MaxRetryError
 from test_framework.messages import ser_uint256
 from test_framework.p2p import MESSAGEMAP
 
-from .k8s import get_mission
+from .k8s import get_default_namespace, get_mission
 from .process import run_command
 
 
@@ -38,10 +38,11 @@ def rpc(tank: str, method: str, params: str):
 def _rpc(tank: str, method: str, params: str):
     # bitcoin-cli should be able to read bitcoin.conf inside the container
     # so no extra args like port, chain, username or password are needed
+    namespace = get_default_namespace()
     if params:
-        cmd = f"kubectl exec {tank} -- bitcoin-cli {method} {' '.join(map(str, params))}"
+        cmd = f"kubectl -n {namespace} exec {tank} -- bitcoin-cli {method} {' '.join(map(str, params))}"
     else:
-        cmd = f"kubectl exec {tank} -- bitcoin-cli {method}"
+        cmd = f"kubectl -n {namespace} exec {tank} -- bitcoin-cli {method}"
     return run_command(cmd)
 
 

--- a/src/warnet/network.py
+++ b/src/warnet/network.py
@@ -62,17 +62,22 @@ def _connected(end="\n"):
     tanks = get_mission("tank")
     for tank in tanks:
         # Get actual
-        peerinfo = json.loads(_rpc(tank.metadata.name, "getpeerinfo", ""))
-        actual = 0
-        for peer in peerinfo:
-            if is_connection_manual(peer):
-                actual += 1
-        expected = int(tank.metadata.annotations["init_peers"])
-        print(f"Tank {tank.metadata.name} peers expected: {expected}, actual: {actual}", end=end)
-        # Even if more edges are specified, bitcoind only allows
-        # 8 manual outbound connections
-        if min(8, expected) > actual:
-            print("\nNetwork not connected")
+        try:
+            peerinfo = json.loads(_rpc(tank.metadata.name, "getpeerinfo", ""))
+            actual = 0
+            for peer in peerinfo:
+                if is_connection_manual(peer):
+                    actual += 1
+            expected = int(tank.metadata.annotations["init_peers"])
+            print(
+                f"Tank {tank.metadata.name} peers expected: {expected}, actual: {actual}", end=end
+            )
+            # Even if more edges are specified, bitcoind only allows
+            # 8 manual outbound connections
+            if min(8, expected) > actual:
+                print("\nNetwork not connected")
+                return False
+        except Exception:
             return False
     print("Network connected                                                           ")
     return True


### PR DESCRIPTION
# Turns this:

```
(.venv) --> warnet status
╭──────────────────── Warnet Overview ────────────────────╮
│                                                         │
│                      Warnet Status                      │
│ ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓ │
│ ┃ Component ┃ Name                          ┃ Status  ┃ │
│ ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩ │
│ │ Tank      │ tank-0000                     │ running │ │
│ │ Tank      │ tank-0001                     │ running │ │
│ │ Tank      │ tank-0002                     │ running │ │
│ │ Tank      │ tank-0003                     │ running │ │
│ │ Tank      │ tank-0004                     │ running │ │
│ │ Tank      │ tank-0005                     │ running │ │
│ │ Tank      │ tank-0006                     │ running │ │
│ │ Tank      │ tank-0007                     │ running │ │
│ │ Tank      │ tank-0008                     │ running │ │
│ │ Tank      │ tank-0009                     │ running │ │
│ │ Tank      │ tank-0010                     │ running │ │
│ │ Tank      │ tank-0011                     │ running │ │
│ │           │                               │         │ │
│ │ Scenario  │ commander-minerstd-1726253550 │ failed  │ │
│ └───────────┴───────────────────────────────┴─────────┘ │
│                                                         │
╰─────────────────────────────────────────────────────────╯

Total Tanks: 12 | Active Scenarios: 0
Traceback (most recent call last):
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/bin/warnet", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/src/warnet/status.py", line 60, in status
    _connected(end="\r")
  File "/Users/matthewzipkin/Desktop/work/warnet/src/warnet/network.py", line 65, in _connected
    peerinfo = json.loads(_rpc(tank.metadata.name, "getpeerinfo", ""))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/src/warnet/bitcoin.py", line 45, in _rpc
    return run_command(cmd)
           ^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/src/warnet/process.py", line 7, in run_command
    raise Exception(result.stderr)
Exception: Error from server (NotFound): pods "tank-0000" not found
```

# Into this...

```
(.venv) --> warnet status
╭──────────────────── Warnet Overview ────────────────────╮
│                                                         │
│                      Warnet Status                      │
│ ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓ │
│ ┃ Component ┃ Name                          ┃ Status  ┃ │
│ ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩ │
│ │ Tank      │ tank-0000                     │ running │ │
│ │ Tank      │ tank-0001                     │ running │ │
│ │ Tank      │ tank-0002                     │ running │ │
│ │ Tank      │ tank-0003                     │ running │ │
│ │ Tank      │ tank-0004                     │ running │ │
│ │ Tank      │ tank-0005                     │ running │ │
│ │ Tank      │ tank-0006                     │ running │ │
│ │ Tank      │ tank-0007                     │ running │ │
│ │ Tank      │ tank-0008                     │ running │ │
│ │ Tank      │ tank-0009                     │ running │ │
│ │ Tank      │ tank-0010                     │ running │ │
│ │ Tank      │ tank-0011                     │ running │ │
│ │           │                               │         │ │
│ │ Scenario  │ commander-minerstd-1726253550 │ failed  │ │
│ └───────────┴───────────────────────────────┴─────────┘ │
│                                                         │
╰─────────────────────────────────────────────────────────╯
Total Tanks: 12 | Active Scenarios: 0
Network connected                                                           
```