### PR TITLE
scenarios: add --admin flag to `run` command for ClusterRole access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
           - simln_test.py
           - scenarios_test.py
           - namespace_admin_test.py
+          - wargames_test.py
     steps:
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v4.2.0

--- a/resources/charts/commander/templates/rbac.yaml
+++ b/resources/charts/commander/templates/rbac.yaml
@@ -33,3 +33,33 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "commander.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.admin }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "commander.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "commander.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "commander.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "commander.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end}}

--- a/resources/charts/commander/values.yaml
+++ b/resources/charts/commander/values.yaml
@@ -66,3 +66,5 @@ volumeMounts: []
 port:
 
 args: ""
+
+admin: false

--- a/resources/scenarios/test_scenarios/generate_one_allnodes.py
+++ b/resources/scenarios/test_scenarios/generate_one_allnodes.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# The base class exists inside the commander container
+try:
+    from commander import Commander
+except Exception:
+    from resources.scenarios.commander import Commander
+
+
+class GenOneAllNodes(Commander):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def add_options(self, parser):
+        parser.description = (
+            "Attempt to generate one block on every node the scenario has access to"
+        )
+        parser.usage = "warnet run /path/to/generate_one_allnodes.py"
+
+    def run_test(self):
+        for node in self.nodes:
+            wallet = self.ensure_miner(node)
+            addr = wallet.getnewaddress("bech32")
+            self.log.info(f"node: {node.tank}")
+            self.log.info(self.generatetoaddress(node, 1, addr))
+
+
+def main():
+    GenOneAllNodes().main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -240,19 +240,21 @@ def get_active_network(namespace):
     "--source_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True), required=False
 )
 @click.argument("additional_args", nargs=-1, type=click.UNPROCESSED)
+@click.option("--admin", is_flag=True, default=False, show_default=False)
 @click.option("--namespace", default=None, show_default=True)
 def run(
     scenario_file: str,
     debug: bool,
     source_dir,
     additional_args: tuple[str],
+    admin: bool,
     namespace: Optional[str],
 ):
     """
     Run a scenario from a file.
     Pass `-- --help` to get individual scenario help
     """
-    return _run(scenario_file, debug, source_dir, additional_args, namespace)
+    return _run(scenario_file, debug, source_dir, additional_args, admin, namespace)
 
 
 def _run(
@@ -260,6 +262,7 @@ def _run(
     debug: bool,
     source_dir,
     additional_args: tuple[str],
+    admin: bool,
     namespace: Optional[str],
 ) -> str:
     namespace = get_default_namespace_or(namespace)
@@ -329,6 +332,8 @@ def _run(
         ]
 
         # Add additional arguments
+        if admin:
+            helm_command.extend(["--set", "admin=true"])
         if additional_args:
             helm_command.extend(["--set", f"args={' '.join(additional_args)}"])
 

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -352,6 +352,7 @@ def _run(
     except subprocess.CalledProcessError as e:
         print(f"Failed to deploy scenario commander: {scenario_name}")
         print(f"Error: {e.stderr}")
+        return None
 
     # upload scenario files and network data to the init container
     wait_for_init(name, namespace=namespace)

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -385,6 +385,7 @@ def deploy_network(directory: Path, debug: bool = False, namespace: Optional[str
             debug=False,
             source_dir=SCENARIOS_DIR,
             additional_args=None,
+            admin=False,
             namespace=namespace,
         )
         wait_for_pod(name, namespace=namespace)

--- a/test/data/wargames/namespaces/armies/namespace-defaults.yaml
+++ b/test/data/wargames/namespaces/armies/namespace-defaults.yaml
@@ -1,0 +1,5 @@
+users:
+  - name: warnet-user
+    roles:
+      - pod-viewer
+      - pod-manager

--- a/test/data/wargames/namespaces/armies/namespaces.yaml
+++ b/test/data/wargames/namespaces/armies/namespaces.yaml
@@ -1,0 +1,2 @@
+namespaces:
+- name: wargames-red

--- a/test/data/wargames/networks/armada/network.yaml
+++ b/test/data/wargames/networks/armada/network.yaml
@@ -1,0 +1,6 @@
+nodes:
+- name: armada
+  image:
+    tag: '27.0'
+  addnode:
+    - miner.default

--- a/test/data/wargames/networks/armada/node-defaults.yaml
+++ b/test/data/wargames/networks/armada/node-defaults.yaml
@@ -1,0 +1,6 @@
+global:
+  chain: regtest
+image:
+  repository: bitcoindevproject/bitcoin
+  pullPolicy: IfNotPresent
+  tag: '27.0'

--- a/test/data/wargames/networks/battlefield/network.yaml
+++ b/test/data/wargames/networks/battlefield/network.yaml
@@ -1,0 +1,10 @@
+nodes:
+- name: miner
+  image:
+    tag: '27.0'
+- name: target-red
+  addnode:
+    - miner
+  image:
+    tag: '27.0'
+    

--- a/test/data/wargames/networks/battlefield/node-defaults.yaml
+++ b/test/data/wargames/networks/battlefield/node-defaults.yaml
@@ -1,0 +1,6 @@
+global:
+  chain: regtest
+image:
+  repository: bitcoindevproject/bitcoin
+  pullPolicy: IfNotPresent
+  tag: '27.0'

--- a/test/wargames_test.py
+++ b/test/wargames_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+
+import pexpect
+from test_base import TestBase
+
+from warnet.k8s import get_kubeconfig_value
+from warnet.process import stream_command
+
+
+class WargamesTest(TestBase):
+    def __init__(self):
+        super().__init__()
+        self.wargame_dir = Path(os.path.dirname(__file__)) / "data" / "wargames"
+        self.scen_src_dir = Path(os.path.dirname(__file__)).parent / "resources" / "scenarios"
+        self.scen_test_dir = (
+            Path(os.path.dirname(__file__)).parent / "resources" / "scenarios" / "test_scenarios"
+        )
+        self.initial_context = get_kubeconfig_value("{.current-context}")
+
+    def run_test(self):
+        try:
+            self.setup_battlefield()
+            self.setup_armies()
+            self.check_scenario_permissions()
+        finally:
+            self.log.info("Restoring initial_context")
+            stream_command(f"kubectl config use-context {self.initial_context}")
+            self.cleanup()
+
+    def setup_battlefield(self):
+        self.log.info("Setting up battlefield")
+        self.log.info(self.warnet(f"deploy {self.wargame_dir / 'networks' / 'battlefield'}"))
+        self.wait_for_all_tanks_status(target="running")
+        self.wait_for_all_edges()
+
+    def setup_armies(self):
+        self.log.info("Deploying namespaces and armadas")
+        self.log.info(self.warnet(f"deploy {self.wargame_dir / 'namespaces' / 'armies'}"))
+        self.log.info(
+            self.warnet(f"deploy {self.wargame_dir / 'networks' / 'armada'} --to-all-users")
+        )
+        self.wait_for_all_tanks_status(target="running")
+        self.wait_for_all_edges()
+
+    def check_scenario_permissions(self):
+        self.log.info("Admin without --admin can not command a node outside of default namespace")
+        stream_command(
+            f"warnet run {self.scen_test_dir / 'generate_one_allnodes.py'} --source_dir={self.scen_src_dir} --debug"
+        )
+        # Only miner.default and target-red.default were accesible
+        assert self.warnet("bitcoin rpc miner getblockcount") == "2"
+
+        self.log.info("Admin with --admin can command all nodes in any namespace")
+        stream_command(
+            f"warnet run {self.scen_test_dir / 'generate_one_allnodes.py'} --source_dir={self.scen_src_dir} --admin --debug"
+        )
+        # armada.wargames-red, miner.default and target-red.default were accesible
+        assert self.warnet("bitcoin rpc miner getblockcount") == "5"
+
+        self.log.info("Switch to wargames player context")
+        self.log.info(self.warnet("admin create-kubeconfigs"))
+        clicker = pexpect.spawn("warnet auth kubeconfigs/warnet-user-wargames-red-kubeconfig")
+        while clicker.expect(["Overwrite", "Updated kubeconfig"]) == 0:
+            print(clicker.before, clicker.after)
+            clicker.sendline("y")
+        print(clicker.before, clicker.after)
+
+        self.log.info("Player without --admin can only command the node inside their own namespace")
+        stream_command(
+            f"warnet run {self.scen_test_dir / 'generate_one_allnodes.py'} --source_dir={self.scen_src_dir} --debug"
+        )
+        # Only armada.wargames-red was (and is) accesible
+        assert self.warnet("bitcoin rpc armada getblockcount") == "6"
+
+        self.log.info("Player attempting to use --admin is gonna have a bad time")
+        stream_command(
+            f"warnet run {self.scen_test_dir / 'generate_one_allnodes.py'} --source_dir={self.scen_src_dir} --admin --debug"
+        )
+        # Nothing was accesible
+        assert self.warnet("bitcoin rpc armada getblockcount") == "6"
+
+        self.log.info("Restore admin context")
+        stream_command(f"kubectl config use-context {self.initial_context}")
+        # Sanity check
+        assert self.warnet("bitcoin rpc miner getblockcount") == "6"
+
+
+if __name__ == "__main__":
+    test = WargamesTest()
+    test.run_test()


### PR DESCRIPTION
Closes https://github.com/bitcoin-dev-project/warnet/issues/680

Usage:

If you are the admin of a wargames battle you can, for example, run the faucet scenario as an admin. this gives your commander pod a `ClusterRole` which enables it to access all pods and all namespaces, which is necessary to get receive addresses from all armada nodes.

```
warnet run --source_dir=scenarios/ scenarios/admin/faucet.py --debug --admin
```

If an admin runs this scenario WITHOUT the admin flag, they won't get an error from kubernetes but the scenario will fail to collect receive addresses from armada tanks, and thus will try to split up the goods among ZERO recipients:

```
Traceback (most recent call last):
  File "/shared/archive.pyz/test_framework/test_framework.py", line 131, in main
    self.run_test()
  File "/shared/archive.pyz/admin/faucet.py", line 59, in run_test
    bal_amt = bal_sats // len(self.addrs)
              ~~~~~~~~~^^~~~~~~~~~~~~~~~~
ZeroDivisionError: integer division or modulo by zero
```


If a wargames user with a namespace-restricted user account tries to run a scenario with `--admin` they will get an error:

```

Failed to deploy scenario commander: faucet
Error: Error: Unable to continue with install: could not get information about the resource ClusterRole "commander-faucet-1739390548" in namespace "": clusterroles.rbac.authorization.k8s.io
"commander-faucet-1739390548" is forbidden: User "system:serviceaccount:wargames-rust:warnet-user" cannot get resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope

```

This should not affect wargames users running their own scenarios normally.

# TODO

- [x] add tests for the behavior described above
- [x] If this gets merged then `commander.py` MUST MUST MUST be copied over to https://github.com/bitcoin-dev-project/battle-of-galen-erso/blob/main/scenarios/commander.py