### PR TITLE
Add sample lnd dashboard to grafana

### DIFF
--- a/resources/charts/grafana-dashboards/files/sample_lnd_dashboard.json
+++ b/resources/charts/grafana-dashboards/files/sample_lnd_dashboard.json
@@ -1,0 +1,91 @@
+{
+  "title": "Sample Warnet Dashboard (LND)",
+  "refresh": "5s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2094"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2094"
+          },
+          "editorMode": "code",
+          "expr": "lnd_balance_channels",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Channel Balance",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2094"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2094"
+          },
+          "editorMode": "code",
+          "expr": "lnd_peers",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Peers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2094"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2094"
+          },
+          "editorMode": "code",
+          "expr": "lnd_block_height",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LND Blocks",
+      "type": "timeseries"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `Sample Warnet Dashboard (LND)` to grafana, similar to `Default Warnet Dashboard`

This PR depends on #691 

Result from tested grafana deployment of this PR:
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/ea83bca7-d2c7-4067-84a6-26ce69ceffcc" />
