### PR TITLE
chart: set rpcpassword as a value, add to labels for scenarios

### DIFF
--- a/resources/charts/bitcoincore/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
     {{ template "bitcoincore.check_semver" . }}
     {{- .Values.baseConfig | nindent 4 }}
     rpcport={{ index .Values .Values.chain "RPCPort" }}
+    rpcpassword={{ .Values.rpcpassword }}
     zmqpubrawblock=tcp://0.0.0.0:{{ .Values.ZMQBlockPort }}
     zmqpubrawtx=tcp://0.0.0.0:{{ .Values.ZMQTxPort }}
     {{- .Values.defaultConfig | nindent 4 }}

--- a/resources/charts/bitcoincore/templates/pod.yaml
+++ b/resources/charts/bitcoincore/templates/pod.yaml
@@ -90,7 +90,7 @@ spec:
         - name: BITCOIN_RPC_USER
           value: user
         - name: BITCOIN_RPC_PASSWORD
-          value: password
+          value: {{ .Values.rpcpassword }}
         {{- if .Values.metrics }}
         - name: METRICS
           value: {{ .Values.metrics }}

--- a/resources/charts/bitcoincore/templates/pod.yaml
+++ b/resources/charts/bitcoincore/templates/pod.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- end }}
     chain: {{ .Values.chain }}
     RPCPort: "{{ index .Values .Values.chain "RPCPort" }}"
+    rpcpassword: {{ .Values.rpcpassword }}
     app: {{ include "bitcoincore.fullname" . }}
     {{- if .Values.collectLogs }}
     collect_logs: "true"

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -124,12 +124,13 @@ baseConfig: |
   fallbackfee=0.00001000
   listen=1
   rpcuser=user
-  rpcpassword=password
+  # rpcpassword MUST be set as a chart value
   rpcallowip=0.0.0.0/0
   rpcbind=0.0.0.0
   rest=1
   # rpcport and zmq endpoints are configured by chain in configmap.yaml
 
+rpcpassword: gn0cchi
 
 config: ""
 

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -205,7 +205,7 @@ def run(scenario_file: str, debug: bool, source_dir, additional_args: tuple[str]
             "rpc_host": tank.status.pod_ip,
             "rpc_port": int(tank.metadata.labels["RPCPort"]),
             "rpc_user": "user",
-            "rpc_password": "password",
+            "rpc_password": tank.metadata.labels["rpcpassword"],
             "init_peers": [],
         }
         for tank in tankpods


### PR DESCRIPTION
The configmap helm logic then adds the chart value to bitcoin.conf and to the pod metadata labels, same mechanism we currently use for rpcport. This allows chart-writers to override rpcpassword on an individual per-tank basis. When deploying a scenario, the metadata with the password is read from the metadata labels and written to warnet.json in the commander pod. Assuming namespaces limit users ability to read pod metadata, this should restrict rpc access to users in multiplayer mode. 

I also changed the default password in the base chart values so if anything was hard coded we should see tests fail.

UPDATE: that was so smart of me, "password" was hard coded in the prometheus exporter