### PR TITLE
Add better namespace logic to `warnet logs`

### DIFF
--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -402,6 +402,13 @@ def _logs(pod_name: str, follow: bool, namespace: Optional[str] = None):
         else:
             return  # cancelled by user
 
+        try:
+            pod = get_pod(pod_name, namespace=namespace)
+        except Exception as e:
+            click.secho(e)
+            click.secho(f"Could not get pod: {pod_name}: {namespace}")
+            return
+
     try:
         pod = get_pod(pod_name, namespace=namespace)
         eligible_container_names = [BITCOINCORE_CONTAINER, COMMANDER_CONTAINER]

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -430,6 +430,7 @@ def _logs(pod_name: str, follow: bool, namespace: Optional[str] = None):
 
             if not namespaces:
                 click.echo(f"Could not find pod in any namespaces: {pod_name}")
+                return
 
             namespace = namespaces[0]
 

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -367,8 +367,6 @@ def logs(pod_name: str, follow: bool, namespace: str):
 
 
 def _logs(pod_name: str, follow: bool, namespace: Optional[str] = None):
-    namespace = get_default_namespace_or(namespace)
-
     def format_pods(pods: list[V1Pod]) -> list[str]:
         sorted_pods = sorted(pods, key=lambda pod: pod.metadata.creation_timestamp, reverse=True)
         return [f"{pod.metadata.name}: {pod.metadata.namespace}" for pod in sorted_pods]
@@ -382,11 +380,11 @@ def _logs(pod_name: str, follow: bool, namespace: Optional[str] = None):
             pod_list.extend(formatted_tanks)
 
         except Exception as e:
-            print(f"Could not fetch any pods in namespace ({namespace}): {e}")
+            click.secho(f"Could not fetch any pods: {e}")
             return
 
         if not pod_list:
-            print(f"Could not fetch any pods in namespace ({namespace})")
+            click.secho("Could not fetch any pods.")
             return
 
         q = [

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -360,7 +360,7 @@ def run(
 @click.command()
 @click.argument("pod_name", type=str, default="")
 @click.option("--follow", "-f", is_flag=True, default=False, help="Follow logs")
-@click.option("--namespace", type=str, default="default", show_default=True)
+@click.option("--namespace", type=str, default="", show_default=True)
 def logs(pod_name: str, follow: bool, namespace: str):
     """Show the logs of a pod"""
     return _logs(pod_name, follow, namespace)

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -367,15 +367,17 @@ def logs(pod_name: str, follow: bool, namespace: str):
 
 
 def _logs(pod_name: str, follow: bool, namespace: Optional[str] = None):
-    def format_pods(pods: list[V1Pod]) -> list[str]:
+    def format_pods(pods: list[V1Pod], namespace: Optional[str]) -> list[str]:
+        if namespace:
+            pods = [pod for pod in pods if pod.metadata.namespace == namespace]
         sorted_pods = sorted(pods, key=lambda pod: pod.metadata.creation_timestamp, reverse=True)
         return [f"{pod.metadata.name}: {pod.metadata.namespace}" for pod in sorted_pods]
 
     if pod_name == "":
         try:
             pod_list = []
-            formatted_commanders = format_pods(get_mission(COMMANDER_MISSION))
-            formatted_tanks = format_pods(get_mission(TANK_MISSION))
+            formatted_commanders = format_pods(get_mission(COMMANDER_MISSION), namespace)
+            formatted_tanks = format_pods(get_mission(TANK_MISSION), namespace)
             pod_list.extend(formatted_commanders)
             pod_list.extend(formatted_tanks)
 

--- a/test/namespace_admin_test.py
+++ b/test/namespace_admin_test.py
@@ -42,6 +42,8 @@ class NamespaceAdminTest(ScenariosTest, TestBase):
         self.blue_users = ["carol-warnettest", "default", "mallory-warnettest"]
         self.red_users = ["alice-warnettest", self.bob_user, "default"]
 
+        self.bitcoin_version_slug = "Bitcoin Core version v27.0.0"
+
     def run_test(self):
         try:
             os.chdir(self.tmpdir)
@@ -182,60 +184,66 @@ class NamespaceAdminTest(ScenariosTest, TestBase):
     def bob_checks_logs(self):
         assert self.this_is_the_current_context(self.bob_context)
         self.log.info("Bob will check the logs")
-        bitcoin_version_slug = "Bitcoin Core version v27.0.0"
-        self.sut = pexpect.spawn("warnet logs", maxread=4096 * 10)
-        self.sut.expect("Please choose a pod", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect(bitcoin_version_slug, timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn(f"warnet logs --namespace {self.red_namespace}", maxread=4096 * 10)
-        self.sut.expect("Please choose a pod", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect(bitcoin_version_slug, timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn("warnet logs tank-0008", maxread=4096 * 10)
-        self.sut.expect(bitcoin_version_slug, timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn(
+
+        sut = pexpect.spawn("warnet logs", maxread=4096 * 10)
+        assert expect_without_traceback("Please choose a pod", sut)
+        sut.sendline("")
+        assert expect_without_traceback(self.bitcoin_version_slug, sut)
+        sut.close()
+
+        sut = pexpect.spawn(f"warnet logs --namespace {self.red_namespace}", maxread=4096 * 10)
+        assert expect_without_traceback("Please choose a pod", sut)
+        sut.sendline("")
+        assert expect_without_traceback(self.bitcoin_version_slug, sut)
+        sut.close()
+
+        sut = pexpect.spawn("warnet logs tank-0008", maxread=4096 * 10)
+        assert expect_without_traceback(self.bitcoin_version_slug, sut)
+        sut.close()
+
+        sut = pexpect.spawn(
             f"warnet logs tank-0008 --namespace {self.red_namespace}", maxread=4096 * 10
         )
-        self.sut.expect(bitcoin_version_slug, timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn("warnet logs this_does_not_exist", maxread=4096 * 10)
-        assert expect_without_traceback(
-            "Could not find pod in any namespaces", self.sut, timeout=10
-        )
-        self.sut.close()
+        assert expect_without_traceback(self.bitcoin_version_slug, sut)
+        sut.close()
+
+        sut = pexpect.spawn("warnet logs this_does_not_exist", maxread=4096 * 10)
+        assert expect_without_traceback("Could not find pod in any namespaces", sut)
+        sut.close()
+
         self.log.info("Bob has checked the logs")
         assert self.this_is_the_current_context(self.bob_context)
 
     def admin_checks_logs(self):
         assert self.this_is_the_current_context(self.initial_context)
         self.log.info("The admin will check the logs")
-        bitcoin_version_slug = "Bitcoin Core version v27.0.0"
-        self.sut = pexpect.spawn("warnet logs", maxread=4096 * 10)
-        self.sut.expect("Please choose a pod", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect(bitcoin_version_slug, timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn(f"warnet logs --namespace {self.red_namespace}", maxread=4096 * 10)
-        self.sut.expect("Please choose a pod", timeout=10)
-        self.sut.sendline("")
-        self.sut.expect(bitcoin_version_slug, timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn("warnet logs tank-0008", maxread=4096 * 10)
-        self.sut.expect("The pod 'tank-0008' is found in these namespaces", timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn(
+
+        sut = pexpect.spawn("warnet logs", maxread=4096 * 10)
+        assert expect_without_traceback("Please choose a pod", sut)
+        sut.sendline("")
+        assert expect_without_traceback(self.bitcoin_version_slug, sut)
+        sut.close()
+
+        sut = pexpect.spawn(f"warnet logs --namespace {self.red_namespace}", maxread=4096 * 10)
+        assert expect_without_traceback("Please choose a pod", sut)
+        sut.sendline("")
+        assert expect_without_traceback(self.bitcoin_version_slug, sut)
+        sut.close()
+
+        sut = pexpect.spawn("warnet logs tank-0008", maxread=4096 * 10)
+        assert expect_without_traceback("The pod 'tank-0008' is found in these namespaces", sut)
+        sut.close()
+
+        sut = pexpect.spawn(
             f"warnet logs tank-0008 --namespace {self.red_namespace}", maxread=4096 * 10
         )
-        self.sut.expect(bitcoin_version_slug, timeout=10)
-        self.sut.close()
-        self.sut = pexpect.spawn("warnet logs this_does_not_exist", maxread=4096 * 10)
-        assert expect_without_traceback(
-            "Could not find pod in any namespaces", self.sut, timeout=10
-        )
-        self.sut.close()
+        assert expect_without_traceback(self.bitcoin_version_slug, sut)
+        sut.close()
+
+        sut = pexpect.spawn("warnet logs this_does_not_exist", maxread=4096 * 10)
+        assert expect_without_traceback("Could not find pod in any namespaces", sut)
+        sut.close()
+
         self.log.info("The admin has checked the logs")
         assert self.this_is_the_current_context(self.initial_context)
 
@@ -260,17 +268,17 @@ class StackTraceFoundException(Exception):
     pass
 
 
-def expect_without_traceback(expectation: str, sut: pexpect.spawn, timeout: int = 10) -> bool:
+def expect_without_traceback(expectation: str, sut: pexpect.spawn, timeout: int = 2) -> bool:
     expectation_found = False
     while True:
         try:
-            sut.expect("\n", timeout=timeout)
+            sut.expect(["\r", "\n"], timeout=timeout)  # inquirer uses \r
             line = sut.before.decode("utf-8")
             if "Traceback (" in line:
                 raise StackTraceFoundException
             if expectation in line:
                 expectation_found = True
-        except pexpect.exceptions.EOF:
+        except (pexpect.exceptions.EOF, pexpect.exceptions.TIMEOUT):
             break
     return expectation_found
 


### PR DESCRIPTION
This addresses #657. It includes a test, and commentary is in each commit.