### PR TITLE
users: check for ~/.kube and create if needed

### DIFF
--- a/src/warnet/users.py
+++ b/src/warnet/users.py
@@ -22,6 +22,9 @@ def auth(auth_config):
 
     is_first_config = False
     if not os.path.exists(KUBECONFIG):
+        kube_folder = os.path.join(os.path.expanduser("~"), ".kube")
+        if not os.path.exists(kube_folder):
+            os.makedirs(kube_folder)
         try:
             write_kubeconfig(auth_config, KUBECONFIG)
             is_first_config = True

--- a/src/warnet/users.py
+++ b/src/warnet/users.py
@@ -22,9 +22,7 @@ def auth(auth_config):
 
     is_first_config = False
     if not os.path.exists(KUBECONFIG):
-        kube_folder = os.path.join(os.path.expanduser("~"), ".kube")
-        if not os.path.exists(kube_folder):
-            os.makedirs(kube_folder)
+        os.makedirs(os.path.dirname(KUBECONFIG), exist_ok=True)
         try:
             write_kubeconfig(auth_config, KUBECONFIG)
             is_first_config = True


### PR DESCRIPTION
Within the `auth` function, check for and create (if needed) a folder appropriate to the KUBECONFIG path.

Addresses #642 