### PR TITLE
ci: bump actions, and ruff version. Use action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,26 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.4"
+          version: "0.6.11"
           enable-cache: true
-      - run: uvx ruff@0.6.8 check .
-
-  ruff-format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v3
+      - name: Lint
+        uses: astral-sh/ruff-action@v3
         with:
-          version: "0.4.4"
-          enable-cache: true
-      - run: uvx ruff@0.6.8 format . --check
+          args: "check --fix"
+      - name: Format
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check --diff"
 
   test:
-    needs: [ruff, ruff-format]
+    needs: [ruff]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -65,12 +61,14 @@ jobs:
       - name: Start minikube's loadbalancer tunnel
         run: minikube tunnel &> /dev/null &
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
           enable-cache: true
-      - name: Install Python
-        run: uv python install $PYTHON_VERSION
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
       - name: Install project
         run: uv sync --all-extras --dev
       - name: Run tests

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -30,17 +30,17 @@ Refer to the `uv` documentation for installation methods: https://docs.astral.sh
 With `uv` installed you can add/remove dependencies using `uv add <dep>` or `uv remove <dep>.
 This will update the [`uv.lock`](https://docs.astral.sh/uv/guides/projects/#uvlock) file automatically.
 
-We use ruff version 0.6.8 in this project currently. This can be installed as a stand-alone binary (see documentation), or via `uv` using:
+We use ruff version 0.11.0 in this project currently. This can be installed as a stand-alone binary (see documentation), or via `uv` using:
 
 ```bash
 # install
-$ uv tool install ruff@0.6.8
+$ uv tool install ruff@0.11.0
 
 # lint
-$ uvx ruff@0.6.8 check .
+$ uvx ruff@0.11.0 check .
 
 # format
-$ uvx ruff@0.6.8 format .
+$ uvx ruff@0.11.0 format .
 ```
 
 ## Release process

--- a/resources/plugins/hello/plugin.py
+++ b/resources/plugins/hello/plugin.py
@@ -72,15 +72,15 @@ def entrypoint(ctx, plugin_content: str, warnet_content: str):
 
     hook_value = warnet_content.get(WarnetContent.HOOK_VALUE.value)
 
-    assert hook_value in {
-        item.value for item in HookValue
-    }, f"{hook_value} is not a valid HookValue"
+    assert hook_value in {item.value for item in HookValue}, (
+        f"{hook_value} is not a valid HookValue"
+    )
 
     if warnet_content.get(PLUGIN_ANNEX):
         for annex_member in [annex_item for annex_item in warnet_content.get(PLUGIN_ANNEX)]:
-            assert annex_member in {
-                item.value for item in AnnexMember
-            }, f"{annex_member} is not a valid AnnexMember"
+            assert annex_member in {item.value for item in AnnexMember}, (
+                f"{annex_member} is not a valid AnnexMember"
+            )
 
     warnet_content[WarnetContent.HOOK_VALUE.value] = HookValue(hook_value)
 

--- a/resources/plugins/simln/plugin.py
+++ b/resources/plugins/simln/plugin.py
@@ -63,15 +63,15 @@ def entrypoint(ctx, plugin_content: str, warnet_content: str):
 
     hook_value = warnet_content.get(WarnetContent.HOOK_VALUE.value)
 
-    assert hook_value in {
-        item.value for item in HookValue
-    }, f"{hook_value} is not a valid HookValue"
+    assert hook_value in {item.value for item in HookValue}, (
+        f"{hook_value} is not a valid HookValue"
+    )
 
     if warnet_content.get(PLUGIN_ANNEX):
         for annex_member in [annex_item for annex_item in warnet_content.get(PLUGIN_ANNEX)]:
-            assert annex_member in {
-                item.value for item in AnnexMember
-            }, f"{annex_member} is not a valid AnnexMember"
+            assert annex_member in {item.value for item in AnnexMember}, (
+                f"{annex_member} is not a valid AnnexMember"
+            )
 
     warnet_content[WarnetContent.HOOK_VALUE.value] = HookValue(hook_value)
 

--- a/resources/scenarios/commander.py
+++ b/resources/scenarios/commander.py
@@ -11,10 +11,10 @@ import sys
 import tempfile
 import threading
 from time import sleep
-from typing import Dict
 
 from kubernetes import client, config
 from ln_framework.ln import LND
+
 from test_framework.authproxy import AuthServiceProxy
 from test_framework.p2p import NetworkThread
 from test_framework.test_framework import (
@@ -160,8 +160,8 @@ class Commander(BitcoinTestFramework):
         self.log.addHandler(ch)
 
         # Keep a separate index of tanks by pod name
-        self.tanks: Dict[str, TestNode] = {}
-        self.lns: Dict[str, LND] = {}
+        self.tanks: dict[str, TestNode] = {}
+        self.lns: dict[str, LND] = {}
         self.channels = WARNET["channels"]
 
         for i, tank in enumerate(WARNET["tanks"]):

--- a/resources/scenarios/ln_init.py
+++ b/resources/scenarios/ln_init.py
@@ -261,9 +261,9 @@ class LNInit(Commander):
             block_height = block["height"]
             for ch in channels:
                 assert ch["id"]["block"] == block_height, f"Actual block:{block_height}\n{ch}"
-                assert (
-                    block_txs[ch["id"]["index"]] == ch["txid"]
-                ), f"Actual txid:{block_txs[ch["id"]["index"]]}\n{ch}"
+                assert block_txs[ch["id"]["index"]] == ch["txid"], (
+                    f"Actual txid:{block_txs[ch['id']['index']]}\n{ch}"
+                )
             self.log.info("👍")
 
         gen(5)
@@ -294,9 +294,9 @@ class LNInit(Commander):
         def update_policy(self, ln, txid_hex, policy, capacity):
             self.log.info(f"Sending update from {ln.name} for channel with outpoint: {txid_hex}:0")
             res = ln.update(txid_hex, policy, capacity)
-            assert (
-                len(res["failed_updates"]) == 0
-            ), f" Failed updates: {res["failed_updates"]}\n txid: {txid_hex}\n policy:{policy}"
+            assert len(res["failed_updates"]) == 0, (
+                f" Failed updates: {res['failed_updates']}\n txid: {txid_hex}\n policy:{policy}"
+            )
 
         update_threads = []
         for ch in self.channels:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-required-version = "==0.6.8"
+required-version = ">=0.11"
 extend-exclude = [
     "resources/scenarios/test_framework",
     "resources/images/exporter/authproxy.py",

--- a/src/warnet/bitcoin.py
+++ b/src/warnet/bitcoin.py
@@ -6,9 +6,10 @@ from io import BytesIO
 from typing import Optional
 
 import click
+from urllib3.exceptions import MaxRetryError
+
 from test_framework.messages import ser_uint256
 from test_framework.p2p import MESSAGEMAP
-from urllib3.exceptions import MaxRetryError
 
 from .constants import BITCOINCORE_CONTAINER
 from .k8s import get_default_namespace_or, get_mission, pod_log

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -60,9 +60,9 @@ class TestBase:
             self.log_msg_assertions_passed = True
 
     def assert_log_msgs(self):
-        assert (
-            self.log_msg_assertions_passed
-        ), f"Log assertion failed. Expected message not found: {self.log_expected_msgs}"
+        assert self.log_msg_assertions_passed, (
+            f"Log assertion failed. Expected message not found: {self.log_expected_msgs}"
+        )
         self.log_msg_assertions_passed = False
 
     def warnet(self, cmd):


### PR DESCRIPTION
Ruff was locked to an old version, it's annoying.

- Bump this to current version, 0.11.0
- Update the CI to use the [ruff-action](https://github.com/astral-sh/ruff-action)
- Fix all outstanding lint/formatting issues

edit:

- Update developer docs with new version