### PR TITLE
fix: handle partial objects in wait_for_predicate timeout message

### DIFF
--- a/test/test_base.py
+++ b/test/test_base.py
@@ -97,9 +97,11 @@ class TestBase:
             timeout -= interval
         import inspect
 
-        raise Exception(
-            f"Timed out waiting for Truth from predicate: {inspect.getsource(predicate).strip()}"
-        )
+        try:
+            source = inspect.getsource(predicate).strip()
+        except (TypeError, OSError):
+            source = repr(predicate)
+        raise Exception(f"Timed out waiting for Truth from predicate: {source}")
 
     def get_tank(self, index):
         # TODO


### PR DESCRIPTION
Found this while investigating a CI failure on PR #791. plugin_test was timing out, but instead of seeing the real timeout error, CI was throwing a confusing TypeError because inspect.getsource() doesn't support functools.partial objects. This fix makes the error reporting robust by falling back to repr() when getsource() fails, so the actual timeout reason is visible instead of a misleading TypeError.