### PR TITLE
Check if minikube tunnel is running in setup

### DIFF
--- a/src/warnet/project.py
+++ b/src/warnet/project.py
@@ -80,6 +80,21 @@ def setup():
             # Minikube command not found
             return False, ""
 
+    def is_minikube_tunnel_running() -> tuple[bool, str]:
+        try:
+            result = subprocess.run(
+                ["pgrep", "-f", "minikube tunnel"],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode == 0:
+                return True, "minikube tunnel is running"
+            else:
+                return False, ""
+        except FileNotFoundError:
+            # pgrep command not found
+            return False, "command not found: pgrep"
+
     def is_docker_running() -> tuple[bool, str]:
         try:
             result = subprocess.run(
@@ -292,6 +307,12 @@ def setup():
         install_instruction="Please make sure minikube is running",
         install_url="https://minikube.sigs.k8s.io/docs/start/",
     )
+    minikube_tunnel_running_info = ToolInfo(
+        tool_name="Running Minikube Tunnel",
+        is_installed_func=is_minikube_tunnel_running,
+        install_instruction="Please make sure minikube tunnel is running",
+        install_url="https://minikube.sigs.k8s.io/docs/commands/tunnel/"
+    )
     kubectl_info = ToolInfo(
         tool_name="Kubectl",
         is_installed_func=is_kubectl_installed_and_offer_if_not,
@@ -355,6 +376,7 @@ def setup():
                 if is_platform_darwin():
                     check_results.append(check_installation(minikube_version_info))
                 check_results.append(check_installation(minikube_running_info))
+                check_results.append(check_installation(minikube_tunnel_running_info))
         else:
             click.secho("Please re-run setup.", fg="yellow")
             sys.exit(1)

--- a/src/warnet/project.py
+++ b/src/warnet/project.py
@@ -83,9 +83,7 @@ def setup():
     def is_minikube_tunnel_running() -> tuple[bool, str]:
         try:
             result = subprocess.run(
-                ["pgrep", "-f", "minikube tunnel"],
-                capture_output=True,
-                text=True
+                ["pgrep", "-f", "minikube tunnel"], capture_output=True, text=True
             )
             if result.returncode == 0:
                 return True, "minikube tunnel is running"
@@ -311,7 +309,7 @@ def setup():
         tool_name="Running Minikube Tunnel",
         is_installed_func=is_minikube_tunnel_running,
         install_instruction="Please make sure minikube tunnel is running",
-        install_url="https://minikube.sigs.k8s.io/docs/commands/tunnel/"
+        install_url="https://minikube.sigs.k8s.io/docs/commands/tunnel/",
     )
     kubectl_info = ToolInfo(
         tool_name="Kubectl",


### PR DESCRIPTION
Hello!

In a minikube environment, [`bash scripts/deploy.sh regtest4` in wrath-of-nalo](https://github.com/bitcoin-dev-project/wrath-of-nalo/blob/aea397cfdb8f05b3b09f31f44c16f40167e60104/scripts/deploy.sh) depends on `minikube tunnel` running. The same is true for `warnet dashboard`.

However, unlike `warnet dashboard`, scripts/deploy.sh (specifically [update_grafana_dashboard.py](https://github.com/bitcoin-dev-project/wrath-of-nalo/blob/aea397cfdb8f05b3b09f31f44c16f40167e60104/scripts/upload_grafana_dashboard.py)) does not return a useful error if the ingress IP address was not found. It prints this error instead:

> Error getting ingress IP: 'NoneType' object is not subscriptable

and then tries to resolve `None` as a domain. Compare this to how `warnet dashboard` mentions this in that case:

> Error: Could not get the IP address of the dashboard
> If you are running Minikube please run 'minikube tunnel' in a separate terminal

I didn't want to duplicate this error handling to update_grafana_dashboard.py. Instead, I thought it'd be nice to let `warnet setup` also handle this, similar to how it's already checking if minikube is running.

This is what this PR is doing! The check depends on `pgrep` with the `-f` option being available.

Here's a video of how I tested this:

https://github.com/user-attachments/assets/25efe0f8-024c-4c48-a4ed-36a060faaff2

I will include suggestions for my own code in a review. This PR is just meant to show the least invasive change to handle this in `warnet setup`, assuming that's even the best place to handle it.