### PR TITLE
update signet test

### DIFF
--- a/test/data/signet/network.yaml
+++ b/test/data/signet/network.yaml
@@ -50,3 +50,33 @@ nodes:
       tag: "0.16.1"
     addnode:
       - miner
+  - name: tank-11
+    image:
+      tag: "98.0.0-invalid-blocks"
+    addnode:
+      - miner
+  - name: tank-12
+    image:
+      tag: "94.0.0-5k-inv"
+    addnode:
+      - miner
+  - name: tank-13
+    image:
+      tag: "95.0.0-disabled-opcodes"
+    addnode:
+      - miner
+  - name: tank-14
+    image:
+      tag: "96.0.0-no-mp-trim"
+    addnode:
+      - miner
+  - name: tank-15
+    image:
+      tag: "97.0.0-50-orphans"
+    addnode:
+      - miner
+  - name: tank-16
+    image:
+      tag: "99.0.0-unknown-message"
+    addnode:
+      - miner

--- a/test/data/signet/node-defaults.yaml
+++ b/test/data/signet/node-defaults.yaml
@@ -1,12 +1,12 @@
 image:
   repository: bitcoindevproject/bitcoin
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: "27.0"
 
 chain: signet
 
 spec:
-  restartPolicy: Always
+  restartPolicy: Never
 
 defaultConfig: |
   debug=rpc

--- a/test/signet_test.py
+++ b/test/signet_test.py
@@ -37,13 +37,13 @@ class SignetTest(TestBase):
             f"bitcoin rpc miner importdescriptors '{json.dumps(self.signer_data['descriptors'])}'"
         )
         self.warnet(
-            f"run resources/scenarios/signet_miner.py --tank=0 generate --min-nbits --address={self.signer_data['address']['address']}"
+            f"run resources/scenarios/signet_miner.py --tank=0 generate --max-blocks=8 --min-nbits --address={self.signer_data['address']['address']}"
         )
 
         def block_one():
-            for n in range(1, 11):
+            for n in range(1, 17):
                 height = int(self.warnet(f"bitcoin rpc tank-{n} getblockcount"))
-                if height != 1:
+                if height < 8:
                     return False
             return True
 


### PR DESCRIPTION
Testing all images on signet for 8 blocks. Test failed on my machine because of the architecture issue with 0.16.1 (logs below) I'll test a few more times locally and also run on a digital ocean cluster

```
2024-10-22 13:38:51.007720 Bitcoin Core version v0.16.1.0-dc94c00-dirty (release build)
2024-10-22 13:38:51.018917 InitParameterInteraction: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1
2024-10-22 13:38:51.027499 Validating signatures for all blocks.
2024-10-22 13:38:51.028121 Setting nMinimumChainWork=0000000000000000000000000000000000000000000000000000000000000000
2024-10-22 13:38:51.092334 Using the 'standard' SHA256 implementation
2024-10-22 13:38:52.569413 Default data directory /root/.bitcoin
2024-10-22 13:38:52.570217 Using data directory /root/.bitcoin/signet
2024-10-22 13:38:52.570954 Using config file /root/.bitcoin/bitcoin.conf
2024-10-22 13:38:52.598360 Using at most 125 automatic connections (1048576 file descriptors available)
2024-10-22 13:38:53.421931 Using 16 MiB out of 32/2 requested for signature cache, able to store 524288 elements
2024-10-22 13:38:53.813165 Using 16 MiB out of 32/2 requested for script execution cache, able to store 524288 elements
2024-10-22 13:38:53.823779 Using 8 threads for script verification
2024-10-22 13:38:54.163354 scheduler thread start
2024-10-22 13:38:54.791683 HTTP: creating work queue of depth 16
2024-10-22 13:38:54.792876 Starting RPC
2024-10-22 13:38:54.877216 Starting HTTP RPC server
2024-10-22 13:38:54.878032 Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.
2024-10-22 13:38:54.973718 HTTP: starting 4 worker threads
2024-10-22 13:38:55.102724 Using wallet directory /root/.bitcoin/signet/wallets
2024-10-22 13:38:55.104638 init message: Verifying wallet(s)...
2024-10-22 13:38:55.108794 Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2024-10-22 13:38:55.112857 Using wallet wallet.dat
2024-10-22 13:38:55.179994 CDBEnv::Open: LogDir=/root/.bitcoin/signet/wallets/database ErrorFile=/root/.bitcoin/signet/wallets/db.log
2024-10-22 13:38:57.793187 net: setting try another outbound peer=false
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```