### PR TITLE
Print dashboard URL when opening

### DIFF
--- a/src/warnet/dashboard.py
+++ b/src/warnet/dashboard.py
@@ -24,4 +24,4 @@ def dashboard():
     url = f"http://{ip}"
 
     webbrowser.open(url)
-    click.echo("Warnet dashboard opened in default browser")
+    click.echo(f"Warnet dashboard opened in default browser. URL: {url}")


### PR DESCRIPTION
When running in a VPS or similar, a "default browser" may not be available.

Print the URL so that a user can open it elsewhere if desired.