### PR TITLE
Establish limit of 100 pods per namespace in war game, configurable in yaml

### DIFF
--- a/resources/charts/namespaces/templates/namespace.yaml
+++ b/resources/charts/namespaces/templates/namespace.yaml
@@ -2,3 +2,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespaceName | default .Release.Name }}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-pod-limit
+  namespace: {{ .Values.namespaceName | default .Release.Name }}
+spec:
+  hard:
+    pods: {{ .Values.podLimit | quote }}

--- a/resources/charts/namespaces/values.yaml
+++ b/resources/charts/namespaces/values.yaml
@@ -58,3 +58,4 @@ roles:
       - apiGroups: ["networking.k8s.io"]
         resources: ["ingresses"]
         verbs: ["list", "get", "watch"]
+podLimit: 100

--- a/resources/scenarios/test_scenarios/nothing.py
+++ b/resources/scenarios/test_scenarios/nothing.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from time import sleep
+
+# The base class exists inside the commander container
+try:
+    from commander import Commander
+except Exception:
+    from resources.scenarios.commander import Commander
+
+
+class Nothing(Commander):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def add_options(self, parser):
+        parser.description = "This test will do nothing, forever"
+        parser.usage = "warnet run /path/to/nothing.py"
+
+    def run_test(self):
+        while True:
+            sleep(60)
+
+
+def main():
+    Nothing("").main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/data/wargames/namespaces/armies/namespace-defaults.yaml
+++ b/test/data/wargames/namespaces/armies/namespace-defaults.yaml
@@ -3,3 +3,4 @@ users:
     roles:
       - pod-viewer
       - pod-manager
+podLimit: 3

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -2,7 +2,9 @@ import json
 import logging
 import logging.config
 import os
+import pexpect
 import re
+import sys
 import threading
 from pathlib import Path
 from subprocess import run
@@ -45,7 +47,10 @@ class TestBase:
         try:
             self.log.info("Stopping network")
             if self.network:
-                self.warnet("down --force")
+                session = pexpect.spawn(f"warnet down", encoding="utf-8")
+                session.logfile = sys.stdout
+                session.expect("Do you want to bring down the running Warnet?", timeout=30)
+                session.sendline("y")
                 self.wait_for_all_tanks_status(target="stopped", timeout=60, interval=1)
         except Exception as e:
             self.log.error(f"Error bringing network down: {e}")

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -2,7 +2,6 @@ import json
 import logging
 import logging.config
 import os
-import pexpect
 import re
 import sys
 import threading
@@ -10,6 +9,8 @@ from pathlib import Path
 from subprocess import run
 from tempfile import mkdtemp
 from time import sleep
+
+import pexpect
 
 from warnet import SRC_DIR
 from warnet.k8s import get_pod_exit_status
@@ -47,7 +48,7 @@ class TestBase:
         try:
             self.log.info("Stopping network")
             if self.network:
-                session = pexpect.spawn(f"warnet down", encoding="utf-8")
+                session = pexpect.spawn("warnet down", encoding="utf-8")
                 session.logfile = sys.stdout
                 session.expect("Do you want to bring down the running Warnet?", timeout=30)
                 session.sendline("y")

--- a/test/wargames_test.py
+++ b/test/wargames_test.py
@@ -64,7 +64,9 @@ class WargamesTest(TestBase):
 
         self.log.info("Switch to wargames player context")
         self.log.info(self.warnet(f"admin create-kubeconfigs --kubeconfig-dir={self.kconfigdir}"))
-        clicker = pexpect.spawn(f"warnet auth {self.kconfigdir}/warnet-user-wargames-red-kubeconfig")
+        clicker = pexpect.spawn(
+            f"warnet auth {self.kconfigdir}/warnet-user-wargames-red-kubeconfig"
+        )
         while clicker.expect(["Overwrite", "Updated kubeconfig"]) == 0:
             print(clicker.before, clicker.after)
             clicker.sendline("y")
@@ -85,11 +87,13 @@ class WargamesTest(TestBase):
         assert self.warnet("bitcoin rpc armada getblockcount") == "6"
 
         self.log.info("Check pod limit per namespace")
-        for i in range(10):
+        for _ in range(10):
             stream_command(
                 f"warnet run {self.scen_test_dir / 'nothing.py'} --source_dir={self.scen_src_dir}"
             )
-        assert len(scenarios_deployed()) == 2, f"Unexpected scenarios deployed:{scenarios_deployed()}"
+        assert len(scenarios_deployed()) == 2, (
+            f"Unexpected scenarios deployed:{scenarios_deployed()}"
+        )
 
         self.log.info("Restore admin context")
         stream_command(f"kubectl config use-context {self.initial_context}")

--- a/test/wargames_test.py
+++ b/test/wargames_test.py
@@ -8,6 +8,7 @@ from test_base import TestBase
 
 from warnet.k8s import get_kubeconfig_value
 from warnet.process import stream_command
+from warnet.status import _get_deployed_scenarios as scenarios_deployed
 
 
 class WargamesTest(TestBase):
@@ -19,6 +20,7 @@ class WargamesTest(TestBase):
             Path(os.path.dirname(__file__)).parent / "resources" / "scenarios" / "test_scenarios"
         )
         self.initial_context = get_kubeconfig_value("{.current-context}")
+        self.kconfigdir = self.tmpdir / "kubeconfigs"
 
     def run_test(self):
         try:
@@ -61,8 +63,8 @@ class WargamesTest(TestBase):
         assert self.warnet("bitcoin rpc miner getblockcount") == "5"
 
         self.log.info("Switch to wargames player context")
-        self.log.info(self.warnet("admin create-kubeconfigs"))
-        clicker = pexpect.spawn("warnet auth kubeconfigs/warnet-user-wargames-red-kubeconfig")
+        self.log.info(self.warnet(f"admin create-kubeconfigs --kubeconfig-dir={self.kconfigdir}"))
+        clicker = pexpect.spawn(f"warnet auth {self.kconfigdir}/warnet-user-wargames-red-kubeconfig")
         while clicker.expect(["Overwrite", "Updated kubeconfig"]) == 0:
             print(clicker.before, clicker.after)
             clicker.sendline("y")
@@ -82,16 +84,22 @@ class WargamesTest(TestBase):
         # Nothing was accesible
         assert self.warnet("bitcoin rpc armada getblockcount") == "6"
 
+        self.log.info("Check pod limit per namespace")
+        for i in range(10):
+            stream_command(
+                f"warnet run {self.scen_test_dir / 'nothing.py'} --source_dir={self.scen_src_dir}"
+            )
+        assert len(scenarios_deployed()) == 2, f"Unexpected scenarios deployed:{scenarios_deployed()}"
+
         self.log.info("Restore admin context")
         stream_command(f"kubectl config use-context {self.initial_context}")
         # Sanity check
         assert self.warnet("bitcoin rpc miner getblockcount") == "6"
 
         self.log.info("Re-generate kubeconfigs after a scenario has been run")
-        self.log.info(self.warnet("admin create-kubeconfigs"))
-        kubeconfig_dir = Path("kubeconfigs/")
+        self.log.info(self.warnet(f"admin create-kubeconfigs --kubeconfig-dir={self.kconfigdir}"))
         count = 0
-        for p in kubeconfig_dir.iterdir():
+        for p in self.kconfigdir.iterdir():
             if p.is_file():
                 print(p)
                 assert "warnet-user" in str(p)


### PR DESCRIPTION
closes https://github.com/bitcoin-dev-project/warnet/issues/778

needs a full scale test to make sure we're not borking the default battlefield namespace