### PR TITLE
Support extra services in caddy / Warnet dashboard

### DIFF
--- a/resources/charts/caddy/templates/configmap.yaml
+++ b/resources/charts/caddy/templates/configmap.yaml
@@ -6,6 +6,34 @@ metadata:
     {{- include "caddy.labels" . | nindent 4 }}
 data:
   Caddyfile: |
-    {{- .Values.caddyConfig | nindent 4 }}
+    :80 {
+      respond /live 200
+      respond /ready 200
+
+      root * /usr/share/caddy
+      file_server
+
+      {{- range .Values.services }}
+      handle_path {{ .path }}* {
+        reverse_proxy {{ .host }}:{{ .port }}
+      }
+      {{- end }}
+    }
   index: |
-    {{- .Values.htmlConfig | nindent 4 }}
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Warnet Dashboard</title>
+    </head>
+    <body>
+        <h1>Welcome to the Warnet dashboard</h1>
+        <p>You can access the following services:</p>
+        <ul>
+            {{- range .Values.services }}
+            <li><a href="{{ .path }}">{{ .title }}</a></li>
+            {{- end }}
+        </ul>
+    </body>
+    </html>

--- a/resources/charts/caddy/values.yaml
+++ b/resources/charts/caddy/values.yaml
@@ -85,14 +85,3 @@ volumeMounts:
     subPath: index
 
 port: 80
-
-services:
-  - title: Grafana
-    path: /grafana/
-    host: loki-grafana
-    port: 80
-  - title: Fork Observer
-    path: /fork-observer/
-    host: fork-observer
-    port: 2323
-    

--- a/resources/charts/caddy/values.yaml
+++ b/resources/charts/caddy/values.yaml
@@ -86,38 +86,13 @@ volumeMounts:
 
 port: 80
 
-caddyConfig: |
-  :80 {
-    respond /live 200
-    respond /ready 200
-
-    root * /usr/share/caddy
-    file_server
-
-    handle_path /fork-observer/* {
-      reverse_proxy fork-observer:2323
-    }
-
-    handle_path /grafana/* {
-      reverse_proxy loki-grafana:80
-    }
-
-  }
-
-htmlConfig: |
-  <!DOCTYPE html>
-  <html lang="en">
-  <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Welcome</title>
-  </head>
-  <body>
-      <h1>Welcome to the Warnet dashboard</h1>
-      <p>You can access the following services:</p>
-      <ul>
-          <li><a href="/grafana/">Grafana</a></li>
-          <li><a href="/fork-observer/">Fork Observer</a></li>
-      </ul>
-  </body>
-  </html>
+services:
+  - title: Grafana
+    path: /grafana/
+    host: loki-grafana
+    port: 80
+  - title: Fork Observer
+    path: /fork-observer/
+    host: fork-observer
+    port: 2323
+    

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -278,7 +278,12 @@ def deploy_caddy(directory: Path, debug: bool):
         )
     if network_file.get("fork_observer", {}).get("enabled", False):
         services.append(
-            {"title": "Fork Observer", "path": "/fork-observer/", "host": "fork-observer", "port": 2323}
+            {
+                "title": "Fork Observer",
+                "path": "/fork-observer/",
+                "host": "fork-observer",
+                "port": 2323,
+            }
         )
     # add any extra services
     services += network_file.get("services", {})

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -280,6 +280,8 @@ def deploy_caddy(directory: Path, debug: bool):
         services.append(
             {"title": "Fork Observer", "path": "/fork-observer/", "host": "fork-observer", "port": 2323}
         )
+    # add any extra services
+    services += network_file.get("services", {})
 
     click.echo(f"Adding services to dashboard: {json.dumps(services, indent=2)}")
 

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -269,7 +269,25 @@ def deploy_caddy(directory: Path, debug: bool):
     if not network_file.get(name, {}).get("enabled", False):
         return
 
-    cmd = f"{HELM_COMMAND} {name} {CADDY_CHART} --namespace {namespace} --create-namespace"
+    # configure reverse proxy to webservers in the network
+    services = []
+    # built-in services
+    if check_logging_required(directory):
+        services.append(
+            {"title": "Grafana", "path": "/grafana/", "host": "loki-grafana", "port": 80}
+        )
+    if network_file.get("fork_observer", {}).get("enabled", False):
+        services.append(
+            {"title": "Fork Observer", "path": "/fork-observer/", "host": "fork-observer", "port": 2323}
+        )
+
+    click.echo(f"Adding services to dashboard: {json.dumps(services, indent=2)}")
+
+    cmd = (
+        f"{HELM_COMMAND} {name} {CADDY_CHART} "
+        f"--namespace {namespace} --create-namespace "
+        f"--set-json services='{json.dumps(services)}'"
+    )
     if debug:
         cmd += " --debug"
 

--- a/test/data/services/network.yaml
+++ b/test/data/services/network.yaml
@@ -35,3 +35,8 @@ fork_observer:
   enabled: true
 caddy:
   enabled: true
+services:
+  - title: Ringo REST
+    path: /ringo/
+    host: ringo.default
+    port: 18443

--- a/test/services_test.py
+++ b/test/services_test.py
@@ -15,11 +15,14 @@ class ServicesTest(TestBase):
     def __init__(self):
         super().__init__()
         self.network_dir = Path(os.path.dirname(__file__)) / "data" / "services"
+        self.ingress_ip = None
 
     def run_test(self):
         try:
             self.setup_network()
+            self.get_ingress_ip()
             self.check_fork_observer()
+            self.check_extra_services()
         finally:
             self.cleanup()
 
@@ -29,25 +32,25 @@ class ServicesTest(TestBase):
         self.wait_for_all_tanks_status(target="running")
         self.wait_for_all_edges()
 
+    def get_ingress_ip(self):
+        self.log.info("Waiting for ingress controller")
+        wait_for_ingress_controller()
+        self.log.info("Waiting for ingress host")
+        attempts = 100
+        while not self.ingress_ip:
+            self.ingress_ip = get_ingress_ip_or_host()
+            attempts -= 1
+            if attempts < 0:
+                raise Exception("Never got ingress host")
+            sleep(1)
+
     def check_fork_observer(self):
         self.log.info("Creating chain split")
         self.warnet("bitcoin rpc john createwallet miner")
         self.warnet("bitcoin rpc john -generate 1")
 
-        self.log.info("Waiting for ingress controller")
-        wait_for_ingress_controller()
-
-        self.log.info("Waiting for ingress host")
-        ingress_ip = None
-        attempts = 100
-        while not ingress_ip:
-            ingress_ip = get_ingress_ip_or_host()
-            attempts -= 1
-            if attempts < 0:
-                raise Exception("Never got ingress host")
-            sleep(1)
         # network id is 0xDEADBE in decimal
-        fo_data_uri = f"http://{ingress_ip}/fork-observer/api/14593470/data.json"
+        fo_data_uri = f"http://{self.ingress_ip}/fork-observer/api/14593470/data.json"
 
         def call_fo_api():
             # if on minikube remember to run `minikube tunnel` for this test to run
@@ -77,6 +80,12 @@ class ServicesTest(TestBase):
             lambda: len(json.loads(self.warnet("bitcoin rpc george getpeerinfo"))) > 1
         )
 
+    def check_extra_services(self):
+        self.log.info("Checking extra web services added to caddy")
+        uri = f"http://{self.ingress_ip}/ringo/rest/chaininfo.json"
+        rest_data = requests.get(uri)
+        rest_json = rest_data.json()
+        assert rest_json["chain"] == "regtest"
 
 if __name__ == "__main__":
     test = ServicesTest()

--- a/test/services_test.py
+++ b/test/services_test.py
@@ -87,6 +87,7 @@ class ServicesTest(TestBase):
         rest_json = rest_data.json()
         assert rest_json["chain"] == "regtest"
 
+
 if __name__ == "__main__":
     test = ServicesTest()
     test.run_test()


### PR DESCRIPTION
Closes https://github.com/bitcoin-dev-project/warnet/issues/679

Abstracts the fork observer and grafana services that were hard coded into the caddy chart. Also adds any extra configured reverse proxy. The test simply adds the REST interface from one of the tanks by adding this to network.yaml:

```yaml
services:
  - title: Ringo REST
    path: /ringo/
    host: ringo.default
    port: 18443
```

In conjunction with a plugin, any additional web services can now be added to a warnet network