### PR TITLE
lnd newaddress: try/catch in case of JSON error

### DIFF
--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -430,12 +430,17 @@ class LND(LNNode):
         while attempt < max_tries:
             attempt += 1
             response = self.get("/v1/newaddress")
-            res = json.loads(response)
-            if "address" in res:
-                return True, res["address"]
-            else:
+            try:
+                res = json.loads(response)
+                if "address" in res:
+                    return True, res["address"]
+                else:
+                    self.log.warning(
+                        f"Couldn't get wallet address from {self.name}:\n  {res}\n  wait and retry..."
+                    )
+            except Exception:
                 self.log.warning(
-                    f"Couldn't get wallet address from {self.name}:\n  {res}\n  wait and retry..."
+                    f"Couldn't decode newaddress JSON from {self.name}:\n  {response}\n  wait and retry..."
                 )
             sleep(1)
         return False, ""


### PR DESCRIPTION
Fix these ln_init errors that break out of the wait/retry loop:

```
  File "/shared/archive.pyz/ln_framework/ln.py", line 433, in newaddress
tank-0007-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
tank-0005-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
tank-0009-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
tank-0006-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
tank-0002-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
Exception in thread Thread-13 (get_ln_addr):
tank-0008-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
  File "/usr/local/lib/python3.12/json/__init__.py", line 339, in loads
Exception in thread Thread-17 (get_ln_addr):
tank-0003-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-16 (get_ln_addr):
Traceback (most recent call last):
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
tank-0001-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-18 (get_ln_addr):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-14 (get_ln_addr):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
tank-0004-ln - ERROR: Error LND POST, Abort: [Errno 111] Connection refused
Exception in thread Thread-12 (get_ln_addr):
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
    self.run()
Exception in thread Thread-15 (get_ln_addr):
    self.run()
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-19 (get_ln_addr):
Traceback (most recent call last):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
```