### PR TITLE
Support signet mining in scenarios

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -59,7 +59,7 @@ target "cmake-base" {
   inherits = ["maintained-base"]
   dockerfile = "./Dockerfile.dev"
   args = {
-    BUILD_ARGS = "-DBUILD_TESTS=OFF -DBUILD_GUI=OFF -DBUILD_BENCH=OFF -DBUILD_FUZZ_BINARY=OFF -DWITH_ZMQ=ON"
+    BUILD_ARGS = "-DBUILD_TESTS=OFF -DBUILD_GUI=OFF -DBUILD_BENCH=OFF -DBUILD_UTIL=ON -DBUILD_FUZZ_BINARY=OFF -DWITH_ZMQ=ON"
   }
 }
 

--- a/resources/charts/bitcoincore/templates/pod.yaml
+++ b/resources/charts/bitcoincore/templates/pod.yaml
@@ -65,6 +65,8 @@ spec:
         {{- toYaml .Values.readinessProbe | nindent 8 }}
         tcpSocket:
           port: {{ index .Values.global .Values.global.chain "RPCPort" }}
+      startupProbe:
+        {{- toYaml .Values.startupProbe | nindent 8 }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
       volumeMounts:

--- a/resources/charts/commander/templates/rbac.yaml
+++ b/resources/charts/commander/templates/rbac.yaml
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "configmaps", "pods/log"]
+    resources: ["pods", "namespaces", "configmaps", "pods/log", "pods/exec"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/resources/scenarios/ln_init.py
+++ b/resources/scenarios/ln_init.py
@@ -26,6 +26,12 @@ class LNInit(Commander):
     def add_options(self, parser):
         parser.description = "Fund LN wallets and open channels"
         parser.usage = "warnet run /path/to/ln_init.py"
+        parser.add_argument(
+            "--miner",
+            dest="miner",
+            type=str,
+            help="Select one tank by name as the blockchain miner",
+        )
 
     def run_test(self):
         ##
@@ -38,7 +44,18 @@ class LNInit(Commander):
         # MINER
         ##
         self.log.info("Setting up miner...")
-        miner = self.ensure_miner(self.nodes[0])
+        if self.options.miner:
+            self.log.info(f"Parsed 'miner' argument: {self.options.miner}")
+            mining_tank = self.tanks[self.options.miner]
+        elif "miner" in self.tanks:
+            # or choose the tank with the right name
+            self.log.info("Found tank named 'miner'")
+            mining_tank = self.tanks["miner"]
+        else:
+            mining_tank = self.nodes[0]
+            self.log.info(f"Using tank {mining_tank.tank} as miner")
+
+        miner = self.ensure_miner(mining_tank)
         miner_addr = miner.getnewaddress()
 
         def gen(n):

--- a/resources/scenarios/test_scenarios/signet_grinder.py
+++ b/resources/scenarios/test_scenarios/signet_grinder.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+from commander import Commander
+
+
+class SignetGrinder(Commander):
+    def set_test_params(self):
+        self.num_nodes = 0
+
+    def run_test(self):
+        self.generatetoaddress(self.tanks["miner"], 1, "tb1qjfplwf7a2dpjj04cx96rysqeastvycc0j50cch")
+
+
+def main():
+    SignetGrinder().main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -401,7 +401,7 @@ def deploy_network(directory: Path, debug: bool = False, namespace: Optional[str
             debug=False,
             source_dir=SCENARIOS_DIR,
             additional_args=None,
-            admin=False,
+            admin=True,
             namespace=namespace,
         )
         wait_for_pod_ready(name, namespace=namespace)

--- a/src/warnet/image_build.py
+++ b/src/warnet/image_build.py
@@ -23,7 +23,7 @@ def build_image(
     action: str,
 ):
     if not build_args:
-        build_args = '"-DBUILD_TESTS=OFF -DBUILD_GUI=OFF -DBUILD_BENCH=OFF -DBUILD_FUZZ_BINARY=OFF -DWITH_ZMQ=ON "'
+        build_args = '"-DBUILD_TESTS=OFF -DBUILD_GUI=OFF -DBUILD_BENCH=OFF -DBUILD_UTIL=ON -DBUILD_FUZZ_BINARY=OFF -DWITH_ZMQ=ON "'
     else:
         build_args = f'"{build_args}"'
 

--- a/test/data/signet/network.yaml
+++ b/test/data/signet/network.yaml
@@ -1,5 +1,7 @@
 nodes:
   - name: miner
+    image:
+      tag: "29.0-util"
   - name: tank-1
     image:
       tag: "0.16.1"


### PR DESCRIPTION
The core change here is expanding `TestNode.generatetoaddress()` to support signet mining. The whole script from the signet miner is copied and refactored in `commander.py`: get block template, create signet TXs, create PSBT, sign with wallet, complete block, etc and THEN, grind the PoW. 

Signet grinding goes a lot faster using `bitcoin-util` rather than single threaded python, so I addeed it to a [v29 image](https://hub.docker.com/layers/bitcoindevproject/bitcoin/29.0-util/images/sha256-a1fbf7e62488ebd6e24c72739510f005721d06e6cd66b20bfba311cb38ae6eb8) and included it in a test. Commander can also fallback to python if bitcoin-util isnt present. But going forward i think we should install it in all images so that change has been made to `image-build` and the docker bake file as well.

Using bitcoin-util inside the tank requires another k8s permission so the scenario must be run with `--admin`, which `ln_init` is automatically.


In summary:

A Warnet can run on Signet with lightning nodes and channels. Upon deployment, the ln_init scenario will generate all blocks necessary for the channels using the `bitcoin-util` grinder for PoW. For now, the mining node in such a network must use the `29.0-util` tag but starting with bitcoin core v30 our warnet images will include bitcoin-util by default

