### PR TITLE
stop: use default namespace

### DIFF
--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -77,14 +77,14 @@ def stop(scenario_name):
 def stop_scenario(scenario_name):
     """Stop a single scenario using Helm"""
     # Stop the pod immediately (faster than uninstalling)
-    cmd = f"kubectl delete pod {scenario_name} --grace-period=0 --force"
+    namespace = get_default_namespace()
+    cmd = f"kubectl --namespace {namespace} delete pod {scenario_name} --grace-period=0 --force"
     if stream_command(cmd):
         console.print(f"[bold green]Successfully stopped scenario: {scenario_name}[/bold green]")
     else:
         console.print(f"[bold red]Failed to stop scenario: {scenario_name}[/bold red]")
 
     # Then uninstall via helm (non-blocking)
-    namespace = get_default_namespace()
     command = f"helm uninstall {scenario_name} --namespace {namespace} --wait=false"
 
     # Run the helm uninstall command in the background


### PR DESCRIPTION
# Turn this ...

```
(.venv) --> warnet stop
             Active Scenarios             
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Number ┃ Scenario Name                 ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      1 │ commander-minerstd-1726254405 │
│      2 │ commander-txflood-1726256906  │
└────────┴───────────────────────────────┘
Enter the number of the scenario to stop, 'a' to stop all, or 'q' to quit: 2
Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
Error from server (NotFound): pods "commander-txflood-1726256906" not found
Traceback (most recent call last):
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/bin/warnet", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/.venv/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/src/warnet/control.py", line 74, in stop
    stop_scenario(scenario_name)
  File "/Users/matthewzipkin/Desktop/work/warnet/src/warnet/control.py", line 81, in stop_scenario
    if stream_command(cmd):
       ^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewzipkin/Desktop/work/warnet/src/warnet/process.py", line 28, in stream_command
    raise Exception(process.stderr)
Exception: None
```

# ... into this!

```
(.venv) --> warnet stop
             Active Scenarios             
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Number ┃ Scenario Name                 ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      1 │ commander-minerstd-1726254405 │
│      2 │ commander-txflood-1726256906  │
└────────┴───────────────────────────────┘
Enter the number of the scenario to stop, 'a' to stop all, or 'q' to quit: a
Are you sure you want to stop all scenarios? [y/n]: y
Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "commander-minerstd-1726254405" force deleted
Successfully stopped scenario: commander-minerstd-1726254405
Initiated helm uninstall for release: commander-minerstd-1726254405
Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "commander-txflood-1726256906" force deleted
Successfully stopped scenario: commander-txflood-1726256906
Initiated helm uninstall for release: commander-txflood-1726256906
All scenarios have been stopped.
```