### PR TITLE
speedy startup

### DIFF
--- a/src/warnet/constants.py
+++ b/src/warnet/constants.py
@@ -96,6 +96,12 @@ LOGGING_CONFIG = {
     },
 }
 
+LOGGING_CRD_COMMANDS = [
+    "helm repo add prometheus-community https://prometheus-community.github.io/helm-charts",
+    "helm repo update",
+    "helm upgrade --install prometheus-operator-crds prometheus-community/prometheus-operator-crds",
+]
+
 # Helm commands for logging setup
 # TODO: also lots of hardcode stuff in these helm commands, will need to fix this when moving to helm charts
 LOGGING_HELM_COMMANDS = [

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -6,6 +6,7 @@ import sys
 import time
 import zipapp
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from multiprocessing import Pool
 from pathlib import Path
 from typing import Optional
 
@@ -112,10 +113,18 @@ def stop_scenario(scenario_name):
 
 
 def stop_all_scenarios(scenarios):
-    """Stop all active scenarios using Helm"""
-    with console.status("[bold yellow]Stopping all scenarios...[/bold yellow]"):
-        for scenario in scenarios:
-            stop_scenario(scenario)
+    """Stop all active scenarios in parallel using multiprocessing"""
+
+    def stop_single(scenario):
+        stop_scenario(scenario)
+        return f"Stopped scenario: {scenario}"
+
+    with console.status("[bold yellow]Stopping all scenarios...[/bold yellow]"), Pool() as pool:
+        results = pool.map(stop_single, scenarios)
+
+    for result in results:
+        console.print(f"[bold green]{result}[/bold green]")
+
     console.print("[bold green]All scenarios have been stopped.[/bold green]")
 
 

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -144,7 +144,7 @@ def deploy_caddy(directory: Path, debug: bool):
     if not network_file.get(name, {}).get("enabled", False):
         return
 
-    cmd = f"{HELM_COMMAND} {name} {CADDY_CHART} --namespace {namespace}"
+    cmd = f"{HELM_COMMAND} {name} {CADDY_CHART} --namespace {namespace} --create-namespace"
     if debug:
         cmd += " --debug"
 


### PR DESCRIPTION
Deploy everything everywhere, all at once (except fork observer).

- no more waiting for logging to install before we even start the next thing
- could probably speed up very large networks by multiprocessing individual tank deployment

Fork observer uses k8s api (via `get_mission()`) to create its config, so it has to wait until at least that deploy is finished.