### PR TITLE
Generate kubeconfigs only for warnet-user #772

### DIFF
--- a/src/warnet/admin.py
+++ b/src/warnet/admin.py
@@ -11,7 +11,7 @@ from .k8s import (
     K8sError,
     get_cluster_of_current_context,
     get_namespaces_by_type,
-    get_service_accounts_in_namespace,
+    get_warnet_user_service_accounts_in_namespace,
     open_kubeconfig,
 )
 from .namespaces import copy_namespaces_defaults, namespaces
@@ -84,7 +84,7 @@ def create_kubeconfigs(kubeconfig_dir, token_duration):
     for v1namespace in warnet_namespaces:
         namespace = v1namespace.metadata.name
         click.echo(f"Processing namespace: {namespace}")
-        service_accounts = get_service_accounts_in_namespace(namespace)
+        service_accounts = get_warnet_user_service_accounts_in_namespace(namespace)
 
         for sa in service_accounts:
             # Create a token for the ServiceAccount with specified duration

--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -494,9 +494,9 @@ def get_warnet_user_service_accounts_in_namespace(namespace):
     Get all service accounts in a namespace. Returns an empty list if no service accounts are found in the specified namespace.
     """
     command = f"kubectl get serviceaccounts -n {namespace} -o jsonpath={{.items[*].metadata.name}}"
-    # skip the default service account created by k8s
+    # skip the default service account created by k8s and commander service accounts created by scenarios
     service_accounts = run_command(command).split()
-    return [sa for sa in service_accounts if sa == "warnet-user"]
+    return [sa for sa in service_accounts if sa != "default" and not sa.startswith("commander-")]
 
 
 def can_delete_pods(namespace: Optional[str] = None) -> bool:

--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -489,14 +489,14 @@ def get_namespaces_by_type(namespace_type: str) -> list[V1Namespace]:
     return [ns for ns in namespaces if ns.metadata.name.startswith(namespace_type)]
 
 
-def get_service_accounts_in_namespace(namespace):
+def get_warnet_user_service_accounts_in_namespace(namespace):
     """
     Get all service accounts in a namespace. Returns an empty list if no service accounts are found in the specified namespace.
     """
     command = f"kubectl get serviceaccounts -n {namespace} -o jsonpath={{.items[*].metadata.name}}"
     # skip the default service account created by k8s
     service_accounts = run_command(command).split()
-    return [sa for sa in service_accounts if sa != "default"]
+    return [sa for sa in service_accounts if sa == "warnet-user"]
 
 
 def can_delete_pods(namespace: Optional[str] = None) -> bool:


### PR DESCRIPTION
Fixes #772

Restricts warnet admin create-kubeconfigs to generate kubeconfigs only for the warnet-user service account. This prevents unnecessary kubeconfig files from being created when multiple ServiceAccounts exist in a namespace.

Updated the service account lookup to return only warnet-user

Renamed the helper function and updated its usage accordingly