### PR TITLE
Update install.md with a link to the scaling tips

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -110,3 +110,6 @@ warnet init
 # Or in a directory of choice
 warnet new <directory>
 ```
+
+> [!TIP]
+> If you are having stability issues it could be due to resource constraints. Check out these tips for [scaling](scaling.md).


### PR DESCRIPTION
This PR is an update to the `install.md` guide that adds a link to `scaling.md`. I followed the install guide but ran into problems with resource constraints while running a scrimmage. It turns out `scaling.md` had exactly what I needed to fix my issue but I may never have found it if pinheadmz didn't point it out in https://github.com/bitcoin-dev-project/battle-of-galen-erso/issues/9. I think it would be helpful to others if a link to it was included in here.

