### PR TITLE
fix: warnet setup bump pinned kubectl to v1.35.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
         uses: medyagh/setup-minikube@v0.0.20
         id: minikube
         with:
-          minikube-version: 1.37.0
-          kubernetes-version: v1.34.0
+          minikube-version: 1.38.1
+          kubernetes-version: v1.35.1
           cpus: max
           memory: 4000m
       - name: Start minikube's loadbalancer tunnel

--- a/resources/charts/commander/templates/rbac.yaml
+++ b/resources/charts/commander/templates/rbac.yaml
@@ -44,8 +44,14 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "configmaps", "pods/log", "pods/exec"]
+    resources: ["pods", "namespaces", "configmaps"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/src/warnet/constants.py
+++ b/src/warnet/constants.py
@@ -206,27 +206,27 @@ HELM_BLESSED_NAME_AND_CHECKSUMS = [
 
 # Kubectl binary
 KUBECTL_BINARY_NAME = "kubectl"
-KUBECTL_BLESSED_VERSION = "v1.31.1"
+KUBECTL_BLESSED_VERSION = "v1.35.1"
 KUBECTL_DOWNLOAD_URL_STUB = f"https://dl.k8s.io/release/{KUBECTL_BLESSED_VERSION}/bin"
 KUBECTL_BLESSED_NAME_AND_CHECKSUMS = [
     {
         "system": "linux",
         "arch": "amd64",
-        "checksum": "57b514a7facce4ee62c93b8dc21fda8cf62ef3fed22e44ffc9d167eab843b2ae",
+        "checksum": "36e2f4ac66259232341dd7866952d64a958846470f6a9a6a813b9117bd965207",
     },
     {
         "system": "linux",
         "arch": "arm64",
-        "checksum": "3af2451191e27ecd4ac46bb7f945f76b71e934d54604ca3ffc7fe6f5dd123edb",
+        "checksum": "706256e21a4e9192ee62d1a007ac0bfcff2b0b26e92cc7baad487a6a5d08ff82",
     },
     {
         "system": "darwin",
         "arch": "amd64",
-        "checksum": "4b86d3fb8dee8dd61f341572f1ba13c1030d493f4dc1b4831476f61f3cbb77d0",
+        "checksum": "07a04d82bc2de2f5d53dfd81f2109ca864f634a82b225257daa2f9c2db15ccef",
     },
     {
         "system": "darwin",
         "arch": "arm64",
-        "checksum": "08909b92e62004f4f1222dfd39214085383ea368bdd15c762939469c23484634",
+        "checksum": "2b000dded317319b1ebca19c2bc70f772c7aaa0e8962fae2d987ba04dd1a1b50",
     },
 ]


### PR DESCRIPTION
Minikube is provisioning Kubernetes v1.35.1....
Digital ocean recommends Kubernetes 1.33, so with kubectl v1.35.1 the client is 2 minor versions ahead
this should fix #747 

```
 minikube start
😄  minikube v1.38.1 on Ubuntu 24.04
✨  Automatically selected the docker driver
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
📌  Using Docker driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.50 ...
💾  Downloading Kubernetes v1.35.1 preload ...
    > preloaded-images-k8s-v18-v1...:  272.45 MiB / 272.45 MiB  100.00% 1.22 Mi
    > gcr.io/k8s-minikube/kicbase...:  519.58 MiB / 519.58 MiB  100.00% 846.93 
🔥  Creating docker container (CPUs=2, Memory=3800MB) ...
🐳  Preparing Kubernetes v1.35.1 on Docker 29.2.1 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

❗  /home/user/projects/warnet/warnet/.venv/bin/kubectl is version 1.31.1, which may have incompatibilities with Kubernetes 1.35.1.
    ▪ Want kubectl v1.35.1? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```