### PR TITLE
Use taproot outputs to fund lightning channels

### DIFF
--- a/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
@@ -40,13 +40,7 @@ spec:
       command:
         - /bin/sh
         - -c
-        - |
-          lightningd --conf=/root/.lightning/config &
-          sleep 1
-          lightning-cli createrune > /working/rune.json
-          echo "Here is the rune file contents"
-          cat /working/rune.json
-          wait
+        - lightningd --conf=/root/.lightning/config
       livenessProbe:
         {{- toYaml .Values.livenessProbe | nindent 8 }}
       readinessProbe:

--- a/resources/charts/bitcoincore/charts/cln/values.yaml
+++ b/resources/charts/bitcoincore/charts/cln/values.yaml
@@ -71,6 +71,16 @@ readinessProbe:
       - "/bin/sh"
       - "-c"
       - "lightning-cli getinfo 2>/dev/null | grep -q 'id' || exit 1"
+startupProbe:
+  failureThreshold: 10
+  periodSeconds: 30
+  successThreshold: 1
+  timeoutSeconds: 60
+  exec:
+    command:
+      - "/bin/sh"
+      - "-c"
+      - "lightning-cli createrune > /working/rune.json"
 
 # Additional volumes on the output Deployment definition.
 volumes:

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -161,7 +161,7 @@ class CLN(LNNode):
 
     def reset_connection(self):
         self.conn = http.client.HTTPSConnection(
-            host=self.name, port=3010, timeout=5, context=INSECURE_CONTEXT
+            host=self.name, port=3010, timeout=60, context=INSECURE_CONTEXT
         )
 
     def setRune(self, rune):
@@ -299,7 +299,7 @@ class LND(LNNode):
 
     def reset_connection(self):
         self.conn = http.client.HTTPSConnection(
-            host=self.name, port=8080, timeout=5, context=INSECURE_CONTEXT
+            host=self.name, port=8080, timeout=60, context=INSECURE_CONTEXT
         )
 
     def get(self, uri):

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -219,9 +219,11 @@ class CLN(LNNode):
 
     def newaddress(self):
         self.createrune()
-        response = self.post("/v1/newaddr")
+        response = self.post("/v1/newaddr", data={"addresstype": "p2tr"})
         res = json.loads(response)
-        return res["bech32"]
+        if "p2tr" in res:
+            return res["p2tr"]
+        raise Exception(res)
 
     def uri(self):
         res = json.loads(self.post("/v1/getinfo"))
@@ -336,9 +338,14 @@ class LND(LNNode):
         return stream
 
     def newaddress(self):
-        response = self.get("/v1/newaddress")
+        # Taproot signatures are a fixed length which improves
+        # the accuracy of fee estimation, and therefore our
+        # channel ID determinism.
+        response = self.get("/v1/newaddress?type=TAPROOT_PUBKEY")
         res = json.loads(response)
-        return res["address"]
+        if "address" in res:
+            return res["address"]
+        raise Exception(res)
 
     def walletbalance(self) -> int:
         res = self.get("/v1/balance/blockchain")

--- a/resources/scenarios/ln_framework/ln.py
+++ b/resources/scenarios/ln_framework/ln.py
@@ -185,7 +185,6 @@ class CLN(LNNode):
         post_header["Content-Length"] = str(len(body))
         post_header["Content-Type"] = "application/json"
         self.reset_connection()
-        self.log.info(f"CLN POST headers: {post_header}")
         self.conn.request(
             method="POST",
             url=uri,

--- a/test/data/ln/network.yaml
+++ b/test/data/ln/network.yaml
@@ -2,6 +2,9 @@ nodes:
   - name: tank-0000
     addnode:
       - tank-0001
+    ln:
+      lnd: false
+      cln: true
   - name: tank-0001
     addnode:
       - tank-0002


### PR DESCRIPTION
The motivation is to ensure predictable channel open transaction size so the fee rate expected by ln_init gets applied correctly. Using p2wpkh previously, sometimes (1 out of 500) lnd would create a channel open tx that was 1 byte smaller due to variable signature length. This would inadvertently cause the effective fee rate of the tx to increase so much that it would actually interfere with the deterministic channel IDs we need in Warnet.

This change is applied to both lnd and cln and so this PR also adds test coverage for cln.