### PR TITLE
log correct number of outbound connections

### DIFF
--- a/docs/logging_monitoring.md
+++ b/docs/logging_monitoring.md
@@ -96,7 +96,7 @@ For example, the default metrics listed above would be explicitly configured as 
 nodes:
   - name: tank-0000
     metricsExport: true
-    metrics: blocks=getblockcount() inbounds=getnetworkinfo()["connections_in"] outbounds=getnetworkinfo()["connections_in"] mempool_size=getmempoolinfo()["size"]
+    metrics: blocks=getblockcount() inbounds=getnetworkinfo()["connections_in"] outbounds=getnetworkinfo()["connections_out"] mempool_size=getmempoolinfo()["size"]
 ```
 
 The data can be retrieved directly from the Prometheus exporter container in the tank pod via port `9332`, example:
@@ -108,7 +108,7 @@ blocks 704.0
 # HELP inbounds getnetworkinfo()["connections_in"]
 # TYPE inbounds gauge
 inbounds 0.0
-# HELP outbounds getnetworkinfo()["connections_in"]
+# HELP outbounds getnetworkinfo()["connections_out"]
 # TYPE outbounds gauge
 outbounds 0.0
 # HELP mempool_size getmempoolinfo()["size"]

--- a/resources/images/exporter/bitcoin-exporter.py
+++ b/resources/images/exporter/bitcoin-exporter.py
@@ -28,7 +28,7 @@ METRICS_PORT = int(os.environ.get("METRICS_PORT", "9332"))
 # label=method(params)[return object key][...]
 METRICS = os.environ.get(
     "METRICS",
-    'blocks=getblockcount() inbounds=getnetworkinfo()["connections_in"] outbounds=getnetworkinfo()["connections_in"] mempool_size=getmempoolinfo()["size"]',
+    'blocks=getblockcount() inbounds=getnetworkinfo()["connections_in"] outbounds=getnetworkinfo()["connections_out"] mempool_size=getmempoolinfo()["size"]',
 )
 
 # Set up bitcoind RPC client


### PR DESCRIPTION
Currently, `connections_in` is used for both inbound and outbound peers. The PR corrects this by using `connections_out` for outbound peers.