### PR TITLE
wait_for_ingress_endpoint

### DIFF
--- a/src/warnet/dashboard.py
+++ b/src/warnet/dashboard.py
@@ -10,7 +10,11 @@ def dashboard():
 
     timeout = 300
     click.echo(f"Waiting {timeout} seconds for ingress endpoint ...")
-    wait_for_ingress_endpoint(timeout=timeout)
+    try:
+        wait_for_ingress_endpoint(timeout=timeout)
+    except Exception as e:
+        print(e)
+        return
     ip = get_ingress_ip_or_host()
 
     url = f"http://{ip}"

--- a/src/warnet/dashboard.py
+++ b/src/warnet/dashboard.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from .k8s import get_ingress_ip_or_host, wait_for_ingress_endpoint
@@ -14,7 +16,7 @@ def dashboard():
         wait_for_ingress_endpoint(timeout=timeout)
     except Exception as e:
         click.echo(e)
-        return
+        sys.exit(1)
     ip = get_ingress_ip_or_host()
 
     url = f"http://{ip}"

--- a/src/warnet/dashboard.py
+++ b/src/warnet/dashboard.py
@@ -1,6 +1,6 @@
 import click
 
-from .k8s import get_ingress_ip_or_host, wait_for_ingress_controller
+from .k8s import get_ingress_ip_or_host, wait_for_ingress_endpoint
 
 
 @click.command()
@@ -8,18 +8,10 @@ def dashboard():
     """Open the Warnet dashboard in default browser"""
     import webbrowser
 
-    wait_for_ingress_controller()
+    timeout = 300
+    click.echo(f"Waiting {timeout} seconds for ingress endpoint ...")
+    wait_for_ingress_endpoint(timeout=timeout)
     ip = get_ingress_ip_or_host()
-
-    if not ip:
-        click.echo("Error: Could not get the IP address of the dashboard")
-        click.echo(
-            "If you are running Minikube please run 'minikube tunnel' in a separate terminal"
-        )
-        click.echo(
-            "If you are running in the cloud, you may need to wait a short while while the load balancer is provisioned"
-        )
-        return
 
     url = f"http://{ip}"
 

--- a/src/warnet/dashboard.py
+++ b/src/warnet/dashboard.py
@@ -13,7 +13,7 @@ def dashboard():
     try:
         wait_for_ingress_endpoint(timeout=timeout)
     except Exception as e:
-        print(e)
+        click.echo(e)
         return
     ip = get_ingress_ip_or_host()
 

--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -347,7 +347,7 @@ def wait_for_ingress_endpoint(timeout=300):
                 + str(e).rstrip()
             )
             if e.status == 404:
-                msg += "\n\nDid you deploy a network?"
+                msg += "\n\nDid you deploy a network with caddy enabled?"
             raise Exception(msg) from e
         lb_ingress = ingress.status.load_balancer.ingress
         if lb_ingress and (lb_ingress[0].hostname or lb_ingress[0].ip):

--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -348,7 +348,7 @@ def wait_for_ingress_endpoint(timeout=300):
             )
             if e.status == 404:
                 msg += "\n\nDid you deploy a network?"
-            raise Exception(msg) from None
+            raise Exception(msg) from e
         lb_ingress = ingress.status.load_balancer.ingress
         if lb_ingress and (lb_ingress[0].hostname or lb_ingress[0].ip):
             return True


### PR DESCRIPTION
This PR introduces `wait_for_ingress_endpoint`, the helper function mentioned in https://github.com/bitcoin-dev-project/warnet/pull/766#issuecomment-3846918292.

It checks every second if ingress is up, in the same way `get_ingress_ip_or_host` tries to return the ingress IP address or hostname. So when `wait_for_ingress_endpoint` did not throw, `get_ingress_ip_or_host` should always succeed.

I considered calling `wait_for_ingress_controller` inside it, but I think it would be a redundant check.

After this PR has been reviewed, approved, and a new version of warnet has been released, I will create PRs in battle-of-galen-erso and wrath-of-nalo to use `wait_for_ingress_endpoint` instead of `wait_for_ingress_controller` in their dashboard upload scripts. This should then fix what https://github.com/bitcoin-dev-project/warnet/pull/766 intended to fix.

I tested this by deploying `regtest_jam` from wrath-of-nalo and then running `python -c "from warnet.k8s import wait_for_ingress_endpoint; wait_for_ingress_endpoint(timeout=5)"`. I got the timeout error without `minikube tunnel` running and no timeout error with it running.

Since the return value of `get_ingress_ip_or_host` is now no longer used to print the hint for the user, we can now consider making it throw instead of returning `None` (failing fast instead of potentially obscure error later). However, it's also used in the tests, so they would break without an update. I didn't want to make a decision on this and mess with the tests in this PR to keep the scope low.