### PR TITLE
Get ln node host from pod name

### DIFF
--- a/src/warnet/ln.py
+++ b/src/warnet/ln.py
@@ -70,13 +70,8 @@ def host(
 
 
 def _host(pod_name: str):
-    info = _rpc(pod_name, "getinfo")
     pod = get_pod(pod_name)
-    if "cln" in pod.metadata.labels["app.kubernetes.io/name"]:
-        return json.loads(info)["alias"]
-    else:
-        uris = json.loads(info)["uris"]
-        if uris and len(uris) >= 0:
-            return uris[0].split("@")[1]
-        else:
-            return ""
+
+    # pod name (lnd.fullname / cln.fullname) matches the configs
+    # 'announce-addr' and 'externalhosts' in configmaps
+    return pod.metadata.name + "." + pod.metadata.namespace


### PR DESCRIPTION
**TODO still need to edit the ln_init to also use host name in original p2p, since peer connection is lost because the ip changes**

My problem is that accross restarts the LND uris (ip:s) are not stable and since I use the address given by the host command (at the start of the network so not the current) in my app, it often loses connection on restart.

Inconsistently LND included the p2p port (9735) in the return value, now it's not returned.

This normalizes the host command to give the pod dns name.

Also, using "alias" for host name for CLN didn't really make sense. It's not the alias that is used in the connection. In reality it's the kube service name (service.yaml). These all work since for each `"lnd.fullname"` or `"cln.fullname"` is used. The actual service name is a bit more cumbersome to get so I think the best is to just use the pod name.

Tested in docker desktop cluster with CLN and LND.

