### PR TITLE
add all LNs to commander regardless of namespace

### DIFF
--- a/resources/scenarios/commander.py
+++ b/resources/scenarios/commander.py
@@ -267,7 +267,9 @@ class Commander(BitcoinTestFramework):
             self.nodes.append(node)
             self.tanks[tank["tank"]] = node
 
+        self.ln_nodes = []
         for ln in WARNET["lightning"]:
+            self.ln_nodes.append(ln)
             self.lns[ln.name] = ln
 
         self.num_nodes = len(self.nodes)


### PR DESCRIPTION
Closes https://github.com/bitcoin-dev-project/warnet/issues/749

Just a work-around, adds `self.ln_nodes[]` to commander without being keyed by pod name so admin scenarios can just get everything they need from there.