### PR TITLE
charts: split off defaultConfig from [node] config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         test:
           - conf_test.py
           - dag_connection_test.py
+          - graph_test.py
           - logging_test.py
           - rpc_test.py
           - services_test.py
@@ -87,24 +88,3 @@ jobs:
           name: kubernetes-logs-${{ matrix.test }}
           path: ./k8s-logs
           retention-days: 5
-  test-without-mk:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test:
-          - graph_test.py
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v2
-        with:
-          version: "latest"
-          enable-cache: true
-      - name: Install Python
-        run: uv python install $PYTHON_VERSION
-      - name: Install project
-        run: uv sync --all-extras --dev
-      - name: Run tests
-        run: |
-          source .venv/bin/activate
-          ./test/${{matrix.test}}

--- a/resources/charts/bitcoincore/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
     rpcport={{ index .Values .Values.chain "RPCPort" }}
     zmqpubrawblock=tcp://0.0.0.0:{{ .Values.ZMQBlockPort }}
     zmqpubrawtx=tcp://0.0.0.0:{{ .Values.ZMQTxPort }}
+    {{- .Values.defaultConfig | nindent 4 }}
     {{- .Values.config | nindent 4 }}
     {{- range .Values.connect }}
       {{- print "connect=" . | nindent 4}}

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -133,6 +133,8 @@ baseConfig: |
 
 config: ""
 
+defaultConfig: ""
+
 connect: []
 loadSnapshot:
   enabled: false

--- a/resources/networks/6_node_bitcoin/network.yaml
+++ b/resources/networks/6_node_bitcoin/network.yaml
@@ -1,11 +1,13 @@
 nodes:
   - name: tank-0001
+    config: uacomment=tank0001
     image:
       tag: "26.0"
     connect:
       - tank-0002
       - tank-0003
   - name: tank-0002
+    config: uacomment=tank0002
     resources:
       limits:
         cpu: 100m
@@ -17,14 +19,17 @@ nodes:
       - tank-0003
       - tank-0004
   - name: tank-0003
+    config: uacomment=tank0003
     connect:
       - tank-0004
       - tank-0005
   - name: tank-0004
+    config: uacomment=tank0004
     connect:
       - tank-0005
       - tank-0006
   - name: tank-0005
+    config: uacomment=tank0005
     connect:
       - tank-0006
   - name: tank-0006

--- a/resources/networks/6_node_bitcoin/node-defaults.yaml
+++ b/resources/networks/6_node_bitcoin/node-defaults.yaml
@@ -21,6 +21,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "27.0"
 
-config: |
+defaultConfig: |
   dns=1
   debug=rpc

--- a/resources/networks/fork_observer/node-defaults.yaml
+++ b/resources/networks/fork_observer/node-defaults.yaml
@@ -21,7 +21,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "27.0"
 
-config: |
+defaultConfig: |
   dns=1
   debug=rpc
   rpcauth=forkobserver:1418183465eecbd407010cf60811c6a0$d4e5f0647a63429c218da1302d7f19fe627302aeb0a71a74de55346a25d8057c

--- a/src/warnet/bitcoin.py
+++ b/src/warnet/bitcoin.py
@@ -1,14 +1,14 @@
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime
 from io import BytesIO
 
 import click
-from urllib3.exceptions import MaxRetryError
-
 from test_framework.messages import ser_uint256
 from test_framework.p2p import MESSAGEMAP
+from urllib3.exceptions import MaxRetryError
 
 from .k8s import get_default_namespace, get_mission
 from .process import run_command
@@ -187,7 +187,6 @@ def get_messages(tank_a: str, tank_b: str, chain: str):
                 file_path = f"{base_dir}/{dir_name}/{file}"
                 # Fetch the file contents from the container
                 cmd = f"kubectl exec {tank_a} -- cat {file_path}"
-                import subprocess
 
                 blob = subprocess.run(
                     cmd, shell=True, capture_output=True, executable="bash"

--- a/test/data/signet/node-defaults.yaml
+++ b/test/data/signet/node-defaults.yaml
@@ -8,7 +8,7 @@ chain: signet
 spec:
   restartPolicy: Always
 
-config: |
+defaultConfig: |
   debug=rpc
   debug=net
   signetchallenge=0014d33b6e11ca95c4edccd8e986434358d79e919730

--- a/test/graph_test.py
+++ b/test/graph_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
+import json
 import os
-import shutil
 
 import pexpect
 from test_base import TestBase
@@ -15,34 +15,65 @@ class GraphTest(TestBase):
 
     def run_test(self):
         try:
+            # cwd out of the git repo for remainder of script
+            os.chdir(self.tmpdir)
             self.directory_not_exist()
             os.mkdir(NETWORKS_DIR)
             self.directory_exists()
-
+            self.run_created_network()
         finally:
-            shutil.rmtree(NETWORKS_DIR) if os.path.exists(NETWORKS_DIR) else None
+            self.cleanup()
 
     def directory_not_exist(self):
-        self.sut = pexpect.spawn("warnet create")
-        self.sut.expect("init", timeout=50)
+        try:
+            self.log.info("testing warnet create, dir doesn't exist")
+            self.sut = pexpect.spawn("warnet create")
+            self.sut.expect("init", timeout=10)
+        except Exception as e:
+            print(f"\nReceived prompt text:\n  {self.sut.before.decode('utf-8')}\n")
+            raise e
 
     def directory_exists(self):
-        self.sut = pexpect.spawn("warnet create")
-        self.sut.expect("name", timeout=10)
-        self.sut.sendline("ANewNetwork")
-        self.sut.expect("many", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect("connections", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect("version", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect("enable fork-observer", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect("seconds", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect("enable grafana", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect("successfully", timeout=50)
+        try:
+            self.log.info("testing warnet create, dir does exist")
+            self.sut = pexpect.spawn("warnet create")
+            self.sut.expect("name", timeout=10)
+            self.sut.sendline("ANewNetwork")
+            self.sut.expect("many", timeout=10)
+            self.sut.sendline("")
+            self.sut.expect("connections", timeout=10)
+            self.sut.sendline("")
+            self.sut.expect("version", timeout=10)
+            self.sut.sendline("")
+            self.sut.expect("enable fork-observer", timeout=10)
+            self.sut.sendline("")
+            self.sut.expect("seconds", timeout=10)
+            self.sut.sendline("")
+            self.sut.expect("enable grafana", timeout=10)
+            self.sut.sendline("")
+            self.sut.expect("successfully", timeout=50)
+        except Exception as e:
+            print(f"\nReceived prompt text:\n  {self.sut.before.decode('utf-8')}\n")
+            raise e
+
+    def run_created_network(self):
+        self.log.info("adding custom config to one tank")
+        with open("networks/ANewNetwork/network.yaml") as f:
+            s = f.read()
+        s = s.replace("  name: tank-0000\n", "  name: tank-0000\n  config: debug=mempool\n")
+        with open("networks/ANewNetwork/network.yaml", "w") as f:
+            f.write(s)
+
+        self.log.info("deploying new network")
+        self.warnet("deploy networks/ANewNetwork")
+        self.wait_for_all_tanks_status(target="running")
+        debugs = json.loads(self.warnet("bitcoin rpc tank-0000 logging"))
+        # set in defaultConfig
+        assert debugs["rpc"]
+        # set in config just for this tank
+        assert debugs["mempool"]
+        # santy check
+        assert not debugs["zmq"]
 
 
 if __name__ == "__main__":

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -39,6 +39,7 @@ class TestBase:
         logging.config.dictConfig(logging_config)
         self.log = logging.getLogger("test")
         self.log.info("Logging started")
+        self.log.info(f"Testdir: {self.tmpdir}")
 
     def cleanup(self, signum=None, frame=None):
         try:


### PR DESCRIPTION
The `config` value could be set in both `node-defaults.yaml` and in `network.yaml` with the latter clobbering the default. This adds a second value `defaultConfig` which is concatenated with `config` so tanks can run bitcoin.conf settings from a combination of:

`baseConfig` set in values.yaml (all nodes in every warnet)
`defaultConfig` set in node-defaults.yaml (all nodes in your network)
`config` set in network.yaml (per-node individual settings)
