### PR TITLE
Node data persistence in persistent volume claims

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           - graph_test.py
           - logging_test.py
           - ln_basic_test.py
-          - ln_test.py
+          - ln_graph_test.py
           - onion_test.py
           - plugin_test.py
           - rpc_test.py

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -11,11 +11,14 @@ Persistence is available for:
 
 Persistence is configured per-node in the network graph definition. Add a `persistence` section to any node's configuration. This creates a new PVC for that node, which is then mounted to the appropriate data directory inside the container.
 
+Also add `restartPolicy: Always` to the node's configuration to ensure that the pod is restarted if it is deleted or crashes. This is important to ensure proper restart after restart of the kubernetes cluster.
+
 ### Bitcoin Core Node
 
 ```yaml
 bitcoin_core:
   image: bitcoincore-27.1:latest
+  restartPolicy: Always
   persistence:
     enabled: true
     size: 20Gi # optional, default is 20Gi
@@ -29,6 +32,7 @@ bitcoin_core:
 <lnd or cln>:
   image:
     tag: <node-version-tag>
+  restartPolicy: Always
   persistence:
     enabled: true
     size: 10Gi # optional, default is 10Gi

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -11,7 +11,7 @@ Persistence is available for:
 
 Persistence is configured per-node in the network graph definition. Add a `persistence` section to any node's configuration. This creates a new PVC for that node, which is then mounted to the appropriate data directory inside the container.
 
-Also add `restartPolicy: Always` to the node's configuration to ensure that the pod is restarted if it is deleted or crashes. This is important to ensure proper restart after restart of the kubernetes cluster.
+Also add `restartPolicy: Always` to the node's configuration to ensure that the pod is restarted if it is deleted or crashes. This is important to ensure proper restart after restart of the kubernetes cluster. If there is a risk of hard resets of the cluster, add `reindex=1` to bitcoin_core config to reindex the blockchain on startup and fix potential corrupted chain state.
 
 ### Bitcoin Core Node
 
@@ -24,6 +24,8 @@ bitcoin_core:
     size: 20Gi # optional, default is 20Gi
     storageClass: "" # optional, default is cluster default storage class
     accessMode: ReadWriteOncePod # optional, default is ReadWriteOncePod. For compatibility with older Kubernetes versions, you may need to set this to ReadWriteOnce
+  config: |
+    reindex=1
 ```
 
 ### Lightning Node

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,55 @@
+# Data Persistence
+
+By default, Warnet nodes use ephemeral storage, meaning all data is lost when a pod is deleted or restarted. This document describes how to enable persistent storage to be able to use warnet for persistent development environment, such that blockchain data, wallet information, and other node state can survive pod restarts and network redeployments. This is done with Kubernetes Persistent Volume Claims (PVCs), which persist independently of pod lifecycle.
+
+Persistence is available for:
+- **Bitcoin Core** nodes
+- **LND** nodes
+- **CLN** nodes
+
+## Enabling Persistence
+
+Persistence is configured per-node in the network graph definition. Add a `persistence` section to any node's configuration. This creates a new PVC for that node, which is then mounted to the appropriate data directory inside the container.
+
+### Bitcoin Core Node
+
+```yaml
+bitcoin_core:
+  image: bitcoincore-27.1:latest
+  persistence:
+    enabled: true
+    size: 20Gi # optional, default is 20Gi
+    storageClass: "" # optional, default is cluster default storage class
+    accessMode: ReadWriteOnce # optional, default is ReadWriteOnce
+```
+
+### Lightning Node
+
+```yaml
+<lnd or cln>:
+  image:
+    tag: <node-version-tag>
+  persistence:
+    enabled: true
+    size: 10Gi # optional, default is 10Gi
+    storageClass: "" # optional, default is cluster default storage class
+    accessMode: ReadWriteOnce # optional, default is ReadWriteOnce
+```
+
+## Existing PVCs
+
+To use custom made PVC or PVC from previous deployment, use the `existingClaim` field to reference an existing PVC by name:
+
+```yaml
+persistence:
+  enabled: true
+  existingClaim: "bitcoin-node-001-data"
+```
+
+## Mount Paths
+
+When persistence is enabled, the following directories are persisted in the PVCs:
+
+- **Bitcoin Core:** `/root/.bitcoin/`
+- **LND:** `/root/.lnd/`
+- **CLN:** `/root/.lightning/`

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -20,7 +20,7 @@ bitcoin_core:
     enabled: true
     size: 20Gi # optional, default is 20Gi
     storageClass: "" # optional, default is cluster default storage class
-    accessMode: ReadWriteOnce # optional, default is ReadWriteOnce
+    accessMode: ReadWriteOncePod # optional, default is ReadWriteOncePod. For compatibility with older Kubernetes versions, you may need to set this to ReadWriteOnce
 ```
 
 ### Lightning Node
@@ -33,18 +33,29 @@ bitcoin_core:
     enabled: true
     size: 10Gi # optional, default is 10Gi
     storageClass: "" # optional, default is cluster default storage class
-    accessMode: ReadWriteOnce # optional, default is ReadWriteOnce
+    accessMode: ReadWriteOncePod # optional, default is ReadWriteOncePod. For compatibility with older Kubernetes versions, you may need to set this to ReadWriteOnce
 ```
 
 ## Existing PVCs
 
-To use custom made PVC or PVC from previous deployment, use the `existingClaim` field to reference an existing PVC by name:
+To use custom made PVC or PVC from previous deployment, use the `existingClaim` field to reference an existing PVC by name. If the network configuration or namespace did not change, there is no need to explicitly set the `existingClaim`. The existing PVC is used by default, since its generated name matches the default pattern. To explicitly use a PVC set the name like this:
 
 ```yaml
 persistence:
   enabled: true
-  existingClaim: "bitcoin-node-001-data"
+  existingClaim: "tank-0001.default-bitcoincore-data"
 ```
+
+The generated PVC names follow the pattern:
+`<pod-name>.<namespace>-<node-type>-data`
+
+For example for a bitcoin core node:
+`tank-0001.default-bitcoincore-data`
+
+And for a LND node:
+`tank-0001-ln.default-lnd-data`
+
+Get the list of PVCs in the cluster with `kubectl get pvc -A` and delete any PVCs that are no longer needed with `kubectl delete pvc <pvc-name> -n <namespace>`.
 
 ## Mount Paths
 

--- a/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
@@ -57,7 +57,7 @@ spec:
           name: config
           subPath: config
         - mountPath: /root/.lightning
-          name: shared-volume
+          name: cln-data
     {{- with .Values.extraContainers }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -82,14 +82,14 @@ spec:
     - configMap:
         name: {{ include "cln.fullname" . }}
       name: config
-    - name: shared-volume
+    - name: cln-data
       {{- if .Values.persistence.enabled }}
       {{- if .Values.persistence.existingClaim }}
       persistentVolumeClaim:
         claimName: {{ .Values.persistence.existingClaim }}
       {{- else }}
       persistentVolumeClaim:
-        claimName: {{ include "cln.fullname" . }}-data
+        claimName: {{ include "cln.fullname" . }}.{{ .Release.Namespace }}-cln-data
       {{- end }}
       {{- else }}
       emptyDir: {}

--- a/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/pod.yaml
@@ -56,6 +56,8 @@ spec:
         - mountPath: /root/.lightning/config
           name: config
           subPath: config
+        - mountPath: /root/.lightning
+          name: shared-volume
     {{- with .Values.extraContainers }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -80,6 +82,18 @@ spec:
     - configMap:
         name: {{ include "cln.fullname" . }}
       name: config
+    - name: shared-volume
+      {{- if .Values.persistence.enabled }}
+      {{- if .Values.persistence.existingClaim }}
+      persistentVolumeClaim:
+        claimName: {{ .Values.persistence.existingClaim }}
+      {{- else }}
+      persistentVolumeClaim:
+        claimName: {{ include "cln.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+      emptyDir: {}
+      {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 4 }}

--- a/resources/charts/bitcoincore/charts/cln/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "cln.fullname" . }}-data
+  name: {{ include "cln.fullname" . }}.{{ .Release.Namespace }}-cln-data
   labels:
     {{- include "cln.labels" . | nindent 4 }}
 spec:

--- a/resources/charts/bitcoincore/charts/cln/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/pvc.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "cln.fullname" . }}.{{ .Release.Namespace }}-cln-data
   labels:
     {{- include "cln.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode }}

--- a/resources/charts/bitcoincore/charts/cln/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/charts/cln/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "cln.fullname" . }}-data
+  labels:
+    {{- include "cln.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/resources/charts/bitcoincore/charts/cln/values.yaml
+++ b/resources/charts/bitcoincore/charts/cln/values.yaml
@@ -82,6 +82,15 @@ startupProbe:
       - "-c"
       - "lightning-cli createrune > /working/rune.json"
 
+# Node data persistence configuration. Create persistent volume claim, or use an existing one.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 10Gi
+  # Use existing persistent volume claim instead of creating a new one.
+  existingClaim: ""
+
 # Additional volumes on the output Deployment definition.
 volumes:
   - name: working

--- a/resources/charts/bitcoincore/charts/cln/values.yaml
+++ b/resources/charts/bitcoincore/charts/cln/values.yaml
@@ -86,7 +86,7 @@ startupProbe:
 persistence:
   enabled: false
   storageClass: ""
-  accessMode: ReadWriteOnce
+  accessMode: ReadWriteOncePod
   size: 10Gi
   # Use existing persistent volume claim instead of creating a new one.
   existingClaim: ""

--- a/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
@@ -79,7 +79,7 @@ spec:
         - mountPath: /root/.lnd/tls.cert
           name: config
           subPath: tls.cert
-        - name: shared-volume
+        - name: lnd-data
           mountPath: /root/.lnd/
     {{- with .Values.extraContainers }}
     {{- toYaml . | nindent 4 }}
@@ -95,7 +95,7 @@ spec:
         - "--macaroonpath=/root/.lnd/data/chain/bitcoin/{{ .Values.global.chain }}/admin.macaroon"
         - "--httplisten=0.0.0.0:{{ .Values.circuitbreaker.httpPort }}"
       volumeMounts:
-        - name: shared-volume
+        - name: lnd-data
           mountPath: /root/.lnd/
         - name: config
           mountPath: /tls.cert
@@ -108,14 +108,14 @@ spec:
     - configMap:
         name: {{ include "lnd.fullname" . }}
       name: config
-    - name: shared-volume
+    - name: lnd-data
       {{- if .Values.persistence.enabled }}
       {{- if .Values.persistence.existingClaim }}
       persistentVolumeClaim:
         claimName: {{ .Values.persistence.existingClaim }}
       {{- else }}
       persistentVolumeClaim:
-        claimName: {{ include "lnd.fullname" . }}-data
+        claimName: {{ include "lnd.fullname" . }}.{{ .Release.Namespace }}-lnd-data
       {{- end }}
       {{- else }}
       emptyDir: {}

--- a/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
@@ -109,7 +109,17 @@ spec:
         name: {{ include "lnd.fullname" . }}
       name: config
     - name: shared-volume
+      {{- if .Values.persistence.enabled }}
+      {{- if .Values.persistence.existingClaim }}
+      persistentVolumeClaim:
+        claimName: {{ .Values.persistence.existingClaim }}
+      {{- else }}
+      persistentVolumeClaim:
+        claimName: {{ include "lnd.fullname" . }}-data
+      {{- end }}
+      {{- else }}
       emptyDir: {}
+      {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 4 }}

--- a/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/pod.yaml
@@ -53,7 +53,15 @@ spec:
             - /bin/sh
             - -c
             - |
-              rm -rf /root/.lnd/data/chain
+              MACAROON_PATH="/root/.lnd/data/chain/bitcoin/{{ .Values.global.chain }}/admin.macaroon"
+
+              # If wallet is already initialized, unlock it and exit
+              if [ -f "$MACAROON_PATH" ]; then
+                until [ "$(curl --silent --insecure https://localhost:8080/v1/unlockwallet --data "{\"wallet_password\":\"AAAAAAAAAAA=\"}")" == "{}" ]; do
+                  sleep 5
+                done
+                exit 0
+              fi
 
               until curl --silent --insecure https://localhost:8080/v1/genseed > /tmp/genseed.json; do
                 sleep 5

--- a/resources/charts/bitcoincore/charts/lnd/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/pvc.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "lnd.fullname" . }}.{{ .Release.Namespace }}-lnd-data
   labels:
     {{- include "lnd.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode }}

--- a/resources/charts/bitcoincore/charts/lnd/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lnd.fullname" . }}-data
+  labels:
+    {{- include "lnd.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/resources/charts/bitcoincore/charts/lnd/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/templates/pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "lnd.fullname" . }}-data
+  name: {{ include "lnd.fullname" . }}.{{ .Release.Namespace }}-lnd-data
   labels:
     {{- include "lnd.labels" . | nindent 4 }}
 spec:

--- a/resources/charts/bitcoincore/charts/lnd/values.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/values.yaml
@@ -15,7 +15,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-podLabels: 
+podLabels:
   app: "warnet"
   mission: "lightning"
 
@@ -65,12 +65,11 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-
 livenessProbe:
   exec:
     command:
-    - pidof
-    - lnd
+      - pidof
+      - lnd
   failureThreshold: 3
   initialDelaySeconds: 60
   periodSeconds: 5
@@ -84,6 +83,15 @@ readinessProbe:
   tcpSocket:
     port: 10009
   timeoutSeconds: 1
+
+# Node data persistence configuration. Create persistent volume claim, or use an existing one.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 10Gi
+  # Use existing persistent volume claim instead of creating a new one.
+  existingClaim: ""
 
 # Additional volumes on the output Deployment definition.
 volumes: []
@@ -128,6 +136,6 @@ defaultConfig: ""
 channels: []
 
 circuitbreaker:
-  enabled: false  # Default to disabled
+  enabled: false # Default to disabled
   image: carlakirkcohen/circuitbreaker:attackathon-test
   httpPort: 9235

--- a/resources/charts/bitcoincore/charts/lnd/values.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/values.yaml
@@ -88,7 +88,7 @@ readinessProbe:
 persistence:
   enabled: false
   storageClass: ""
-  accessMode: ReadWriteOnce
+  accessMode: ReadWriteOncePod
   size: 10Gi
   # Use existing persistent volume claim instead of creating a new one.
   existingClaim: ""

--- a/resources/charts/bitcoincore/charts/lnd/values.yaml
+++ b/resources/charts/bitcoincore/charts/lnd/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: lightninglabs/lnd
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.19.0-beta"
+  tag: "v0.20.1-beta"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/resources/charts/bitcoincore/templates/pod.yaml
+++ b/resources/charts/bitcoincore/templates/pod.yaml
@@ -115,7 +115,7 @@ spec:
         claimName: {{ .Values.persistence.existingClaim }}
       {{- else }}
       persistentVolumeClaim:
-        claimName: {{ include "bitcoincore.fullname" . }}-data
+        claimName: {{ include "bitcoincore.fullname" . }}.{{ .Release.Namespace }}-bitcoincore-data
       {{- end }}
       {{- else }}
       emptyDir: {}

--- a/resources/charts/bitcoincore/templates/pod.yaml
+++ b/resources/charts/bitcoincore/templates/pod.yaml
@@ -109,7 +109,17 @@ spec:
       {{- toYaml . | nindent 4 }}
     {{- end }}
     - name: data
+      {{- if .Values.persistence.enabled }}
+      {{- if .Values.persistence.existingClaim }}
+      persistentVolumeClaim:
+        claimName: {{ .Values.persistence.existingClaim }}
+      {{- else }}
+      persistentVolumeClaim:
+        claimName: {{ include "bitcoincore.fullname" . }}-data
+      {{- end }}
+      {{- else }}
       emptyDir: {}
+      {{- end }}
     - name: config
       configMap:
         name: {{ include "bitcoincore.fullname" . }}

--- a/resources/charts/bitcoincore/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/templates/pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "bitcoincore.fullname" . }}-data
+  name: {{ include "bitcoincore.fullname" . }}.{{ .Release.Namespace }}-bitcoincore-data
   labels:
     {{- include "bitcoincore.labels" . | nindent 4 }}
 spec:

--- a/resources/charts/bitcoincore/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/templates/pvc.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "bitcoincore.fullname" . }}.{{ .Release.Namespace }}-bitcoincore-data
   labels:
     {{- include "bitcoincore.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode }}

--- a/resources/charts/bitcoincore/templates/pvc.yaml
+++ b/resources/charts/bitcoincore/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "bitcoincore.fullname" . }}-data
+  labels:
+    {{- include "bitcoincore.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -15,7 +15,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-podLabels: 
+podLabels:
   app: "warnet"
   mission: "tank"
 
@@ -61,12 +61,11 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-
 livenessProbe:
   exec:
     command:
-    - pidof
-    - bitcoind
+      - pidof
+      - bitcoind
   failureThreshold: 12
   initialDelaySeconds: 5
   periodSeconds: 5
@@ -78,6 +77,14 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 10
 
+# Node data persistence configuration. Create persisten volume claim, or use an existing one.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 20Gi
+  # Use existing persistent volume claim instead of creating a new one.
+  existingClaim: ""
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/resources/charts/bitcoincore/values.yaml
+++ b/resources/charts/bitcoincore/values.yaml
@@ -81,7 +81,7 @@ readinessProbe:
 persistence:
   enabled: false
   storageClass: ""
-  accessMode: ReadWriteOnce
+  accessMode: ReadWriteOncePod
   size: 20Gi
   # Use existing persistent volume claim instead of creating a new one.
   existingClaim: ""

--- a/resources/scenarios/commander.py
+++ b/resources/scenarios/commander.py
@@ -176,7 +176,7 @@ class Commander(BitcoinTestFramework):
 
         if "miner" not in wallets:
             allwallets = node.listwalletdir()
-            if "miner" in allwallets:
+            if "'miner'" in str(allwallets):
                 node.loadwallet("miner")
             else:
                 node.createwallet("miner", descriptors=True)

--- a/resources/scenarios/commander.py
+++ b/resources/scenarios/commander.py
@@ -173,8 +173,13 @@ class Commander(BitcoinTestFramework):
     @staticmethod
     def ensure_miner(node):
         wallets = node.listwallets()
+
         if "miner" not in wallets:
-            node.createwallet("miner", descriptors=True)
+            allwallets = node.listwalletdir()
+            if "miner" in allwallets:
+                node.loadwallet("miner")
+            else:
+                node.createwallet("miner", descriptors=True)
         return node.get_wallet_rpc("miner")
 
     @staticmethod

--- a/resources/scenarios/ln_init.py
+++ b/resources/scenarios/ln_init.py
@@ -63,6 +63,15 @@ class LNInit(Commander):
             mining_tank.rpc_timeout = 6000
             return self.generatetoaddress(mining_tank, n, miner_addr, sync_fun=self.no_op)
 
+        ##
+        # Run only once per network, do this after p2p connections
+        # so everyone is on the same chain if there is a restart
+        # with inconsistent persistence.
+        ##
+        if mining_tank.getblockcount() > 0:
+            self.log.info("Chain already exists, exiting")
+            return
+
         self.log.info("Locking out of IBD...")
         gen(1)
 

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -33,6 +33,7 @@ from .k8s import (
     get_default_namespace_or,
     get_mission,
     get_namespaces,
+    get_persistent_volume_claims,
     get_pod,
     get_pods,
     pod_log,
@@ -161,12 +162,18 @@ def down():
         subprocess.Popen(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return f"Initiated deletion of pod: {pod_name} in namespace {namespace}"
 
+    def delete_persistent_volume_claim(pvc_name, namespace):
+        cmd = f"kubectl delete pvc --ignore-not-found=true {pvc_name} -n {namespace}"
+        subprocess.Popen(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return f"Initiated deletion of PVC: {pvc_name} in namespace {namespace}"
+
     if not can_delete_pods():
         click.secho("You do not have permission to bring down the network.", fg="red")
         return
 
     namespaces = get_namespaces()
     release_list: list[dict[str, str]] = []
+    pvc_list: list[dict[str, str]] = []
     for v1namespace in namespaces:
         namespace = v1namespace.metadata.name
         command = f"helm list --namespace {namespace} -o json"
@@ -175,6 +182,10 @@ def down():
             releases = json.loads(result)
             for release in releases:
                 release_list.append({"namespace": namespace, "name": release["name"]})
+
+            pvcs = get_persistent_volume_claims(namespace)
+            for pvc in pvcs:
+                pvc_list.append({"namespace": namespace, "name": pvc.metadata.name})
 
     confirmed = "confirmed"
     click.secho("Preparing to bring down the running Warnet...", fg="yellow")
@@ -207,6 +218,36 @@ def down():
         click.secho("Operation cancelled by user", fg="yellow")
         sys.exit(0)
 
+    # Prompt to also delete PVCs containing persistent data
+    pvc_answers = None
+    if len(pvc_list) > 0:
+        table = Table(
+            title="Persistent Volume Claims to be destroyed",
+            show_header=True,
+            header_style="bold red",
+        )
+        table.add_column("Namespace", style="red")
+        table.add_column("Name", style="red")
+        for pvc in pvc_list:
+            table.add_row(pvc["namespace"], pvc["name"])
+        console.print(table)
+        pvc_confirmed = "pvc_confirmed"
+        pvc_answers = inquirer.prompt(
+            [
+                inquirer.Confirm(
+                    pvc_confirmed,
+                    message=click.style(
+                        "Do you also want to delete all PVCs containing persistent node data?",
+                        fg="yellow",
+                        bold=False,
+                    ),
+                    default=False,
+                ),
+            ]
+        )
+
+    delete_pvcs = pvc_answers and pvc_answers[pvc_confirmed]
+
     with ThreadPoolExecutor(max_workers=10) as executor:
         futures = []
 
@@ -227,6 +268,13 @@ def down():
         pods = get_pods()
         for pod in pods:
             futures.append(executor.submit(delete_pod, pod.metadata.name, pod.metadata.namespace))
+
+        # Delete PVCs if confirmed
+        if delete_pvcs:
+            for pvc in pvc_list:
+                futures.append(
+                    executor.submit(delete_persistent_volume_claim, pvc["name"], pvc["namespace"])
+                )
 
         # Wait for all tasks to complete and print results
         for future in as_completed(futures):

--- a/src/warnet/control.py
+++ b/src/warnet/control.py
@@ -158,14 +158,16 @@ def down():
         return f"Uninstalled {release_name} in namespace {namespace}"
 
     def delete_pod(pod_name, namespace):
-        cmd = f"kubectl delete pod --ignore-not-found=true {pod_name} -n {namespace} --grace-period=0 --force"
-        subprocess.Popen(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        return f"Initiated deletion of pod: {pod_name} in namespace {namespace}"
+        cmd = f"kubectl delete pod --ignore-not-found=true {pod_name} -n {namespace} --wait"
+        print(f"Initiated deletion of pod: {pod_name} in namespace {namespace}")
+        subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return f"Deleted pod: {pod_name} in namespace {namespace}"
 
     def delete_persistent_volume_claim(pvc_name, namespace):
-        cmd = f"kubectl delete pvc --ignore-not-found=true {pvc_name} -n {namespace}"
-        subprocess.Popen(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        return f"Initiated deletion of PVC: {pvc_name} in namespace {namespace}"
+        cmd = f"kubectl delete pvc --ignore-not-found=true {pvc_name} -n {namespace} --wait"
+        print(f"Initiated deletion of PVC: {pvc_name} in namespace {namespace}")
+        subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return f"Deleted PVC: {pvc_name} in namespace {namespace}"
 
     if not can_delete_pods():
         click.secho("You do not have permission to bring down the network.", fg="red")

--- a/src/warnet/deploy.py
+++ b/src/warnet/deploy.py
@@ -387,28 +387,27 @@ rpc_password = "{FORK_OBSERVER_RPC_PASSWORD}"
 
 
 def deploy_network(directory: Path, debug: bool = False, namespace: Optional[str] = None):
-    network_file_path = directory / NETWORK_FILE
     namespace = get_default_namespace_or(namespace)
+    network_file_path = directory / NETWORK_FILE
+    default_file_path = directory / DEFAULTS_FILE
 
     with network_file_path.open() as f:
         network_file = yaml.safe_load(f)
 
+    with default_file_path.open() as f:
+        default_file = yaml.safe_load(f)
+
     needs_ln_init = False
     supported_ln_projects = ["lnd", "cln"]
-    for node in network_file["nodes"]:
-        ln_config = node.get("ln", {})
+    merged = network_file["nodes"].copy()
+    merged.append(default_file)
+    for node in merged:
         for key in supported_ln_projects:
-            if ln_config.get(key, False) and key in node and "channels" in node[key]:
+            if key in node and "channels" in node[key]:
                 needs_ln_init = True
                 break
         if needs_ln_init:
             break
-
-    default_file_path = directory / DEFAULTS_FILE
-    with default_file_path.open() as f:
-        default_file = yaml.safe_load(f)
-    if any(default_file.get("ln", {}).get(key, False) for key in supported_ln_projects):
-        needs_ln_init = True
 
     processes = []
     for node in network_file["nodes"]:

--- a/src/warnet/k8s.py
+++ b/src/warnet/k8s.py
@@ -99,6 +99,13 @@ def get_channels(namespace: Optional[str] = None) -> any:
     return channels
 
 
+def get_persistent_volume_claims(namespace: Optional[str] = None) -> any:
+    namespace = get_default_namespace_or(namespace)
+    sclient = get_static_client()
+    pvcs = sclient.list_namespaced_persistent_volume_claim(namespace=namespace)
+    return pvcs.items
+
+
 def create_kubernetes_object(
     kind: str, metadata: dict[str, any], spec: dict[str, any] = None
 ) -> dict[str, any]:

--- a/test/data/ln/network.yaml
+++ b/test/data/ln/network.yaml
@@ -5,12 +5,25 @@ nodes:
     ln:
       lnd: false
       cln: true
+    persistence:
+      enabled: true
+    cln:
+      persistence:
+        enabled: true
+
   - name: tank-0001
     addnode:
       - tank-0002
+
   - name: tank-0002
     addnode:
       - tank-0000
+    persistence:
+      enabled: true
+    lnd:
+      persistence:
+        enabled: true
+
   - name: tank-0003
     addnode:
       - tank-0000

--- a/test/ln_basic_test.py
+++ b/test/ln_basic_test.py
@@ -2,7 +2,9 @@
 
 import json
 import os
+import pexpect
 import subprocess
+import sys
 from pathlib import Path
 from time import sleep
 
@@ -52,6 +54,8 @@ class LNBasicTest(TestBase):
             self.wait_for_gossip_sync(self.lns[:3], 2 + 2)
             self.pay_invoice(sender="tank-0000-ln", recipient="tank-0002-ln")
 
+            # Test data persistence
+            self.test_data_persistence()
         finally:
             self.cleanup()
 
@@ -205,6 +209,61 @@ class LNBasicTest(TestBase):
         self.log.info(f"Got limits: {limits}")
 
         self.log.info("✅ Circuit Breaker API tests passed")
+
+    def get_ln_node_state(self, tankln):
+        if tankln == "tank-0000-ln":
+            # cln
+            pub = json.loads(self.warnet(f"ln rpc {tankln} getinfo"))["id"]
+            pays = json.loads(self.warnet(f"ln rpc {tankln} listpays"))
+        else:
+            # lnd
+            pub = json.loads(self.warnet(f"ln rpc {tankln} getinfo"))["identity_pubkey"]
+            pays = json.loads(self.warnet(f"ln rpc {tankln} listpayments"))
+        # same for both
+        invs = json.loads(self.warnet(f"ln rpc {tankln} listinvoices"))
+        self.log.info(f"{tankln} pubkey: {pub}")
+        return {
+            "pub": pub,
+            "pays": pays,
+            "invs": invs
+        }
+
+    def test_data_persistence(self):
+        self.log.info("Testing data persistence")
+        lns = [
+            # Persistence enabled
+            "tank-0000-ln",
+            "tank-0002-ln",
+            # No persistence
+            "tank-0003-ln",
+            "tank-0005-ln"
+        ]
+        self.log.info("Saving state from LN tanks")
+        first = {}
+        for ln in lns:
+            first[ln] = self.get_ln_node_state(ln)
+
+        self.log.info("Stopping network")
+        session = pexpect.spawn("warnet down", encoding="utf-8", dimensions=(60, 200))
+        session.logfile = sys.stdout
+        session.expect("Do you want to bring down the running Warnet?", timeout=30)
+        session.send("y")
+        session.expect("Do you also want to delete all PVCs", timeout=5)
+        session.send("n")
+        session.expect("Warnet teardown process completed", timeout=300)
+
+        self.log.info("Restarting...")
+        self.setup_network()
+
+        self.log.info("ln tanks 0000 and 0002 should have restored persistent data")
+        for ln in ["tank-0000-ln", "tank-0002-ln"]:
+            second = self.get_ln_node_state(ln)
+            assert first[ln] == second, first.items() ^ second.items()
+
+        self.log.info("ln tanks 0003 and 0005 should NOT have restored persistent data")
+        for ln in ["tank-0003-ln", "tank-0005-ln"]:
+            second = self.get_ln_node_state(ln)
+            assert first[ln] != second, first.items()
 
 
 if __name__ == "__main__":

--- a/test/ln_basic_test.py
+++ b/test/ln_basic_test.py
@@ -2,12 +2,12 @@
 
 import json
 import os
-import pexpect
 import subprocess
 import sys
 from pathlib import Path
 from time import sleep
 
+import pexpect
 from test_base import TestBase
 
 from warnet.process import stream_command
@@ -222,11 +222,7 @@ class LNBasicTest(TestBase):
         # same for both
         invs = json.loads(self.warnet(f"ln rpc {tankln} listinvoices"))
         self.log.info(f"{tankln} pubkey: {pub}")
-        return {
-            "pub": pub,
-            "pays": pays,
-            "invs": invs
-        }
+        return {"pub": pub, "pays": pays, "invs": invs}
 
     def test_data_persistence(self):
         self.log.info("Testing data persistence")
@@ -236,7 +232,7 @@ class LNBasicTest(TestBase):
             "tank-0002-ln",
             # No persistence
             "tank-0003-ln",
-            "tank-0005-ln"
+            "tank-0005-ln",
         ]
         self.log.info("Saving state from LN tanks")
         first = {}

--- a/test/ln_graph_test.py
+++ b/test/ln_graph_test.py
@@ -11,7 +11,7 @@ from warnet.k8s import wait_for_pod
 from warnet.process import run_command, stream_command
 
 
-class LNTest(TestBase):
+class LNGraphTest(TestBase):
     def __init__(self):
         super().__init__()
         self.graph_file = Path(os.path.dirname(__file__)) / "data" / "LN_10.json"
@@ -120,5 +120,5 @@ class LNTest(TestBase):
 
 
 if __name__ == "__main__":
-    test = LNTest()
+    test = LNGraphTest()
     test.run_test()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -52,7 +52,20 @@ class TestBase:
                 session.logfile = sys.stdout
                 session.expect("Do you want to bring down the running Warnet?", timeout=30)
                 session.sendline("y")
-                session.expect("Warnet teardown process completed", timeout=300)
+
+                # Handle PVC question if asked within 5 seconds
+                outcome = session.expect(
+                    ["Do you also want to delete all PVCs", pexpect.EOF, pexpect.TIMEOUT], timeout=5
+                )
+                if outcome == 1:
+                    assert "Warnet teardown process completed" in session.before
+                    self.log.info("Warnet teardown process completed")
+                else:
+                    if outcome == 0:
+                        session.sendline("y")
+                    else:
+                        self.log.info("Didn't get delete PVC question, continuing...")
+                    session.expect("Warnet teardown process completed", timeout=300)
                 self.wait_for_all_tanks_status(target="stopped", timeout=60, interval=1)
         except Exception as e:
             self.log.error(f"Error bringing network down: {e}")

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -48,10 +48,10 @@ class TestBase:
         try:
             self.log.info("Stopping network")
             if self.network:
-                session = pexpect.spawn("warnet down", encoding="utf-8")
+                session = pexpect.spawn("warnet down", encoding="utf-8", dimensions=(60, 200))
                 session.logfile = sys.stdout
                 session.expect("Do you want to bring down the running Warnet?", timeout=30)
-                session.sendline("y")
+                session.send("y")
 
                 # Handle PVC question if asked within 5 seconds
                 outcome = session.expect(
@@ -62,7 +62,8 @@ class TestBase:
                     self.log.info("Warnet teardown process completed")
                 else:
                     if outcome == 0:
-                        session.sendline("y")
+                        sleep(1)
+                        session.send("y")
                     else:
                         self.log.info("Didn't get delete PVC question, continuing...")
                     session.expect("Warnet teardown process completed", timeout=300)


### PR DESCRIPTION
At Torq / Mion we intend to move to using warnet for persistent regtest lightning network for development locally. This requires to have the nodes keep their state indefinetly, to not need to constantly recreate the network, connect nodes to our software etc. I tried to do it by defining `volumes` and `volumeMounts`, but for bitcoin core the _.bitcoin_ directory is already mounted so it conflicted on making a new mount to the same dir. This PR aims to add built-in, easy and configurable persistence option.

### Overview

- Uses persistent volume claims. Either auto generated or pre-defined
- A new helm configuration value set "persistence"
  - Simply add `enabled: true` to create automatic PVC for the node
  - Use `existingClaim: <existing-pvc-name>` to use pre-created PVC instead of creating new one
  - If not set, everything should work as it did before
- Down command prompts to delete the PVCs if they exist
- Added documentation on how to use this

Tested in Windows WSL environment.