### PR TITLE
Pin blessed < 1.40.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "docker==7.1.0",
     "flask==3.0.3",
     "inquirer==3.4.0",
+    "blessed<1.40",
     "kubernetes==30.1.0",
     "rich==13.7.1",
     "tabulate==0.9.0",


### PR DESCRIPTION
Starting from blessed 1.40.0, Terminal.__init__ queries the terminal's capabilities via an XTGETTCAP escape sequence and blocks reading the response. This runs as a side effect of merely importing inquirer (control.py imports it at module scope).

warnet pins inquirer==3.4.0, but inquirer doesn't pin its own dependency on blessed, so a fresh install always resolves to whatever blessed release is newest at install time.

warnet deploy spawns one multiprocessing.Process per tank. In macOS deployments this becomes a problem, given multiprocessing's default start method is "spawn". When running `warnet deploy` in macOS, each spawned task will re-execute the whole warnet import tree, re-triger the inquirer import and run the blocking terminal query.