### PR TITLE
lnd: rm rf wallet on restart

### DIFF
--- a/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
@@ -53,6 +53,8 @@ spec:
             - /bin/sh
             - -c
             - |
+              rm -rf /root/.lnd/data/chain
+
               until curl --silent --insecure https://localhost:8080/v1/genseed > /tmp/genseed.json; do
                 sleep 5
               done
@@ -85,7 +87,7 @@ spec:
     {{- if .Values.circuitbreaker.enabled }}
     - name: circuitbreaker
       image: {{ .Values.circuitbreaker.image | quote }}
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always
       args:
         - "--network={{ .Values.global.chain }}"
         - "--rpcserver=localhost:{{ .Values.RPCPort }}"


### PR DESCRIPTION
If LND crashes and restarts, the init commands wont work because "wallet already exists"