### PR TITLE
setup: clarify that helm and kubectl are required dependencies

### DIFF
--- a/src/warnet/project.py
+++ b/src/warnet/project.py
@@ -190,7 +190,7 @@ def setup():
                     inquirer.Confirm(
                         "install_kubectl",
                         message=click.style(
-                            "Kubectl is required to run Warnet and was not found. Install it into your virtual environment?",
+                            "Kubectl is required to run Warnet and was not found. Install it into your virtual environment ?",
                             fg="blue",
                             bold=True,
                         ),
@@ -228,7 +228,7 @@ def setup():
                     inquirer.Confirm(
                         "install_helm",
                         message=click.style(
-                            "Helm is required to run Warnet and was not found. Install it into your virtual environment now?",
+                            "Helm is required to run Warnet and was not found. Install it into your virtual environment ?",
                             fg="blue",
                             bold=True,
                         ),

--- a/src/warnet/project.py
+++ b/src/warnet/project.py
@@ -190,7 +190,7 @@ def setup():
                     inquirer.Confirm(
                         "install_kubectl",
                         message=click.style(
-                            "Would you like Warnet to install Kubectl into your virtual environment?",
+                            "Kubectl is required to run Warnet and was not found. Install it into your virtual environment?",
                             fg="blue",
                             bold=True,
                         ),
@@ -228,7 +228,7 @@ def setup():
                     inquirer.Confirm(
                         "install_helm",
                         message=click.style(
-                            "Would you like Warnet to install Helm into your virtual environment?",
+                            "Helm is required to run Warnet and was not found. Install it into your virtual environment now?",
                             fg="blue",
                             bold=True,
                         ),


### PR DESCRIPTION
The setup prompts for helm and kubectl were phrased as optional
`("Would you like to install...")`, which was unclear, both tools
are required to run Warnet.

This pr  updates both prompts to make this clear while still offering to
auto-install them. Applied the same fix to kubectl since it had
identical unclear phrasing.


Closes #754
