### PR TITLE
Add docker app image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 .git
+.github
 
 **/__pycache__
 .trunk
 .venv
+.envrc
 build
 dist
 **/*.egg-info

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,0 +1,91 @@
+name: Publish Warnet app bundle image
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+env:
+  REGISTRY_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/warnet-app
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          file: resources/images/warnet-bundle/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/resources/images/warnet-bundle/Dockerfile
+++ b/resources/images/warnet-bundle/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-alpine
+
+# Install uv and ktop by copying from their docker images
+COPY --from=ghcr.io/astral-sh/uv:0.4.12 /uv /bin/uv
+COPY --from=ghcr.io/vladimirvivien/ktop:latest /ko-app/ktop /bin/ktop
+
+RUN apk add --no-cache bash curl ca-certificates git kubectl helm k9s fish vim mc nano
+
+# Setup venv and install warnet
+ADD . /warnet
+WORKDIR /warnet
+RUN uv sync
+
+# Setup autocomplete
+RUN mkdir -p /root/.config/fish/completions
+RUN cat <<EOF > /root/.config/fish/completions/warnet.fish
+_WARNET_COMPLETE=fish_source warnet | source
+EOF
+
+# Start
+CMD ["/usr/bin/fish", "-c", "source /warnet/.venv/bin/activate.fish; cd /root; exec fish"]


### PR DESCRIPTION
Ok I _think_ this is better than a flatpak (more cross-platform).

Builds a docker image with:

- `warnet`
- `k9s`
- `kubectl`
- `ktop`

...installed.

I set `fish` as the default shell, as that gets you pretty tab-autocompletion.

All that's needed is to configure `~/.kube/config` inside the machine (does `warnet auth` do this?), and you're good to go.

Current CI is set to build PR branches and pushes to master (tagged as `latest`), but we can change that if desired.

I will add a test command for it after the image has built in the first run here.