### PR TITLE
scenarios: miner_std should accept single --tank option

### DIFF
--- a/resources/scenarios/miner_std.py
+++ b/resources/scenarios/miner_std.py
@@ -41,15 +41,21 @@ class MinerStd(Commander):
             action="store_true",
             help="When true, generate 101 blocks ONCE per miner",
         )
+        parser.add_argument(
+            "--tank",
+            dest="tank",
+            type=str,
+            help="Select one tank by name as the only miner",
+        )
 
     def run_test(self):
         self.log.info("Starting miners.")
-
-        max_miners = 1
-        if self.options.allnodes:
-            max_miners = len(self.nodes)
-        for index in range(max_miners):
-            self.miners.append(Miner(self.nodes[index], self.options.mature))
+        if self.options.tank:
+            self.miners = [Miner(self.tanks[self.options.tank], self.options.mature)]
+        else:
+            max_miners = len(self.nodes) if self.options.allnodes else 1
+            for index in range(max_miners):
+                self.miners.append(Miner(self.nodes[index], self.options.mature))
 
         while True:
             for miner in self.miners:

--- a/src/warnet/bitcoin.py
+++ b/src/warnet/bitcoin.py
@@ -5,10 +5,9 @@ from datetime import datetime
 from io import BytesIO
 
 import click
-from urllib3.exceptions import MaxRetryError
-
 from test_framework.messages import ser_uint256
 from test_framework.p2p import MESSAGEMAP
+from urllib3.exceptions import MaxRetryError
 
 from .k8s import get_default_namespace, get_mission
 from .process import run_command

--- a/test/conf_test.py
+++ b/test/conf_test.py
@@ -7,18 +7,22 @@ from pathlib import Path
 
 from test_base import TestBase
 
+from warnet.control import stop_scenario
 from warnet.k8s import get_mission
+from warnet.status import _get_deployed_scenarios as scenarios_deployed
 
 
 class ConfTest(TestBase):
     def __init__(self):
         super().__init__()
         self.network_dir = Path(os.path.dirname(__file__)) / "data" / "bitcoin_conf"
+        self.scen_dir = Path(os.path.dirname(__file__)).parent / "resources" / "scenarios"
 
     def run_test(self):
         try:
             self.setup_network()
             self.check_uacomment()
+            self.check_single_miner()
         finally:
             self.cleanup()
 
@@ -51,6 +55,22 @@ class ConfTest(TestBase):
             return True
 
         self.wait_for_predicate(get_uacomment)
+
+    def check_single_miner(self):
+        scenario_file = self.scen_dir / "miner_std.py"
+        self.log.info(f"Running scenario from: {scenario_file}")
+        # Mine from a tank that is not first or last and
+        # is one of the only few in the network that even
+        # has rpc reatewallet method!
+        self.warnet(f"run {scenario_file} --tank=tank-0026 --interval=1")
+        self.wait_for_predicate(
+            lambda: int(self.warnet("bitcoin rpc tank-0026 getblockcount")) >= 10
+        )
+        running = scenarios_deployed()
+        assert len(running) == 1, f"Expected one running scenario, got {len(running)}"
+        assert running[0]["status"] == "running", "Scenario should be running"
+        stop_scenario(running[0]["name"])
+        self.wait_for_all_scenarios()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently miner_std either tries to mine from ALL nodes or only the 0th node in the network. Since it also naively calls rpc `createwallet` and some older node versions do not support that command, the scenario fails. I think we can also modify the scenario to be more flexible with older versions but it also makes sense to be able to just pick a single mining node. The signet miner scenario already has this option.