### PR TITLE
Add eclair support #2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           - graph_test.py
           - logging_test.py
           - ln_basic_test.py
+          - ln_mixed_test.py
           - ln_test.py
           - onion_test.py
           - plugin_test.py

--- a/docs/circuit-breaker.md
+++ b/docs/circuit-breaker.md
@@ -20,9 +20,8 @@ nodes:
   - name: tank-0003
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       config: |
         bitcoin.timelockdelta=33
       channels:
@@ -51,27 +50,26 @@ nodes:
   - name: tank-0000
     addnode:
       - tank-0001
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0001
     addnode:
       - tank-0002
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0002
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0003
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       config: |
         bitcoin.timelockdelta=33
       channels:
@@ -88,9 +86,8 @@ nodes:
   - name: tank-0004
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       channels:
         - id:
             block: 300
@@ -102,8 +99,8 @@ nodes:
   - name: tank-0005
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 ```
 
 ## Accessing Circuit Breaker

--- a/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
@@ -41,12 +41,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          lightningd --conf=/root/.lightning/config &
-          sleep 1
-          lightning-cli createrune > /working/rune.json
-          echo "Here is the rune file contents"
-          cat /working/rune.json
-          wait
+          lightningd --conf=/root/.lightning/config
       livenessProbe:
         {{- toYaml .Values.livenessProbe | nindent 8 }}
       readinessProbe:

--- a/resources/charts/bitcoincore/charts/cln/values.yaml
+++ b/resources/charts/bitcoincore/charts/cln/values.yaml
@@ -57,10 +57,10 @@ livenessProbe:
       - "-c"
       - "lightning-cli getinfo >/dev/null 2>&1"
   failureThreshold: 3
-  initialDelaySeconds: 5
+  initialDelaySeconds: 10
   periodSeconds: 5
   successThreshold: 1
-  timeoutSeconds: 1
+  timeoutSeconds: 5
 readinessProbe:
   failureThreshold: 10
   periodSeconds: 30
@@ -71,6 +71,20 @@ readinessProbe:
       - "/bin/sh"
       - "-c"
       - "lightning-cli getinfo 2>/dev/null | grep -q 'id' || exit 1"
+startupProbe:
+  failureThreshold: 10
+  periodSeconds: 30
+  successThreshold: 1
+  timeoutSeconds: 60
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - |
+        while [ ! -s /working/rune.json ]; do
+          lightning-cli createrune > /working/rune.json 2>/dev/null
+          sleep 2
+        done
 
 # Additional volumes on the output Deployment definition.
 volumes:

--- a/resources/charts/bitcoincore/charts/eclair/.helmignore
+++ b/resources/charts/bitcoincore/charts/eclair/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/resources/charts/bitcoincore/charts/eclair/Chart.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/Chart.yaml
@@ -1,17 +1,6 @@
 apiVersion: v2
-name: bitcoincore
-description: A Helm chart for Bitcoin Core
-
-dependencies:
-  - name: lnd
-    version: 0.1.0
-    condition: lnd.enabled
-  - name: cln
-    version: 0.1.0
-    condition: cln.enabled
-  - name: eclair
-    version: 0.1.0
-    condition: eclair.enabled
+name: eclair
+description: A Helm chart for Eclair
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -32,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0
+appVersion: "0.1.0"

--- a/resources/charts/bitcoincore/charts/eclair/templates/_helpers.tpl
+++ b/resources/charts/bitcoincore/charts/eclair/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/*
+Expand the name of the PARENT chart.
+*/}}
+{{- define "bitcoincore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified PARENT app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bitcoincore.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eclair.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}-ln
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eclair.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" }}-ln
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eclair.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "eclair.labels" -}}
+helm.sh/chart: {{ include "eclair.chart" . }}
+{{ include "eclair.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "eclair.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "eclair.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "eclair.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "eclair.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/resources/charts/bitcoincore/charts/eclair/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/templates/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "eclair.fullname" . }}
+  labels:
+    {{- include "eclair.labels" . | nindent 4 }}
+data:
+  eclair.conf: |
+    {{- .Values.baseConfig | nindent 4 }}
+    {{- .Values.defaultConfig | nindent 4 }}
+    {{- .Values.config | nindent 4 }}
+    eclair.chain = {{ .Values.global.chain }}
+    eclair.bitcoind.host = {{ include "bitcoincore.fullname" . }}
+    eclair.bitcoind.rpcport = {{ index .Values.global .Values.global.chain "RPCPort" }}
+    eclair.bitcoind.rpcuser = user
+    eclair.bitcoind.rpcpassword = {{ .Values.global.rpcpassword }}
+    eclair.node-alias = {{ include "eclair.fullname" . }}
+    eclair.bitcoind.zmqblock = "tcp://{{ include "bitcoincore.fullname" . }}:{{ .Values.global.ZMQBlockPort }}"
+    eclair.bitcoind.zmqtx = "tcp://{{ include "bitcoincore.fullname" . }}:{{ .Values.global.ZMQTxPort }}"
+    eclair.bitcoind.startup-locked-utxos-behavior = "unlock"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "eclair.fullname" . }}-channels
+  labels:
+    channels: "true"
+    {{- include "eclair.labels" . | nindent 4 }}
+data:
+  source: {{ include "eclair.fullname" . }}
+  channels: |
+    {{ .Values.channels | toJson }}

--- a/resources/charts/bitcoincore/charts/eclair/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/templates/pod.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "eclair.fullname" . }}
+  labels:
+    {{- include "eclair.labels" . | nindent 4 }}
+    {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app: {{ include "eclair.fullname" . }}
+    {{- if .Values.collectLogs }}
+    collect_logs: "true"
+    {{- end }}
+    chain: {{ .Values.global.chain }}
+  annotations:
+    kubectl.kubernetes.io/default-container: "eclair"
+spec:
+  {{- with .Values.imagePullSecrets }}
+  restartPolicy: "{{ .Values.restartPolicy }}"
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
+  containers:
+    - name: {{ .Chart.Name }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 12 }}
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command:
+        - "sh"
+        - "-c"
+      args:
+        - >
+          /app/eclair-node/bin/eclair-node.sh -v &
+          while [ ! -f /root/.eclair/eclair.log ]; do
+            echo "Waiting for log file"
+            sleep 2
+          done &&
+          tail -f /root/.eclair/eclair.log
+      ports:
+        - name: server
+          containerPort: {{ .Values.ServerPort }}
+          protocol: TCP
+        - name: rest
+          containerPort: {{ .Values.RestPort }}
+          protocol: TCP
+      livenessProbe:
+        {{- toYaml .Values.livenessProbe | nindent 8 }}
+      readinessProbe:
+        {{- toYaml .Values.readinessProbe | nindent 8 }}
+      startupProbe:
+        {{- toYaml .Values.startupProbe | nindent 8 }}
+      resources:
+        {{- toYaml .Values.resources | nindent 12 }}
+      volumeMounts:
+        {{- with .Values.volumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    {{- with .Values.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  volumes:
+    {{- with .Values.volumes }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    - configMap:
+        name: {{ include "eclair.fullname" . }}
+      name: config
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}

--- a/resources/charts/bitcoincore/charts/eclair/templates/service.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "eclair.fullname" . }}
+  labels:
+    {{- include "eclair.labels" . | nindent 4 }}
+    app: {{ include "eclair.fullname" . }} 
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.ServerPort }}
+      targetPort: server
+      protocol: TCP
+      name: server
+    - port: {{ .Values.RestPort }}
+      targetPort: rest
+      protocol: TCP
+      name: rest
+  selector:
+    {{- include "eclair.selectorLabels" . | nindent 4 }}

--- a/resources/charts/bitcoincore/charts/eclair/values.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/values.yaml
@@ -103,7 +103,7 @@ baseConfig: |
   eclair.api.port = 8080
   eclair.features.keysend = optional
   eclair.bitcoind.startup-locked-utxos-behavior = "unlock"
- 
+
 config: ""
 
 defaultConfig: ""

--- a/resources/charts/bitcoincore/charts/eclair/values.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/values.yaml
@@ -6,9 +6,9 @@ namespace: warnet
 restartPolicy: Never
 
 image:
-  repository: bitdonkey/eclair
+  repository: polarlightning/eclair
   pullPolicy: IfNotPresent
-  tag: "0.11.0"
+  tag: "0.12.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/resources/charts/bitcoincore/charts/eclair/values.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/values.yaml
@@ -53,28 +53,27 @@ resources: {}
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  exec:
-    command:
-      - eclair-cli 
-      - -p 
-      - 21satoshi 
-      - getinfo
+  tcpSocket:
+    port: 8080
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 5
   successThreshold: 1
-  timeoutSeconds: 5
+  timeoutSeconds: 10
 readinessProbe:
   failureThreshold: 3
   periodSeconds: 5
   successThreshold: 1
   timeoutSeconds: 10
-  exec:
-    command:
-      - eclair-cli 
-      - -p 
-      - 21satoshi 
-      - getinfo
+  tcpSocket:
+    port: 8080
+startupProbe:
+  failureThreshold: 3
+  periodSeconds: 15
+  successThreshold: 1
+  timeoutSeconds: 15
+  tcpSocket:
+    port: 8080
 
 # Additional volumes on the output Deployment definition.
 volumes:

--- a/resources/charts/bitcoincore/charts/eclair/values.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/values.yaml
@@ -1,0 +1,111 @@
+# Default values for eclair.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+namespace: warnet
+
+restartPolicy: Never
+
+image:
+  repository: bitdonkey/eclair
+  pullPolicy: IfNotPresent
+  tag: "0.11.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podLabels: 
+  app: "warnet"
+  mission: "lightning"
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+
+ServerPort: 9735
+RestPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  exec:
+    command:
+      - eclair-cli 
+      - -p 
+      - 21satoshi 
+      - getinfo
+  failureThreshold: 3
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  failureThreshold: 3
+  periodSeconds: 5
+  successThreshold: 1
+  timeoutSeconds: 10
+  exec:
+    command:
+      - eclair-cli 
+      - -p 
+      - 21satoshi 
+      - getinfo
+
+# Additional volumes on the output Deployment definition.
+volumes:
+  - name: temp-storage
+    emptyDir: {}
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts:
+  - mountPath: /root/.eclair/eclair.conf
+    name: config
+    subPath: eclair.conf
+  - mountPath: /root/.eclair
+    name: temp-storage
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+baseConfig: |
+  eclair.server.port = 9735
+  eclair.api.enabled = true
+  eclair.api.binding-ip = 0.0.0.0
+  eclair.api.password = 21satoshi
+  eclair.api.port = 8080
+  eclair.features.keysend = optional
+  eclair.bitcoind.startup-locked-utxos-behavior = "unlock"
+ 
+config: ""
+
+defaultConfig: ""
+
+channels: []

--- a/resources/charts/bitcoincore/charts/eclair/values.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/values.yaml
@@ -102,7 +102,6 @@ baseConfig: |
   eclair.api.password = 21satoshi
   eclair.api.port = 8080
   eclair.features.keysend = optional
-  eclair.bitcoind.startup-locked-utxos-behavior = "unlock"
 
 config: ""
 

--- a/resources/charts/bitcoincore/charts/eclair/values.yaml
+++ b/resources/charts/bitcoincore/charts/eclair/values.yaml
@@ -60,10 +60,10 @@ livenessProbe:
       - 21satoshi 
       - getinfo
   failureThreshold: 3
-  initialDelaySeconds: 5
+  initialDelaySeconds: 10
   periodSeconds: 5
   successThreshold: 1
-  timeoutSeconds: 1
+  timeoutSeconds: 5
 readinessProbe:
   failureThreshold: 3
   periodSeconds: 5

--- a/resources/charts/bitcoincore/templates/_helpers.tpl
+++ b/resources/charts/bitcoincore/templates/_helpers.tpl
@@ -56,7 +56,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-
 {{/*
 Add network section heading in bitcoin.conf
 Always add for custom semver, check version for valid semver
@@ -66,5 +65,16 @@ Always add for custom semver, check version for valid semver
 {{- $newer := semverCompare ">=0.17.0" .Values.image.tag -}}
 {{- if or $newer $custom -}}
 [{{ .Values.global.chain }}]
+{{- end -}}
+{{- end -}}
+
+{{/*
+eclair requires zmqpubhashblock https://github.com/ACINQ/eclair/blob/master/README.md#installation
+*/}}
+{{- define "bitcoincore.set_zmqblocktype" -}}
+{{- if .Values.eclair.enabled -}}
+zmqpubhashblock
+{{- else }}
+zmqpubrawblock
 {{- end -}}
 {{- end -}}

--- a/resources/charts/bitcoincore/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
     {{- .Values.baseConfig | nindent 4 }}
     rpcport={{ index .Values.global .Values.global.chain "RPCPort" }}
     rpcpassword={{ .Values.global.rpcpassword }}
-    zmqpubrawblock=tcp://0.0.0.0:{{ .Values.global.ZMQBlockPort }}
+    {{- include "bitcoincore.set_zmqblocktype" . | nindent 4 }}=tcp://0.0.0.0:{{ .Values.global.ZMQBlockPort }}
     zmqpubrawtx=tcp://0.0.0.0:{{ .Values.global.ZMQTxPort }}
     {{- .Values.defaultConfig | nindent 4 }}
     {{- .Values.config | nindent 4 }}

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -129,7 +129,6 @@ baseConfig: |
   rpcallowip=0.0.0.0/0
   rpcbind=0.0.0.0
   rest=1
-  dnsseed=0 # needed for eclair stability
   # rpcport and zmq endpoints are configured by chain in configmap.yaml
 
 config: ""

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -123,6 +123,7 @@ baseConfig: |
   capturemessages=1
   fallbackfee=0.00001000
   listen=1
+  txindex=1
   rpcuser=user
   # rpcpassword MUST be set as a chart value
   rpcallowip=0.0.0.0/0
@@ -140,6 +141,10 @@ loadSnapshot:
   enabled: false
   url: ""
 
-ln:
-  lnd: false
-  cln: false
+cln:
+  enabled: false
+eclair:
+  enabled: false
+lnd:
+  enabled: false
+

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -129,6 +129,7 @@ baseConfig: |
   rpcallowip=0.0.0.0/0
   rpcbind=0.0.0.0
   rest=1
+  dnsseed=0 # needed for eclair stability
   # rpcport and zmq endpoints are configured by chain in configmap.yaml
 
 config: ""

--- a/resources/plugins/simln/README.md
+++ b/resources/plugins/simln/README.md
@@ -48,27 +48,26 @@ nodes:
   - name: tank-0000
     addnode:
       - tank-0001
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0001
     addnode:
       - tank-0002
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0002
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    eclair:
+      enabled: true
 
   - name: tank-0003
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       config: |
         bitcoin.timelockdelta=33
       channels:
@@ -82,9 +81,8 @@ nodes:
   - name: tank-0004
     addnode:
       - tank-0000
-    ln:
-      cln: true
     cln:
+      enabled: true
       channels:
         - id:
             block: 300
@@ -96,8 +94,8 @@ nodes:
   - name: tank-0005
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
 plugins:
   postDeploy:

--- a/resources/plugins/simln/charts/simln/values.yaml
+++ b/resources/plugins/simln/charts/simln/values.yaml
@@ -1,7 +1,7 @@
 name: "simln"
 image:
   repository: "bitcoindevproject/simln"
-  tag: "0.2.3"
+  tag: "0.2.4"
   pullPolicy: IfNotPresent
 
 workingVolume:

--- a/resources/plugins/simln/plugin.py
+++ b/resources/plugins/simln/plugin.py
@@ -163,20 +163,22 @@ def _launch_activity(activity: Optional[list[dict]], plugin_dir: str) -> str:
 
 def _generate_activity_json(activity: Optional[list[dict]]) -> str:
     nodes = []
-
     for i in get_mission(LIGHTNING_MISSION):
         ln_name = i.metadata.name
-        port = 10009
         node = {"id": ln_name}
         if "cln" in i.metadata.labels["app.kubernetes.io/name"]:
-            port = 9736
+            node["address"] = f"https://{ln_name}:9736"
             node["ca_cert"] = f"/working/{ln_name}-ca.pem"
             node["client_cert"] = f"/working/{ln_name}-client.pem"
             node["client_key"] = f"/working/{ln_name}-client-key.pem"
+        elif "eclair" in i.metadata.labels["app.kubernetes.io/name"]:
+            node["base_url"] = f"http://{ln_name}:8080"
+            node["api_username"] = ""
+            node["api_password"] = "21satoshi"
         else:
+            node["address"] = f"https://{ln_name}:10009"
             node["macaroon"] = "/working/admin.macaroon"
             node["cert"] = "/working/tls.cert"
-        node["address"] = f"https://{ln_name}:{port}"
         nodes.append(node)
 
     if activity:

--- a/resources/scenarios/commander.py
+++ b/resources/scenarios/commander.py
@@ -13,7 +13,7 @@ import threading
 from time import sleep
 
 from kubernetes import client, config
-from ln_framework.ln import CLN, LND, LNNode
+from ln_framework.ln import CLN, ECLAIR, LND, LNNode
 from test_framework.authproxy import AuthServiceProxy
 from test_framework.p2p import NetworkThread
 from test_framework.test_framework import (
@@ -73,6 +73,8 @@ for pod in pods.items:
         lnnode = LND(pod.metadata.name, pod.status.pod_ip)
         if "cln" in pod.metadata.labels["app.kubernetes.io/name"]:
             lnnode = CLN(pod.metadata.name, pod.status.pod_ip)
+        elif "eclair" in pod.metadata.labels["app.kubernetes.io/name"]:
+            lnnode = ECLAIR(pod.metadata.name, pod.status.pod_ip)
         WARNET["lightning"].append(lnnode)
 
 for cm in cmaps.items:

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -599,7 +599,7 @@ class ECLAIR(LNNode):
                     }
                 else:
                     self.log.warning(f"unable to open channel: {response}, wait and retry...")
-                    sleep(1)
+                    sleep(5)
             else:
                 self.log.debug(f"channel response: {response}, wait and retry...")
                 sleep(5)

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -1,9 +1,11 @@
 import base64
+import hashlib
 import http.client
 import json
 import logging
 import re
 import ssl
+import subprocess
 import urllib.parse
 from abc import ABC, abstractmethod
 from time import sleep
@@ -82,7 +84,7 @@ class Policy:
 
 class LNNode(ABC):
     @abstractmethod
-    def __init__(self, pod_name, ip_address):
+    def __init__(self, pod_name, ip_address=None, use_rpc=False):
         self.name = pod_name
         self.ip_address = ip_address
         self.log = logging.getLogger(pod_name)
@@ -91,6 +93,7 @@ class LNNode(ABC):
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
         self.log.setLevel(logging.INFO)
+        self.use_rpc = use_rpc
 
     @staticmethod
     def hex_to_b64(hex):
@@ -103,12 +106,42 @@ class LNNode(ABC):
         else:
             return base64.b64decode(b64).hex()
 
+    def rpc_call(self, command: str, data: list[str] = None) -> str:
+        """Call warnet ln rpc via tank-name command and return stdout as string"""
+        try:
+            command_list = ["warnet", "ln", "rpc", self.name, command]
+            if data:
+                command_list.extend(data)
+            self.log.debug(f"rpc command: {command_list}")
+            result = subprocess.run(
+                command_list,
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            # Only log and return the actual error output
+            self.log.error(e.stderr.strip())
+            return None
+        except Exception as e:
+            self.log.error(f"RPC call failed: {e}")
+            return None
+
     @abstractmethod
     def newaddress(self, max_tries=10) -> tuple[bool, str]:
         pass
 
     @abstractmethod
+    def nodeid(self) -> str:
+        pass
+
+    @abstractmethod
     def uri(self) -> str:
+        pass
+
+    @abstractmethod
+    def channelbalance(self) -> int:
         pass
 
     @abstractmethod
@@ -124,6 +157,14 @@ class LNNode(ABC):
         pass
 
     @abstractmethod
+    def createinvoice(self, sats, label, description) -> str:
+        pass
+
+    @abstractmethod
+    def payinvoice(self, payment_request) -> str:
+        pass
+
+    @abstractmethod
     def graph(self) -> dict:
         pass
 
@@ -133,8 +174,8 @@ class LNNode(ABC):
 
 
 class CLN(LNNode):
-    def __init__(self, pod_name, ip_address):
-        super().__init__(pod_name, ip_address)
+    def __init__(self, pod_name, ip_address=None, use_rpc=False):
+        super().__init__(pod_name, ip_address, use_rpc=use_rpc)
         self.conn = None
         self.headers = {}
         self.impl = "cln"
@@ -219,11 +260,12 @@ class CLN(LNNode):
         raise Exception(f"Unable to fetch rune from {self.name}")
 
     def newaddress(self, max_tries=2):
-        self.createrune()
+        if not self.use_rpc:
+            self.createrune()
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/v1/newaddr")
+            response = self.rpc_call("newaddr") if self.use_rpc else self.post("/v1/newaddr")
             if not response:
                 sleep(2)
                 continue
@@ -237,8 +279,18 @@ class CLN(LNNode):
             sleep(2)
         return False, ""
 
+    def nodeid(self):
+        if self.use_rpc:
+            res = json.loads(self.rpc_call("getinfo"))
+        else:
+            res = json.loads(self.post("/v1/getinfo"))
+        return res["id"]
+
     def uri(self):
-        res = json.loads(self.post("/v1/getinfo"))
+        if self.use_rpc:
+            res = json.loads(self.rpc_call("getinfo"))
+        else:
+            res = json.loads(self.post("/v1/getinfo"))
         if len(res["address"]) < 1:
             return None
         return f"{res['id']}@{res['address'][0]['address']}:{res['address'][0]['port']}"
@@ -247,7 +299,7 @@ class CLN(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/v1/listfunds")
+            response = self.rpc_call("listfunds") if self.use_rpc else self.post("/v1/listfunds")
             if not response:
                 sleep(2)
                 continue
@@ -259,7 +311,7 @@ class CLN(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/v1/listfunds")
+            response = self.rpc_call("listfunds") if self.use_rpc else self.post("/v1/listfunds")
             if not response:
                 sleep(2)
                 continue
@@ -271,7 +323,10 @@ class CLN(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/v1/connect", {"id": target_uri})
+            if self.use_rpc:
+                response = self.rpc_call("connect", [target_uri])
+            else:
+                response = self.post("/v1/connect", {"id": target_uri})
             if response:
                 res = json.loads(response)
                 if "id" in res:
@@ -296,7 +351,10 @@ class CLN(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/v1/fundchannel", data)
+            if self.use_rpc:
+                response = self.rpc_call("fundchannel", [pk, str(capacity)])
+            else:
+                response = self.post("/v1/fundchannel", data)
             if response:
                 res = json.loads(response)
                 if "txid" in res:
@@ -309,17 +367,23 @@ class CLN(LNNode):
                 sleep(2)
         return None
 
-    def createinvoice(self, sats, label, description="new invoice") -> str:
-        response = self.post(
-            "invoice", {"amount_msat": sats * 1000, "label": label, "description": description}
-        )
+    def createinvoice(self, sats, label, description="new_invoice") -> str:
+        if self.use_rpc:
+            response = self.rpc_call("invoice", [str(sats * 1000), label, description])
+        else:
+            response = self.post(
+                "invoice", {"amount_msat": sats * 1000, "label": label, "description": description}
+            )
         if response:
             res = json.loads(response)
             return res["bolt11"]
         return None
 
     def payinvoice(self, payment_request) -> str:
-        response = self.post("/v1/pay", {"bolt11": payment_request})
+        if self.use_rpc:
+            response = self.rpc_call("pay", [payment_request])
+        else:
+            response = self.post("/v1/pay", {"bolt11": payment_request})
         if response:
             res = json.loads(response)
             if "code" in res:
@@ -332,7 +396,10 @@ class CLN(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/v1/listchannels")
+            if self.use_rpc:
+                response = self.rpc_call("listchannels")
+            else:
+                response = self.post("/v1/listchannels")
             if response:
                 res = json.loads(response)
                 if "channels" in res:
@@ -358,8 +425,8 @@ class CLN(LNNode):
 
 
 class ECLAIR(LNNode):
-    def __init__(self, pod_name, ip_address):
-        super().__init__(pod_name, ip_address)
+    def __init__(self, pod_name, ip_address=None, use_rpc=False):
+        super().__init__(pod_name, ip_address, use_rpc=use_rpc)
         self.conn = None
         self.headers = {"Authorization": "Basic OjIxc2F0b3NoaQ=="}
         self.impl = "eclair"
@@ -368,7 +435,10 @@ class ECLAIR(LNNode):
     def reset_connection(self):
         self.conn = http.client.HTTPConnection(host=self.name, port=8080, timeout=5)
 
-    def get(self, uri):
+    def get(self, uri: str):
+        if self.use_rpc:
+            cmd = uri.replace("/", "")
+            return self.rpc_call(cmd)
         attempt = 0
         while True:
             try:
@@ -387,7 +457,10 @@ class ECLAIR(LNNode):
                     return None
                 sleep(1)
 
-    def post(self, uri, data=None):
+    def post(self, uri: str, data=None):
+        if self.use_rpc:
+            cmd = uri.replace("/", "")
+            return self.rpc_call(cmd, data)
         if not data:
             data = {}
         body = urllib.parse.urlencode(data)
@@ -435,9 +508,20 @@ class ECLAIR(LNNode):
             return True, response.strip('"')
         return False, ""
 
+    def nodeid(self):
+        if self.use_rpc:
+            res = json.loads(self.rpc_call("getinfo"))
+        else:
+            res = json.loads(self.post("/v1/getinfo"))
+        return res["nodeId"]
+
     def uri(self):
-        res = json.loads(self.post("/getinfo"))
-        return f"{res['nodeId']}@{res['alias']}:9735"
+        response = self.post("/getinfo")
+        if response:
+            res = json.loads(response)
+            if "nodeId" in res:
+                return f"{res['nodeId']}@{res['alias']}:9735"
+        return None
 
     def walletbalance(self, max_tries=2) -> int:
         attempt = 0
@@ -467,8 +551,11 @@ class ECLAIR(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/connect", {"uri": target_uri})
-            if "connected" in response:
+            if self.use_rpc:
+                response = self.rpc_call("connect", [f"--nodeId={target_uri}"])
+            else:
+                response = self.post("/connect", {"uri": target_uri})
+            if response and "connected" in response:
                 return {}
             else:
                 self.log.debug(f"connect response: {response}, wait and retry...")
@@ -487,8 +574,19 @@ class ECLAIR(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/open", data)
-            print("channel open", response)
+            if self.use_rpc:
+                response = self.rpc_call(
+                    "open",
+                    [
+                        f"--nodeId={pk}",
+                        f"--fundingSatoshis={capacity}",
+                        f"--pushMsat={push_amt}",
+                        f"--fundingFeerateSatByte={fee_rate}",
+                        f"--fundingFeeBudgetSatoshis={fee_rate * NON_GROUPED_UTXO_BYTE_SIZE}",
+                    ],
+                )
+            else:
+                response = self.post("/open", data)
             if response:
                 if "created channel" in response:
                     # created channel e872f515dc5d8a3d61ccbd2127f33141eaa115807271dcc5c5c727f3eca914d3 with fundingTxId=bc2b8db55b9588d3a18bd06bd0e284f63ee8cc149c63138d51ac8ef81a72fc6f and fees=720 sat
@@ -508,18 +606,26 @@ class ECLAIR(LNNode):
         return None
 
     def createinvoice(self, sats, label, description="new invoice") -> str:
-        b64_desc = base64.b64encode(description.encode("utf-8"))
-        response = self.post(
-            "/createinvoice",
-            {"amountMsat": sats * 1000, "description": label, "descriptionHash": b64_desc},
-        )  # https://acinq.github.io/eclair/#createinvoice
+        if self.use_rpc:
+            response = self.rpc_call(
+                "createinvoice", [f"--amountMsat={sats * 1000}", f'--description="{label}"']
+            )
+        else:
+            b64_desc = base64.b64encode(description.encode("utf-8"))
+            response = self.post(
+                "/createinvoice",
+                {"amountMsat": sats * 1000, "description": label, "descriptionHash": b64_desc},
+            )  # https://acinq.github.io/eclair/#createinvoice
         if response:
             res = json.loads(response)
-            return res
+            return res["serialized"]
         return None
 
     def payinvoice(self, payment_request) -> str:
-        response = self.post("/payinvoice", {"invoice": payment_request})
+        if self.use_rpc:
+            response = self.rpc_call("payinvoice", [f"--invoice={payment_request}"])
+        else:
+            response = self.post("/payinvoice", {"invoice": payment_request})
         # https://acinq.github.io/eclair/#payinvoice
         if response:
             return response
@@ -529,7 +635,9 @@ class ECLAIR(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/allupdates")  # https://acinq.github.io/eclair/#allupdates
+            response = (
+                self.rpc_call("allupdates") if self.use_rpc else self.post("/allupdates")
+            )  # https://acinq.github.io/eclair/#allupdates
             if response:
                 res = json.loads(response)
                 if len(res) > 0:
@@ -549,8 +657,8 @@ class ECLAIR(LNNode):
 
 
 class LND(LNNode):
-    def __init__(self, pod_name, ip_address):
-        super().__init__(pod_name, ip_address)
+    def __init__(self, pod_name, ip_address=None, use_rpc=False):
+        super().__init__(pod_name, ip_address, use_rpc=use_rpc)
         self.conn = http.client.HTTPSConnection(
             host=pod_name, port=8080, timeout=5, context=INSECURE_CONTEXT
         )
@@ -565,7 +673,10 @@ class LND(LNNode):
             host=self.name, port=8080, timeout=5, context=INSECURE_CONTEXT
         )
 
-    def get(self, uri):
+    def get(self, uri: str):
+        if self.use_rpc:
+            cmd = uri.replace("/v1/", "")
+            return self.rpc_call(cmd)
         attempt = 0
         while True:
             try:
@@ -622,7 +733,10 @@ class LND(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.get("/v1/newaddress")
+            if self.use_rpc:
+                response = self.rpc_call("newaddress", ["p2wkh"])
+            else:
+                response = self.get("/v1/newaddress")
             if not response:
                 sleep(5)
                 continue
@@ -637,12 +751,23 @@ class LND(LNNode):
         return False, ""
 
     def walletbalance(self) -> int:
-        res = self.get("/v1/balance/blockchain")
-        return int(json.loads(res)["confirmed_balance"])
+        res = self.rpc_call("walletbalance") if self.use_rpc else self.get("/v1/balance/blockchain")
+        if res:
+            return int(json.loads(res)["confirmed_balance"])
+        else:
+            return 0
 
     def channelbalance(self) -> int:
-        res = self.get("/v1/balance/channels")
-        return int(json.loads(res)["balance"])
+        res = self.rpc_call("channelbalance") if self.use_rpc else self.get("/v1/balance/channels")
+        if res:
+            return int(json.loads(res)["balance"])
+        else:
+            return 0
+
+    def nodeid(self):
+        res = self.get("/v1/getinfo")
+        info = json.loads(res)
+        return info["identity_pubkey"]
 
     def uri(self):
         res = self.get("/v1/getinfo")
@@ -653,36 +778,59 @@ class LND(LNNode):
 
     def connect(self, target_uri):
         pk, host = target_uri.split("@")
-        res = self.post("/v1/peers", data={"addr": {"pubkey": pk, "host": host}})
-        return json.loads(res)
+        if self.use_rpc:
+            res = self.rpc_call("connect", [target_uri])
+        else:
+            res = self.post("/v1/peers", data={"addr": {"pubkey": pk, "host": host}})
+        if res:
+            return json.loads(res)
+        else:
+            return res
 
-    def channel(self, pk, capacity, push_amt, fee_rate, max_tries=2):
-        b64_pk = self.hex_to_b64(pk)
+    def channel(self, pk, capacity, push_amt, fee_rate, max_tries=5):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post(
-                "/v1/channels/stream",
-                data={
-                    "local_funding_amount": capacity,
-                    "push_sat": push_amt,
-                    "node_pubkey": b64_pk,
-                    "sat_per_vbyte": fee_rate,
-                },
-            )
-            try:
-                res = json.loads(response)
-                if "result" in res:
-                    res["txid"] = self.b64_to_hex(
-                        res["result"]["chan_pending"]["txid"], reverse=True
-                    )
-                    res["outpoint"] = (
-                        f"{res['txid']}:{res['result']['chan_pending']['output_index']}"
-                    )
-                    return res
-                self.log.warning(f"Open LND channel error: {res}")
-            except Exception as e:
-                self.log.error(f"Error opening LND channel: {e}")
+            if self.use_rpc:
+                response = self.rpc_call(
+                    "openchannel",
+                    [
+                        "--node_key",
+                        pk,
+                        "--local_amt",
+                        capacity,
+                        "--push_amt",
+                        push_amt,
+                        "--sat_per_vbyte",
+                        fee_rate,
+                    ],
+                )
+                if response:
+                    res = json.loads(response)
+                    return {"txid": res["funding_txid"]}
+            else:
+                response = self.post(
+                    "/v1/channels/stream",
+                    data={
+                        "local_funding_amount": capacity,
+                        "push_sat": push_amt,
+                        "node_pubkey": self.hex_to_b64(pk),
+                        "sat_per_vbyte": fee_rate,
+                    },
+                )
+                try:
+                    res = json.loads(response)
+                    if "result" in res:
+                        res["txid"] = self.b64_to_hex(
+                            res["result"]["chan_pending"]["txid"], reverse=True
+                        )
+                        res["outpoint"] = (
+                            f"{res['txid']}:{res['result']['chan_pending']['output_index']}"
+                        )
+                        return res
+                    self.log.warning(f"Open LND channel error: {res}")
+                except Exception as e:
+                    self.log.error(f"Error opening LND channel: {e}")
             sleep(2)
         return None
 
@@ -699,27 +847,44 @@ class LND(LNNode):
         return json.loads(res)
 
     def createinvoice(self, sats, label, description="new invoice") -> str:
-        b64_desc = base64.b64encode(description.encode("utf-8"))
-        response = self.post(
-            "/v1/invoices", data={"value": sats, "memo": label, "description_hash": b64_desc}
-        )
+        if self.use_rpc:
+            response = self.rpc_call(
+                "addinvoice",
+                [
+                    "--amt",
+                    str(sats),
+                    "--memo",
+                    label,
+                    "--description_hash",
+                    hashlib.sha256(description.encode("utf-8")).digest().hex(),
+                ],
+            )
+        else:
+            b64_desc = base64.b64encode(description.encode("utf-8"))
+            response = self.post(
+                "/v1/invoices", data={"value": sats, "memo": label, "description_hash": b64_desc}
+            )
         if response:
             res = json.loads(response)
             return res["payment_request"]
         return None
 
     def payinvoice(self, payment_request) -> str:
-        response = self.post(
-            "/v1/channels/transaction-stream", data={"payment_request": payment_request}
-        )
-        if response:
-            res = json.loads(response)
-            if "payment_error" in res:
-                return res["payment_error"]
-            else:
-                return res["payment_hash"]
+        if self.use_rpc:
+            response = self.rpc_call("payinvoice", ["-f", payment_request])
+            return response
+        else:
+            response = self.post(
+                "/v1/channels/transaction-stream", data={"payment_request": payment_request}
+            )
+            if response:
+                res = json.loads(response)
+                if "payment_error" in res:
+                    return res["payment_error"]
+                else:
+                    return res["payment_hash"]
         return None
 
     def graph(self):
-        res = self.get("/v1/graph")
+        res = self.get("describegraph") if self.use_rpc else self.get("/v1/graph")
         return json.loads(res)

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -245,7 +245,7 @@ class CLN(LNNode):
                     return None
                 sleep(1)
 
-    def createrune(self, max_tries=2):
+    def createrune(self, max_tries=10):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
@@ -649,7 +649,7 @@ class ECLAIR(LNNode):
             else:
                 self.log.debug(f"channel response: {response}, wait and retry...")
                 sleep(2)
-        return None
+        return {"edges": []}
 
     def update(self, txid_hex: str, policy: dict, capacity: int, max_tries=2) -> dict:
         self.log.warning("Channel Policy Updates not supported by ECLAIR yet!")

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -539,12 +539,12 @@ class ECLAIR(LNNode):
         attempt = 0
         while attempt < max_tries:
             attempt += 1
-            response = self.post("/usablebalances")
+            response = self.post("/channelbalances")
             if not response:
                 sleep(2)
                 continue
             res = json.loads(response)
-            return int(sum(o["canSend"] + o["canReceive"] for o in res))
+            return int(sum(o["canSend"] for o in res) / 1000)
         return 0
 
     def connect(self, target_uri, max_tries=5) -> dict:

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -483,7 +483,7 @@ class ECLAIR(LNNode):
             "nodeId": pk,
             "fundingFeerateSatByte": fee_rate,
             "fundingFeeBudgetSatoshis": fee_rate * NON_GROUPED_UTXO_BYTE_SIZE,
-        }  # FIXME: https://acinq.github.io/eclair/#open-2 what parameters should be sent?
+        }  # https://acinq.github.io/eclair/#open-2
         attempt = 0
         while attempt < max_tries:
             attempt += 1

--- a/resources/scenarios/ln_init.py
+++ b/resources/scenarios/ln_init.py
@@ -280,6 +280,11 @@ class LNInit(Commander):
         def ln_all_chs(self, ln):
             expected = len(self.channels)
             actual = 0
+            if ln.impl == "eclair" and all(
+                ch["source"] != ln.name and ch["target"] != ln.name for ch in self.channels
+            ):
+                self.log.debug(f"eclair node {ln.name} will list channels if not connected")
+                return
             while actual != expected:
                 actual = len(ln.graph()["edges"])
                 sleep(5)
@@ -362,10 +367,12 @@ class LNInit(Commander):
                     assert len(expected) == len(actual), (
                         f"Expected edges {len(expected)}, actual edges {len(actual)}\n{actual}"
                     )
+                if ln.impl == "eclair" and all(
+                    ch["source"] != ln.name and ch["target"] != ln.name for ch in self.channels
+                ):
+                    self.log.debug(f"eclair node {ln.name} does support network capacity checks")
+                    return
                 for i, actual_ch in enumerate(actual):
-                    if ln.impl == "eclair":
-                        self.log.debug("eclair nodes do not support network capacity checks")
-                        continue
                     expected_ch = expected[i]
                     capacity = expected_ch["capacity"]
                     # We assert this because it isn't updated as part of policy.

--- a/resources/scenarios/ln_init.py
+++ b/resources/scenarios/ln_init.py
@@ -28,6 +28,12 @@ class LNInit(Commander):
         self.log.info("Setting up miner...")
         miner = self.ensure_miner(self.nodes[0])
         miner_addr = miner.getnewaddress()
+        # create wallet for any eclair node
+        for node in self.nodes[1:]:
+            for ln in self.lns.values():
+                if node.tank in ln.name and ln.impl == "eclair":
+                    self.log.info(f"creating wallet for {node.tank}")
+                    node.createwallet("eclair", descriptors=True)
 
         def gen(n):
             return self.generatetoaddress(self.nodes[0], n, miner_addr, sync_fun=self.no_op)
@@ -361,6 +367,9 @@ class LNInit(Commander):
                         f"Expected edges {len(expected)}, actual edges {len(actual)}\n{actual}"
                     )
                 for i, actual_ch in enumerate(actual):
+                    if ln.impl == "eclair":
+                        self.log.debug("eclair nodes do not support network capacity checks")
+                        continue
                     expected_ch = expected[i]
                     capacity = expected_ch["capacity"]
                     # We assert this because it isn't updated as part of policy.

--- a/resources/scenarios/ln_init.py
+++ b/resources/scenarios/ln_init.py
@@ -279,13 +279,9 @@ class LNInit(Commander):
 
         def ln_all_chs(self, ln):
             expected = len(self.channels)
-            attempts = 0
             actual = 0
             while actual != expected:
                 actual = len(ln.graph()["edges"])
-                if attempts > 10:
-                    break
-                attempts += 1
                 sleep(5)
             if actual == expected:
                 self.log.info(f"LN {ln.name} has graph with all {expected} channels")

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -366,11 +366,10 @@ def deploy_network(directory: Path, debug: bool = False, namespace: Optional[str
         network_file = yaml.safe_load(f)
 
     needs_ln_init = False
-    supported_ln_projects = ["lnd", "cln"]
+    supported_ln_projects = ["lnd", "cln", "eclair"]
     for node in network_file["nodes"]:
-        ln_config = node.get("ln", {})
         for key in supported_ln_projects:
-            if ln_config.get(key, False) and key in node and "channels" in node[key]:
+            if key in node and node[key].get("enabled", False):
                 needs_ln_init = True
                 break
         if needs_ln_init:
@@ -379,7 +378,7 @@ def deploy_network(directory: Path, debug: bool = False, namespace: Optional[str
     default_file_path = directory / DEFAULTS_FILE
     with default_file_path.open() as f:
         default_file = yaml.safe_load(f)
-    if any(default_file.get("ln", {}).get(key, False) for key in supported_ln_projects):
+    if any(default_file.get(key, {}).get("enabled", False) for key in supported_ln_projects):
         needs_ln_init = True
 
     processes = []

--- a/src/warnet/graph.py
+++ b/src/warnet/graph.py
@@ -333,7 +333,7 @@ def _import_network(graph_file_path, output_path):
         tank = f"tank-{index:04d}"
         pk_to_tank[node["pub_key"]] = tank
         tank_to_pk[tank] = node["pub_key"]
-        tanks[tank] = {"name": tank, "ln": {"lnd": True}, "lnd": {"channels": []}}
+        tanks[tank] = {"name": tank, "lnd": {"enabled": True, "channels": []}}
         index += 1
     print(f"Imported {index} nodes")
 

--- a/test/data/ln/node-defaults.yaml
+++ b/test/data/ln/node-defaults.yaml
@@ -9,9 +9,8 @@ collectLogs: false
 metricsExport: false
 
 #LN configs
-ln:
-  lnd: true
 lnd:
+  enabled: true
   defaultConfig: |
     color=#000000
   config: |

--- a/test/data/ln_mixed/network.yaml
+++ b/test/data/ln_mixed/network.yaml
@@ -1,0 +1,61 @@
+nodes:
+  - name: tank-0001
+    addnode:
+      - tank-0003
+    eclair:
+      enabled: true
+      channels:
+        - id:
+            block: 300
+            index: 1
+          target: tank-0003-ln
+          capacity: 50001
+          push_amt: 25003
+  - name: tank-0002
+    addnode:
+      - tank-0001
+    cln:
+      enabled: true
+      channels:
+        - id:
+            block: 301
+            index: 1
+          target: tank-0004-ln
+          capacity: 50002
+          push_amt: 25001
+  - name: tank-0003
+    addnode:
+      - tank-0004
+    lnd:
+      enabled: true
+      channels:
+        - id:
+            block: 302
+            index: 3
+          target: tank-0002-ln
+          capacity: 200003
+          push_amt: 100004
+  - name: tank-0004
+    addnode:
+      - tank-0003
+    lnd:
+      enabled: true
+      channels:
+        - id:
+            block: 302
+            index: 2
+          target: tank-0001-ln
+          capacity: 150004
+          push_amt: 25005
+  - name: tank-0005
+    addnode:
+      - tank-0003
+    lnd:
+      enabled: true
+      channels:
+        - id:
+            block: 302
+            index: 1
+          target: tank-0004-ln
+          capacity: 100005
+          push_amt: 51002

--- a/test/data/ln_mixed/node-defaults.yaml
+++ b/test/data/ln_mixed/node-defaults.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: bitcoindevproject/bitcoin
+  pullPolicy: IfNotPresent
+  tag: "29.0"
+
+lnd:
+  defaultConfig: |
+    color=#000000
+  config: |
+    bitcoin.timelockdelta=33
+    minchansize=200
+
+cln:
+  defaultConfig: |
+    rgb=ff3155

--- a/test/data/logging/network.yaml
+++ b/test/data/logging/network.yaml
@@ -11,9 +11,8 @@ nodes:
   - name: tank-0002
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       metricsExport: true
       prometheusMetricsPort: 9332
       extraContainers:

--- a/test/data/logging/network.yaml
+++ b/test/data/logging/network.yaml
@@ -12,7 +12,13 @@ nodes:
     addnode:
       - tank-0000
     lnd:
-      enabled: true
+      channels:
+        - id:
+            block: 300
+            index: 1
+          target: tank-0001-ln
+          capacity: 100000
+          push_amt: 50000
       metricsExport: true
       prometheusMetricsPort: 9332
       extraContainers:

--- a/test/data/logging/node-defaults.yaml
+++ b/test/data/logging/node-defaults.yaml
@@ -3,3 +3,6 @@ image:
   repository: bitcoindevproject/bitcoin
   pullPolicy: IfNotPresent
   tag: "27.0"
+
+lnd:
+  enabled: true

--- a/test/data/network_with_plugins/network.yaml
+++ b/test/data/network_with_plugins/network.yaml
@@ -2,27 +2,26 @@ nodes:
   - name: tank-0000
     addnode:
       - tank-0001
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0001
     addnode:
       - tank-0002
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0002
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0003
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       config: |
         bitcoin.timelockdelta=33
       channels:
@@ -39,9 +38,8 @@ nodes:
   - name: tank-0004
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       channels:
         - id:
             block: 300
@@ -53,8 +51,8 @@ nodes:
   - name: tank-0005
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
 plugins:  # Each plugin section has a number of hooks available (preDeploy, postDeploy, etc)
   preDeploy:  # For example, the preDeploy hook means it's plugin will run before all other deploy code

--- a/test/data/plugins/hello/README.md
+++ b/test/data/plugins/hello/README.md
@@ -35,27 +35,26 @@ nodes:
   - name: tank-0000
     addnode:
       - tank-0001
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0001
     addnode:
       - tank-0002
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0002
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
   - name: tank-0003
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       config: |
         bitcoin.timelockdelta=33
       channels:
@@ -69,9 +68,8 @@ nodes:
   - name: tank-0004
     addnode:
       - tank-0000
-    ln:
-      lnd: true
     lnd:
+      enabled: true
       channels:
         - id:
             block: 300
@@ -83,8 +81,8 @@ nodes:
   - name: tank-0005
     addnode:
       - tank-0000
-    ln:
-      lnd: true
+    lnd:
+      enabled: true
 
 plugins:  # Each plugin section has a number of hooks available (preDeploy, postDeploy, etc)
   preDeploy:  # For example, the preDeploy hook means it's plugin will run before all other deploy code 

--- a/test/ln_mixed_test.py
+++ b/test/ln_mixed_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+from time import sleep
+
+from test_base import TestBase
+
+from resources.scenarios.ln_framework.ln import CLN, ECLAIR, LND, LNNode
+from warnet.process import stream_command
+
+
+class LNMultiTest(TestBase):
+    def __init__(self):
+        super().__init__()
+        self.network_dir = Path(os.path.dirname(__file__)) / "data" / "ln_mixed"
+        self.scen_dir = Path(os.path.dirname(__file__)).parent / "resources" / "scenarios"
+        self.lns = [
+            ECLAIR("tank-0001-ln", use_rpc=True),
+            CLN("tank-0002-ln", use_rpc=True),
+            LND("tank-0003-ln", use_rpc=True),
+            LND("tank-0004-ln", use_rpc=True),
+            LND("tank-0005-ln", use_rpc=True),
+        ]
+
+    def node(self, name: str) -> LNNode:
+        matching_nodes = [n for n in self.lns if n.name == name]
+        if not matching_nodes:
+            raise ValueError(f"No node found with name: {name}")
+        return matching_nodes[0]
+
+    def run_test(self):
+        try:
+            # Wait for all nodes to wake up. ln_init will start automatically
+            self.setup_network()
+
+            # open channel and pay invoice
+            self.manual_open_channels()
+            self.pay_invoice(sender="tank-0003-ln", recipient="tank-0004-ln")
+
+            # pay cln to lnd - channel opened by ln_init - test routing
+            self.pay_invoice(sender="tank-0002-ln", recipient="tank-0003-ln")
+
+            # pay lnd to eclair - channel opened by ln_init - test routing 3 -> 1
+            self.pay_invoice(sender="tank-0003-ln", recipient="tank-0001-ln")
+
+        finally:
+            self.cleanup()
+
+    def setup_network(self):
+        self.log.info("Setting up network")
+        stream_command(f"warnet deploy {self.network_dir}")
+
+    def wait_for_txs(self, count):
+        self.wait_for_predicate(
+            lambda: json.loads(self.warnet("bitcoin rpc tank-0001 getmempoolinfo"))["size"] == count
+        )
+
+    def manual_open_channels(self):
+        # 3 -> 4
+        pk4 = self.node("tank-0004-ln").nodeid()
+        channel = self.node("tank-0003-ln").channel(pk4, "444444", "200000", "5000", 1)
+        assert "txid" in channel, "Failed to create channel between nodes"
+        self.log.info(f"Channel txid {channel['txid']}")
+
+        self.wait_for_txs(1)
+
+        self.warnet("bitcoin rpc tank-0001 -generate 10")
+
+    def wait_for_gossip_sync(self, nodes, expected):
+        while len(nodes) > 0:
+            for node in nodes:
+                chs = node.graph()["edges"]
+                if len(chs) >= expected:
+                    self.log.info(f"Too many edges for {node}")
+            sleep(1)
+
+    def pay_invoice(self, sender: str, recipient: str):
+        self.log.info(f"pay invoice using LNNode {sender} -> {recipient}")
+        init_balance = self.node(recipient).channelbalance()
+        assert init_balance > 0, f"{recipient} is zero, abort"
+
+        self.log.info(f"{recipient} initial balance {init_balance}")
+
+        # create invoice
+        inv = self.node(recipient).createinvoice(10000, f"{sender}-{recipient}")
+        self.log.info(f"invoice {inv}")
+        # pay recipient invoice
+        self.log.info(self.node(sender).payinvoice(inv))
+
+        def wait_for_success():
+            current_balance = self.node(recipient).channelbalance()
+            self.log.info(f"{recipient} current balance {current_balance}")
+            return current_balance == init_balance + 10000
+
+        self.wait_for_predicate(wait_for_success)
+
+
+if __name__ == "__main__":
+    test = LNMultiTest()
+    test.run_test()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -68,10 +68,11 @@ class TestBase:
     def warnet(self, cmd):
         self.log.debug(f"Executing warnet command: {cmd}")
         command = ["warnet"] + cmd.split()
-        proc = run(command, capture_output=True)
+        capture_output = "--debug" not in cmd
+        proc = run(command, capture_output=capture_output)
         if proc.stderr:
             raise Exception(proc.stderr.decode().strip())
-        return proc.stdout.decode().strip()
+        return proc.stdout.decode().strip() if proc.stdout else ""
 
     def output_reader(self, pipe, func):
         while not self.stop_threads.is_set():

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -68,8 +68,7 @@ class TestBase:
     def warnet(self, cmd):
         self.log.debug(f"Executing warnet command: {cmd}")
         command = ["warnet"] + cmd.split()
-        capture_output = "--debug" not in cmd
-        proc = run(command, capture_output=capture_output)
+        proc = run(command, capture_output=True)
         if proc.stderr:
             raise Exception(proc.stderr.decode().strip())
         return proc.stdout.decode().strip() if proc.stdout else ""


### PR DESCRIPTION
This PR adds eclair support to warnet and sim-ln

**Notes:**
- upgrade sim-ln plugin to 0.2.4 for eclair support
- pin eclair docker image to 0.11.0 version - address persistent crash with 0.12.0+ (secp256k1_der_parse_integer+0x166)
- eclair 0.11.0 requires bitcoin core 27.2+ (tested with 28.1 and 29.0)
- enable txindex on bitcoin core
- support switching zmqblock format on bitcoin core node - eclair and lnd require different format
- now LNNode instances can be used in test with common syntax between ln nodes
  - newaddress
  - nodeid
  - uri
  - walletbalance
  - channelbalance
  - connect
  - channel
  - createinvoice
  - payinvoice
  - graph


 
### Breaking change (bitcoincore chart dependencies):
**previous**
```
ln:
  lnd: true
lnd:
  channels: 
```
**proposed**
```
lnd:
  enabled: true
  channels:
```