### PR TITLE
Accomdate LN nodes in "wargames" namespaces

### DIFF
--- a/resources/charts/bitcoincore/charts/cln/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
     bitcoin-rpcconnect={{ include "bitcoincore.fullname" . }}
     bitcoin-rpcport={{ index .Values.global .Values.global.chain "RPCPort" }}
     bitcoin-rpcpassword={{ .Values.global.rpcpassword }}
-    alias={{ include "cln.fullname" . }}
+    alias={{ include "lnd.fullname" . }}.{{ .Release.Namespace }}
     announce-addr=dns:{{ include "cln.fullname" . }}:{{ .Values.P2PPort }}
     database-upgrade=true
     bitcoin-retry-timeout=600

--- a/resources/charts/bitcoincore/charts/cln/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
     bitcoin-rpcconnect={{ include "bitcoincore.fullname" . }}
     bitcoin-rpcport={{ index .Values.global .Values.global.chain "RPCPort" }}
     bitcoin-rpcpassword={{ .Values.global.rpcpassword }}
-    alias={{ include "lnd.fullname" . }}.{{ .Release.Namespace }}
+    alias={{ include "cln.fullname" . }}.{{ .Release.Namespace }}
     announce-addr=dns:{{ include "cln.fullname" . }}:{{ .Values.P2PPort }}
     database-upgrade=true
     bitcoin-retry-timeout=600

--- a/resources/charts/bitcoincore/charts/lnd/templates/_helpers.tpl
+++ b/resources/charts/bitcoincore/charts/lnd/templates/_helpers.tpl
@@ -76,3 +76,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create a hex-encoded RGB color derived from the namespace
+*/}}
+{{- define "namespace.color" -}}
+{{- $hash := sha256sum .Release.Namespace -}}
+{{- printf "#%s" (substr 0 6 $hash) -}}
+{{- end -}}
+

--- a/resources/charts/bitcoincore/charts/lnd/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
     bitcoind.rpchost={{ include "bitcoincore.fullname" . }}:{{ index .Values.global .Values.global.chain "RPCPort" }}
     bitcoind.zmqpubrawblock=tcp://{{ include "bitcoincore.fullname" . }}:{{ .Values.global.ZMQBlockPort }}
     bitcoind.zmqpubrawtx=tcp://{{ include "bitcoincore.fullname" . }}:{{ .Values.global.ZMQTxPort }}
-    alias={{ include "lnd.fullname" . }}
+    alias={{ include "lnd.fullname" . }}.{{ .Release.Namespace }}
     externalhosts={{ include "lnd.fullname" . }}
     tlsextradomain={{ include "lnd.fullname" . }}
   tls.cert: |

--- a/resources/charts/bitcoincore/charts/lnd/templates/configmap.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
     bitcoind.zmqpubrawblock=tcp://{{ include "bitcoincore.fullname" . }}:{{ .Values.global.ZMQBlockPort }}
     bitcoind.zmqpubrawtx=tcp://{{ include "bitcoincore.fullname" . }}:{{ .Values.global.ZMQTxPort }}
     alias={{ include "lnd.fullname" . }}.{{ .Release.Namespace }}
+    color={{ include "namespace.color" . }}
     externalhosts={{ include "lnd.fullname" . }}
     tlsextradomain={{ include "lnd.fullname" . }}
   tls.cert: |

--- a/resources/scenarios/commander.py
+++ b/resources/scenarios/commander.py
@@ -92,6 +92,7 @@ for pod in pods.items:
         WARNET["tanks"].append(
             {
                 "tank": pod.metadata.name,
+                "namespace": pod.metadata.namespace,
                 "chain": pod.metadata.labels["chain"],
                 "rpc_host": pod.status.pod_ip,
                 "rpc_port": int(pod.metadata.labels["RPCPort"]),
@@ -104,10 +105,13 @@ for pod in pods.items:
     if pod.metadata.labels["mission"] == "lightning":
         if "lnd" in pod.metadata.labels["app.kubernetes.io/name"]:
             lnnode = LND(
-                pod.metadata.name, pod.status.pod_ip, pod.metadata.annotations["adminMacaroon"]
+                pod.metadata.name,
+                pod.metadata.namespace,
+                pod.status.pod_ip,
+                pod.metadata.annotations["adminMacaroon"],
             )
         if "cln" in pod.metadata.labels["app.kubernetes.io/name"]:
-            lnnode = CLN(pod.metadata.name, pod.status.pod_ip)
+            lnnode = CLN(pod.metadata.name, pod.metadata.namespace, pod.status.pod_ip)
         assert lnnode
         WARNET["lightning"].append(lnnode)
 

--- a/src/warnet/ln.py
+++ b/src/warnet/ln.py
@@ -28,8 +28,8 @@ def rpc(pod: str, method: str, params: str, namespace: Optional[str]):
 
 
 def _rpc(pod_name: str, method: str, params: str = "", namespace: Optional[str] = None):
-    pod = get_pod(pod_name)
     namespace = get_default_namespace_or(namespace)
+    pod = get_pod(pod_name, namespace)
     chain = pod.metadata.labels["chain"]
     ln_client = "lncli"
     if "cln" in pod.metadata.labels["app.kubernetes.io/name"]:

--- a/test/ln_basic_test.py
+++ b/test/ln_basic_test.py
@@ -64,11 +64,11 @@ class LNBasicTest(TestBase):
         info = json.loads(
             self.warnet("ln rpc tank-0001-ln --rpcserver=tank-0002-ln.default:10009 getinfo")
         )
-        assert info["alias"] == "tank-0002-ln"
+        assert info["alias"] == "tank-0002-ln.default"
         info = json.loads(
             self.warnet("ln rpc tank-0002-ln --rpcserver=tank-0005-ln.default:10009 getinfo")
         )
-        assert info["alias"] == "tank-0005-ln"
+        assert info["alias"] == "tank-0005-ln.default"
 
         self.log.info("Testing lnd nodes with unique macaroon root key can NOT query each other")
         # These tanks are configured with unique macaroon root keys


### PR DESCRIPTION
Sending RPCs from `warnet ln rpc` and also sending commands to ln nodes from scenarios, we need to include the namespace of the node in the domain name / URI, so that an `--admin` scenario can get addresses from tanks like `armada-1-ln.wargames-red` and send funds to it from tanks like `miner.default`