### PR TITLE
tool: pin ruff version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: eifinger/setup-uv@v1
-      - run: uvx ruff check .
+      - name: Install a specific version of uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.4.4"
+          enable-cache: true
+      - run: uvx ruff@0.6.8 check .
 
   ruff-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v2
+      - name: Install a specific version of uv
+        uses: astral-sh/setup-uv@v3
         with:
-          version: "latest"
+          version: "0.4.4"
           enable-cache: true
-      - run: uvx ruff format . --check
+      - run: uvx ruff@0.6.8 format . --check
 
   test:
     needs: [ruff, ruff-format]

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -21,15 +21,27 @@ pip install --upgrade pip
 pip install -e .
 ```
 
-## Lint
+## Formatting & linting
 
 This project primarily uses the `uv` python packaging tool: https://docs.astral.sh/uv/ along with the sister formatter/linter `ruff` https://docs.astral.sh/ruff/
+
+Refer to the `uv` documentation for installation methods: https://docs.astral.sh/uv/getting-started/installation/
 
 With `uv` installed you can add/remove dependencies using `uv add <dep>` or `uv remove <dep>.
 This will update the [`uv.lock`](https://docs.astral.sh/uv/guides/projects/#uvlock) file automatically.
 
+We use ruff version 0.6.8 in this project currently. This can be installed as a stand-alone binary (see documentation), or via `uv` using:
 
-`uv` can also run tools (like `ruff`) without external installation, simply run `uvx ruff check .` or `uvx ruff format .` to use a uv-managed format/lint on the project.
+```bash
+# install
+$ uv tool install ruff@0.6.8
+
+# lint
+$ uvx ruff@0.6.8 check .
+
+# format
+$ uvx ruff@0.6.8 format .
+```
 
 ## Release process
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,4 @@
+required-version = "==0.6.8"
 extend-exclude = [
     "resources/scenarios/test_framework",
     "resources/images/exporter/authproxy.py",


### PR DESCRIPTION
Hopefully this will fix the ruff inconsistencies between local and CI envs.

Install the correct version using uv:

```bash
# install
$ uv tool install ruff@0.6.8

# use
$ uvx ruff@0.6.8 check .
```

If this is the only version you have installed then it may be possible to still use the shorthand, if the version comes back correct:

```bash
$ uvx ruff --version
ruff 0.6.8

$ uvx ruff check.
```