### PR TITLE
Guard missing peer addr in connect_dag assertions

### DIFF
--- a/resources/scenarios/test_scenarios/connect_dag.py
+++ b/resources/scenarios/test_scenarios/connect_dag.py
@@ -105,12 +105,12 @@ class ConnectDag(Commander):
         if connection_type == ConnectionType.DNS:
             assert any(
                 # ignore the ...-service suffix
-                self.nodes[connectee_index].tank in d.get("addr")
+                self.nodes[connectee_index].tank in (d.get("addr") or "")
                 for d in connector
-            ), "Could not find conectee hostname"
+            ), "Could not find connectee hostname"
         elif connection_type == ConnectionType.IP:
             assert any(
-                d.get("addr").split(":")[0] == self.nodes[connectee_index].rpchost
+                (d.get("addr") or "").split(":")[0] == self.nodes[connectee_index].rpchost
                 for d in connector
             ), "Could not find connectee ip addr"
         else:


### PR DESCRIPTION
I noticed a small edge case in connect_dag.py: some peer entries can have a missing or null addr, and the current assertions can crash while splitting or substring checks. This change keeps behavior the same for valid data, but adds a safe fallback using d.get('addr') or '' for both DNS and IP assertions. Also fixed a typo in the error message from conectee to connectee.