### PR TITLE
Improve installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Monitor and analyze the emergent behaviors of Bitcoin networks.
 
 ```sh
 python3 -m venv .venv
-source ./venv/bin/activate
+source .venv/bin/activate
 ```
 
 ### 2. Install Warnet

--- a/resources/plugins/simln/README.md
+++ b/resources/plugins/simln/README.md
@@ -102,14 +102,14 @@ nodes:
 plugins:
   postDeploy:
     simln:
-      entrypoint: "../../plugins/simln"  # This is the path to the simln plugin folder (relative to the network.yaml file).
+      entrypoint: "/path/to/plugins/simln"  # This is the path to the simln plugin folder (relative to the network.yaml file).
       activity: '[{"source": "tank-0003-ln", "destination": "tank-0005-ln", "interval_secs": 1, "amount_msat": 2000}]'
 ````
 
 </details>
 
 
-## Generating your own SimLn image
+## Generating your own SimLN image
 The SimLN plugin fetches a SimLN docker image from dockerhub. You can generate your own docker image if you choose:
 
 1. Clone SimLN: `git clone git@github.com:bitcoin-dev-project/sim-ln.git`


### PR DESCRIPTION
- First commit corrects the path to the venv in the top-level `README`.
- Second commit changes the path to the entrypoint to a perhaps more generic one. The reason for that is that the given relative path to the simln plugin might not always be right (it wasn't for me, at least). While at it, we also correct the spelling of simln to be consistent with the rest.