### PR TITLE
let python3 run `plugin.py` instead of bash

### DIFF
--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -166,7 +166,7 @@ def run_plugins(directory, hook_value: HookValue, namespace, annex: Optional[dic
                 }
 
                 cmd = (
-                    f"{network_file_path.parent / entrypoint_path / Path('plugin.py')} entrypoint "
+                    f"python3 {network_file_path.parent / entrypoint_path / Path('plugin.py')} entrypoint "
                     f"'{json.dumps(plugin_content)}' '{json.dumps(warnet_content)}'"
                 )
                 print(

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -166,7 +166,7 @@ def run_plugins(directory, hook_value: HookValue, namespace, annex: Optional[dic
                 }
 
                 cmd = (
-                    f"python3 {network_file_path.parent / entrypoint_path / Path('plugin.py')} entrypoint "
+                    f"{sys.executable} {network_file_path.parent / entrypoint_path / Path('plugin.py')} entrypoint "
                     f"'{json.dumps(plugin_content)}' '{json.dumps(warnet_content)}'"
                 )
                 print(


### PR DESCRIPTION
`plugin.py` should just be ingested by python instead doing what we do today which is chmod-ing `plugin.py` and calling it via bash.

Also, when deciding between using `python` and  `python3`, I did some research and `python3` is allegedly the sure-fire way to call python on both linux and macos.

Addresses #678 