### PR TITLE
warnet auth --revert

### DIFF
--- a/src/warnet/constants.py
+++ b/src/warnet/constants.py
@@ -83,6 +83,7 @@ DEFAULT_NAMESPACES = Path("two_namespaces_two_users")
 
 # Kubeconfig related stuffs
 KUBECONFIG = os.environ.get("KUBECONFIG", os.path.expanduser("~/.kube/config"))
+KUBECONFIG_UNDO = KUBECONFIG + "_warnet_undo"
 
 # TODO: all of this logging stuff should be a helm chart
 LOGGING_CONFIG = {

--- a/test/namespace_admin_test.py
+++ b/test/namespace_admin_test.py
@@ -147,8 +147,7 @@ class NamespaceAdminTest(ScenariosTest, TestBase):
         return self.red_namespace in maybe_namespaces
 
     def return_to_initial_context(self):
-        cmd = f"kubectl config use-context {self.initial_context}"
-        self.log.info(run_command(cmd))
+        self.log.info(self.warnet("auth --revert"))
         self.wait_for_predicate(self.this_is_the_current_context(self.initial_context))
 
     def this_is_the_current_context(self, context: str) -> Callable[[], bool]:


### PR DESCRIPTION
After using `warnet auth <path/to/file>` to enter a game, use `warnet auth --revert` to go back (hopefully back to `docker-desktop` or `minikube`)