### PR TITLE
Add --debug option to run scenarios for faster development

### DIFF
--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -3,13 +3,14 @@ import os
 import sys
 import tempfile
 from pathlib import Path
+from time import sleep
 
 import yaml
 from kubernetes import client, config, watch
 from kubernetes.client.models import CoreV1Event, V1PodList
+from kubernetes.client.rest import ApiException
 from kubernetes.dynamic import DynamicClient
 from kubernetes.stream import stream
-from kubernetes.client.rest import ApiException
 
 from .constants import (
     CADDY_INGRESS_NAME,
@@ -293,7 +294,17 @@ def pod_log(pod_name, container_name=None, follow=False):
             namespace=get_default_namespace(),
             container=container_name,
             follow=follow,
-            _preload_content=False
+            _preload_content=False,
         )
     except ApiException as e:
-        raise Exception(json.loads(e.body.decode('utf-8'))["message"])
+        raise Exception(json.loads(e.body.decode("utf-8"))["message"]) from None
+
+
+def wait_for_pod(pod_name, timeout_seconds=10):
+    sclient = get_static_client()
+    while timeout_seconds > 0:
+        pod = sclient.read_namespaced_pod_status(name=pod_name, namespace=get_default_namespace())
+        if pod.status.phase != "Pending":
+            return
+        sleep(1)
+        timeout_seconds -= 1

--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -9,6 +9,7 @@ from kubernetes import client, config, watch
 from kubernetes.client.models import CoreV1Event, V1PodList
 from kubernetes.dynamic import DynamicClient
 from kubernetes.stream import stream
+from kubernetes.client.rest import ApiException
 
 from .constants import (
     CADDY_INGRESS_NAME,
@@ -282,3 +283,17 @@ def get_ingress_ip_or_host():
     except Exception as e:
         print(f"Error getting ingress IP: {e}")
         return None
+
+
+def pod_log(pod_name, container_name=None, follow=False):
+    sclient = get_static_client()
+    try:
+        return sclient.read_namespaced_pod_log(
+            name=pod_name,
+            namespace=get_default_namespace(),
+            container=container_name,
+            follow=follow,
+            _preload_content=False
+        )
+    except ApiException as e:
+        raise Exception(json.loads(e.body.decode('utf-8'))["message"])


### PR DESCRIPTION
This PR also refactors `warnet logs` and `warnet logs -f` to remove dependence on kubectl.

The `--debug` flag, when added to `warnet run <scenario>`:
- deploys the commander like usual
- streams the log output of the commander to stdout while it runs
- deletes the commander pod when user interrupts with ctrl-C
- OR deletes the commander pod when scenario is complete / success / fail

Note that the `--debug` flag does not interfere with extra args passed to the scenario itself!

## Examples:

### scenario self destructs

```

(.venv) --> warnet run test/data/scenario_buggy_failure.py --debug
Successfully started scenario: scenario_buggy_failure
Commander pod name: commander-scenariobuggyfailure-1726684435
Waiting for commander pod to start...
Failure  Adding TestNode #0 from pod tank-0001 with IP 10.1.35.210
Failure  Adding TestNode #1 from pod tank-0002 with IP 10.1.35.211
Failure  Adding TestNode #2 from pod tank-0003 with IP 10.1.35.212
Failure  Adding TestNode #3 from pod tank-0004 with IP 10.1.35.213
Failure  Adding TestNode #4 from pod tank-0005 with IP 10.1.35.214
Failure  Adding TestNode #5 from pod tank-0006 with IP 10.1.35.215
Failure  Adding TestNode #6 from pod tank-0007 with IP 10.1.35.216
Failure  Adding TestNode #7 from pod tank-0008 with IP 10.1.35.217
Failure  Adding TestNode #8 from pod tank-0009 with IP 10.1.35.218
Failure  Adding TestNode #9 from pod tank-0010 with IP 10.1.35.219
Failure  Adding TestNode #10 from pod tank-0011 with IP 10.1.35.220
Failure  User supplied random seed 131260415370612
Failure  PRNG seed is: 131260415370612
Failure  Unexpected exception caught during testing
Traceback (most recent call last):
  File "/test_framework/test_framework.py", line 131, in main
    self.run_test()
  File "/scenario.py", line 20, in run_test
    raise Exception("Failed execution!")
Exception: Failed execution!
Failure  Stopping nodes
Failure  Not cleaning up dir /tmp/bitcoin_func_test_v9j7p8ht
Failure  Test failed. Test logging available at /tmp/bitcoin_func_test_v9j7p8ht/test_framework.log
Failure
Failure  Hint: Call /combine_logs.py '/tmp/bitcoin_func_test_v9j7p8ht' to consolidate all logs
Failure
Failure  If this failure happened unexpectedly or intermittently, please file a bug and provide a link or upload of the combined log.
Failure
Failure
Deleting pod...
pod "commander-scenariobuggyfailure-1726684435" deleted
```

### scenario is cancelled by user with ctrl-c

```

(.venv) --> warnet run resources/scenarios/miner_std.py --interval=1 --allnodes --debug
Successfully started scenario: miner_std
Commander pod name: commander-minerstd-1726684605
Waiting for commander pod to start...
MinerStd Adding TestNode #0 from pod tank-0001 with IP 10.1.35.210
MinerStd Adding TestNode #1 from pod tank-0002 with IP 10.1.35.211
MinerStd Adding TestNode #2 from pod tank-0003 with IP 10.1.35.212
MinerStd Adding TestNode #3 from pod tank-0004 with IP 10.1.35.213
MinerStd Adding TestNode #4 from pod tank-0005 with IP 10.1.35.214
MinerStd Adding TestNode #5 from pod tank-0006 with IP 10.1.35.215
MinerStd Adding TestNode #6 from pod tank-0007 with IP 10.1.35.216
MinerStd Adding TestNode #7 from pod tank-0008 with IP 10.1.35.217
MinerStd Adding TestNode #8 from pod tank-0009 with IP 10.1.35.218
MinerStd Adding TestNode #9 from pod tank-0010 with IP 10.1.35.219
MinerStd Adding TestNode #10 from pod tank-0011 with IP 10.1.35.220
MinerStd User supplied random seed 131260415370612
MinerStd PRNG seed is: 131260415370612
MinerStd Starting miners.
MinerStd generated 1 block(s) from node 0. New chain height: 189
MinerStd generated 1 block(s) from node 1. New chain height: 190
MinerStd generated 1 block(s) from node 2. New chain height: 191
MinerStd generated 1 block(s) from node 3. New chain height: 192
^CInterrupted streaming log!
Deleting pod...
pod "commander-minerstd-1726684605" deleted

```